### PR TITLE
test(marketing): stop the fixture campaign id tripping secret scan

### DIFF
--- a/tests/test_marketing_links.py
+++ b/tests/test_marketing_links.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qs, urlsplit
 
 from marketing.links import destination_with_utms, mint_token, tracked_url
 
-_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000001"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ab"
 
 
 def test_a_token_is_unguessable_and_fits_its_column() -> None:

--- a/tests/test_marketing_mint_route.py
+++ b/tests/test_marketing_mint_route.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 
 from marketing import admin_app
 
-_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000001"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ab"
 # A token a caller tries to choose for themselves. Named rather than inlined so
 # ruff's hardcoded-credential rule (S105) does not fire on a value whose entire
 # purpose is to be REJECTED.


### PR DESCRIPTION
`_CAMPAIGN` was `b3f1c0de-0000-4000-8000-000000000001`. Its final UUID group is **twelve digits**, and `.gitleaks.toml`'s `biffo-aws-account-id` rule matches any bare 12-digit number, allowlisting only `123456789012` and `999999999999`.

**This repo's own gate did not catch it.** tabsii-platform's did, when these tests were vendored in alongside the plugin source — two findings, both this one constant:

```
services/marketing/tests/test_marketing_links.py:15       biffo-aws-account-id
services/marketing/tests/test_marketing_mint_route.py:19  biffo-aws-account-id
```

Fixed **here** rather than in the instance, because the instance's copy is vendored from this one: patching it there would be undone by the next sync, and the two copies would disagree in the meantime.

The last group is now `0000000000ab` — still an obviously-fake UUID, no longer a 12-digit run.

## Verification

- `uv run pytest` — **112 passed**
- `gitleaks detect --no-git` — clean over the whole tree

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)