### PR TITLE
fix(marketing): serve assets at /assets, not /asets

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -385,31 +385,31 @@
     },
     {
       "method": "GET",
-      "path": "/asets",
+      "path": "/assets",
       "table": "marketing_asset",
       "operation": "list",
-      "description": "List asets for the caller's tenant."
+      "description": "List assets for the caller's tenant."
     },
     {
       "method": "GET",
-      "path": "/asets/{id}",
+      "path": "/assets/{id}",
       "table": "marketing_asset",
       "operation": "read",
-      "description": "Read one aset."
+      "description": "Read one asset."
     },
     {
       "method": "POST",
-      "path": "/asets",
+      "path": "/assets",
       "table": "marketing_asset",
       "operation": "create",
-      "description": "Create a aset."
+      "description": "Create an asset."
     },
     {
       "method": "PATCH",
-      "path": "/asets/{id}",
+      "path": "/assets/{id}",
       "table": "marketing_asset",
       "operation": "update",
-      "description": "Update a aset."
+      "description": "Update an asset."
     },
     {
       "method": "GET",

--- a/tests/test_marketing_manifest.py
+++ b/tests/test_marketing_manifest.py
@@ -102,6 +102,29 @@ def test_every_route_names_a_table_this_manifest_declares(route: dict) -> None:
 
 
 @pytest.mark.parametrize("route", _raw()["api_routes"], ids=lambda r: f"{r['method']} {r['path']}")
+def test_every_route_path_is_derived_from_its_table_name(route: dict) -> None:
+    """The collection segment must be the table's own name, pluralised.
+
+    This exists because ``marketing_asset`` shipped as ``/asets`` — a typo in a
+    hand-written manifest, in a file with a test suite already asserting types,
+    auto-columns, foreign keys and verb/operation pairing. **Nothing asserted
+    the path**, so a wrong one was invisible: the route still named a real
+    table, still paired its verb correctly, and still passed every check here.
+
+    A path is the one part of a manifest a human types twice and a machine never
+    reconciles — Core mounts whatever is written, so a typo is not an error, it
+    is just a differently-named endpoint that the UI then has to match. Deriving
+    it removes the second copy.
+    """
+    collection = route["path"].split("/")[1]
+    expected = route["table"].removeprefix("marketing_") + "s"
+    assert collection == expected, (
+        f"{route['method']} {route['path']} serves {route['table']!r}, "
+        f"so its collection segment should be /{expected}, not /{collection}"
+    )
+
+
+@pytest.mark.parametrize("route", _raw()["api_routes"], ids=lambda r: f"{r['method']} {r['path']}")
 def test_route_verbs_match_their_operation(route: dict) -> None:
     """Core pairs these strictly; a mismatch is a config error at install."""
     expected = {"list": "GET", "read": "GET", "create": "POST", "delete": "DELETE"}


### PR DESCRIPTION
`marketing_asset`'s four CRUD routes shipped in M1 at **`/asets`**, with the
descriptions to match — *"List asets"*, *"Read one aset"*, *"Create a aset"*.

Core mounts whatever the manifest declares, so this was never an error anywhere.
It was simply a differently-named endpoint that the admin UI would then have had
to match, forever.

Fixing it now because **nothing calls it yet**. M5 and M6 are the first
milestones to touch assets; a path gets much harder to change once a UI, a test
and someone's muscle memory depend on it.

Also corrects `"Create a artefact"` → `"Create an artefact"` while in the file.

## Why a test comes with it

This typo survived a manifest test suite that already asserts column types,
auto-columns, foreign keys, verb/operation pairing, and `marketing_click` being
append-only. **Nothing asserted the path.** So a wrong one was structurally
invisible — the route still named a real table, still paired its verb correctly,
and still passed every check in the file.

A path is the one part of a manifest a person types twice and no machine ever
reconciles. `test_every_route_path_is_derived_from_its_table_name` derives the
collection segment from the table name instead of reading it, which removes the
second copy.

**Proven fail-first.** Reverted the manifest to the typo'd version with the new
test in place:

```
FAILED test_every_route_path_is_derived_from_its_table_name[GET /asets]
FAILED test_every_route_path_is_derived_from_its_table_name[GET /asets/{id}]
FAILED test_every_route_path_is_derived_from_its_table_name[POST /asets]
FAILED test_every_route_path_is_derived_from_its_table_name[PATCH /asets/{id}]
4 failed, 14 passed
```

Exactly the four bad routes and nothing else.

## Verification

- `uv run pytest tests/` — **79 passed** (was 61; the new guard is parametrised
  over all 18 routes)
- `ruff check` / `ruff format` clean

**Not verified: anything deployed.** The plugin is not installed into any
instance yet, so neither the old path nor the new one has ever served a request.
That is also precisely why this is cheap to change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
