### PR TITLE
feat(marketing): still-image generation behind a provider port

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -52,6 +52,7 @@ from pydantic import BaseModel, Field
 from . import pipeline
 from .config import public_base_url
 from .definitions import MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
+from .image_routes import router as image_router
 from .links import destination_with_utms, mint_token, tracked_url
 
 require_admin = require_group("admin")
@@ -584,6 +585,10 @@ def build_app() -> FastAPI:
     """
     app = FastAPI(title="Marketing — campaign studio (admin)")
     app.include_router(router)
+    # Still-image generation (M6, issue #5) — routes live in image_routes.py,
+    # not here, so this file gains only this one line. See that module's
+    # docstring for why.
+    app.include_router(image_router)
 
     # LAST. See the module docstring: a StaticFiles mount at "/" swallows
     # everything registered after it, so anything below this line is unreachable.

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -1,0 +1,217 @@
+"""The still-image generation port (M6, issue #5).
+
+`ImageProvider` is the single choke point issue #5 asks for: nothing outside
+this module names a specific image-generation vendor, model, or SDK.
+`image_routes.py` depends only on the `ImageProvider` Protocol below, and the
+cost-ledger write it makes reads its fields straight off the `GeneratedImage`
+a provider returns — so replacing `OpenAIImageProvider` with a second vendor
+is a new class implementing this Protocol, never a change to a caller or to
+how cost gets recorded.
+
+Modelled on `idea_scout.ports.CoreGateway` (this estate's other Protocol-based
+port) and on this repo's own `pipeline.AgentGateway` — same shape, narrower
+surface: one method, because "turn a prompt into a still" is the only
+operation this milestone needs behind the seam.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+
+import httpx
+from aws_lambda_powertools import Logger
+
+logger = Logger(child=True)
+
+
+@dataclass(frozen=True)
+class GeneratedImage:
+    """One generated still, and everything the media-generation ledger
+    (biffo-template#1439) needs about it.
+
+    ``cost_usd`` is ``None``, never ``0.0``, whenever the provider's response
+    carries no price — see `OpenAIImageProvider` below for a provider where
+    that is the normal case, not an error. Core's own ledger schema treats
+    "no price returned" and "genuinely free" as structurally different facts
+    (nullable ``cost_usd``, with the null case load-bearing); collapsing the
+    two here would make that distinction impossible for anything downstream
+    to recover.
+
+    ``units``/``unit_kind`` are stored **verbatim in the provider's own
+    unit** — never normalised here. One image is ``units=1.0,
+    unit_kind="image"`` for this milestone's only provider, but a video or
+    per-second provider would report different units, and choosing one
+    canonical unit at this layer would bake in a conversion Core's ledger is
+    deliberately built not to need (see `media_generation.py` in Core).
+    """
+
+    content: bytes
+    content_type: str
+    filename: str
+    provider: str
+    model: str
+    units: float
+    unit_kind: str
+    cost_usd: float | None
+
+
+class ImageProviderError(RuntimeError):
+    """A provider could not produce a still — a missing/invalid credential, a
+    non-2xx response, or a response this adapter cannot parse.
+
+    Never raised for "the provider returned no price" — that is a successful
+    generation with ``GeneratedImage.cost_usd = None``, not a failure.
+    """
+
+
+class ImageProvider(Protocol):
+    """Everything a route needs to turn a prompt into a still.
+
+    Exactly one method. Requirement 3 of issue #5 — "swapping the provider is
+    an implementation change, not a rewrite" — is proven in this plugin's
+    tests by a fake implementing this same Protocol with no network calls; a
+    second real provider would be exactly the same kind of addition.
+    """
+
+    async def generate_still(self, *, prompt: str) -> GeneratedImage: ...
+
+
+#: Direct env, checked first — set in local development and in tests, so
+#: neither has to reach AWS to run. Named for this plugin specifically
+#: (`MARKETING_`, not a shared `BIFFO_` prefix) because the credential belongs
+#: to this provider integration, not to the platform.
+_DIRECT_ENV = "MARKETING_IMAGE_PROVIDER_API_KEY"
+
+#: The SSM parameter NAME (never the value — see `config.public_base_url`'s
+#: docstring in this same repo for why: an installed plugin has no Terraform
+#: channel for instance-specific secrets until biffo-template#1456 closes, so
+#: the value arrives out of band via `aws ssm put-parameter`, and this module
+#: only ever reads a name Terraform can safely put in state).
+_PARAMETER_ENV = "MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER"
+
+_OPENAI_IMAGES_URL = "https://api.openai.com/v1/images/generations"
+_OPENAI_MODEL = "gpt-image-1"
+
+#: Resolved once per Lambda container, mirroring `config.public_base_url`'s
+#: cache: `None` means "not yet looked up", distinct from `""` meaning
+#: "looked up, and there is nothing there" — without that distinction an
+#: unconfigured deployment would re-query SSM on every request.
+_cached_api_key: str | None = None
+
+
+def _api_key() -> str:
+    """This deployment's image-provider API key, or ``""`` if unconfigured."""
+    global _cached_api_key
+
+    if _cached_api_key is not None:
+        return _cached_api_key
+
+    direct = os.environ.get(_DIRECT_ENV, "").strip()
+    if direct:
+        _cached_api_key = direct
+        return _cached_api_key
+
+    parameter = os.environ.get(_PARAMETER_ENV, "").strip()
+    if not parameter:
+        _cached_api_key = ""
+        return _cached_api_key
+
+    try:
+        import boto3
+
+        client = boto3.client("ssm")
+        value = client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"]
+        _cached_api_key = str(value).strip()
+    except Exception:
+        logger.warning(
+            "Could not read the image provider API key from %s", parameter, exc_info=True
+        )
+        _cached_api_key = ""
+    return _cached_api_key
+
+
+def reset_api_key_cache() -> None:
+    """Forget the resolved key. For tests only."""
+    global _cached_api_key
+    _cached_api_key = None
+
+
+class OpenAIImageProvider:
+    """`ImageProvider` backed by OpenAI's Images API (`gpt-image-1`).
+
+    **This provider's responses carry no price.** Unlike OpenRouter's chat
+    completions — what `agent_runs.cost_usd` is sourced from, a real snapshot
+    of `usage.cost` — OpenAI's Images API returns no cost field at all. Every
+    generation through this adapter is therefore, correctly, `unpriced` in
+    the ledger. That is not a gap here; it is the real shape of the upstream
+    API, and it is exactly the case `media_generations.cost_usd` being
+    nullable exists to represent honestly, rather than defaulting to a wrong
+    zero or asserting a rate-card price this adapter has no authority to
+    invent.
+    """
+
+    def __init__(
+        self, *, timeout: float = 60.0, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
+        self._timeout = timeout
+        #: `None` in production — real network. Tests pass an
+        #: `httpx.MockTransport` so this adapter's parsing/error-mapping is
+        #: exercised with no socket ever opened, per this repo's "no network
+        #: calls in tests" rule.
+        self._transport = transport
+
+    async def generate_still(self, *, prompt: str) -> GeneratedImage:
+        api_key = _api_key()
+        if not api_key:
+            raise ImageProviderError(
+                f"No image provider API key configured ({_DIRECT_ENV} / "
+                f"{_PARAMETER_ENV} are both unset)."
+            )
+
+        async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
+            try:
+                response = await client.post(
+                    _OPENAI_IMAGES_URL,
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json={"model": _OPENAI_MODEL, "prompt": prompt, "n": 1, "size": "1024x1024"},
+                )
+            except httpx.HTTPError as exc:
+                raise ImageProviderError(f"OpenAI request failed: {exc}") from exc
+
+        if response.status_code != httpx.codes.OK:
+            raise ImageProviderError(
+                f"OpenAI returned {response.status_code}: {response.text[:500]}"
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise ImageProviderError("OpenAI response was not valid JSON.") from exc
+
+        items = body.get("data") or []
+        if not items:
+            raise ImageProviderError("OpenAI returned no image data.")
+
+        b64 = items[0].get("b64_json")
+        if not b64:
+            raise ImageProviderError("OpenAI response had no b64_json payload.")
+
+        try:
+            content = base64.b64decode(b64, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise ImageProviderError("OpenAI's b64_json payload did not decode.") from exc
+
+        return GeneratedImage(
+            content=content,
+            content_type="image/png",
+            filename=f"{uuid.uuid4()}.png",
+            provider="openai",
+            model=_OPENAI_MODEL,
+            units=1.0,
+            unit_kind="image",
+            cost_usd=None,
+        )

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -1,0 +1,263 @@
+"""Still-image generation (M6, issue #5): prompt -> stored asset -> ledgered cost.
+
+A new module rather than a route added to `admin_app.py`: other work lands in
+that file concurrently, and `admin_app.py` gains exactly one line — the
+`include_router` call below wires this in, ahead of its `StaticFiles` mount
+(which must stay last — see `admin_app`'s module docstring).
+
+The flow, in the order issue #5 asks for it:
+
+1. `image_provider.ImageProvider.generate_still` — behind the port, so a
+   provider swap never touches this file (issue #5's requirement 3).
+2. Store the bytes via Core's plugin object-storage capability
+   (biffo-template#1437): presign, upload, confirm with `head_object`. The
+   documented flow is "browser PUT" because the capability's usual caller is
+   a user uploading a file — there is no browser in a machine-generated
+   flow, so this Lambda plays that role instead: a presigned POST is just an
+   HTTP request, and nothing about it requires a browser to send it. Bytes
+   still never pass through **Core's** Lambda, which only signs and later
+   verifies with `head_object` — the property the precondition actually
+   promises.
+3. Record the generation in Core's media ledger (biffo-template#1439): a
+   cost, or visibly `unpriced` — never silently zero.
+
+Then a `marketing_asset` row is created with `is_source=True`: the ONE
+approved creative placements are later rendered from (`render.py`, M5) —
+never a placement render itself. This route is the only path in this plugin
+that calls a provider to *create* image bytes, so every asset it writes is,
+by construction, a source.
+
+Both internal Core routes (storage, ledger) are SigV4-signed as
+`system:marketing` (ADR-0009) via the SDK's `create_core_client()` — the same
+mechanism `admin_app._CoreAgentGateway` uses (M3). Reading/writing this
+plugin's own `marketing_campaign` / `marketing_asset` tables uses the
+ordinary Cognito-bearer path instead, via `biffo_plugin_sdk.BiffoAPIClient`
+directly rather than `admin_app._core`: importing back from the module this
+router is included INTO would be a circular import, and reaching into
+`admin_app` for it would grow this module's edit of that file past the single
+include line the boundary asks for.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import httpx
+from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
+from biffo_plugin_sdk.user_serving import require_group
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from .image_provider import GeneratedImage, ImageProvider, ImageProviderError, OpenAIImageProvider
+
+require_admin = require_group("admin")
+
+router = APIRouter(dependencies=[Depends(require_admin)])
+
+_STORAGE_PATH = "/internal/plugins/me/storage"
+_LEDGER_PATH = "/internal/media-generations"
+
+#: A plain client's own upload timeout, matching `admin_app._CORE_TIMEOUT`'s
+#: reasoning: generous enough that a cold start or a slow provider does not
+#: read as a broken feature.
+_UPLOAD_TIMEOUT = 30.0
+
+
+def _validated_campaign_id(campaign_id: str) -> str:
+    """Identical guard to `admin_app._validated_campaign_id`, deliberately
+    duplicated rather than imported (see the module docstring): `campaign_id`
+    below is interpolated into an HTTP path this plugin calls with its own
+    credentials, and CodeQL flagged exactly that shape as a partial SSRF on
+    the first version of `admin_app.mint_links`. A pure UUID-parse-and-
+    re-render has no logic that can drift between two copies the way a
+    stateful helper could — see `admin_app`'s copy for the full reasoning.
+    """
+    try:
+        parsed = uuid.UUID(campaign_id)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found."
+        ) from None
+    return str(parsed)
+
+
+def get_image_provider() -> ImageProvider:
+    """One provider per request, matching `admin_app.get_agent_gateway`'s
+    shape. `OpenAIImageProvider` is the only production implementation this
+    milestone ships; tests override this dependency with a fake — proving
+    issue #5's requirement 3 (a provider swap is an implementation change,
+    not a rewrite) rather than merely asserting it in prose.
+    """
+    return OpenAIImageProvider()
+
+
+def get_core_client() -> BiffoAPIClient:
+    """SigV4-signed by default (ADR-0009): the internal storage and ledger
+    routes are IAM-only, never Cognito. See `admin_app._CoreAgentGateway` for
+    the same mechanism, used there for the internal agent-run API instead.
+    """
+    return create_core_client()
+
+
+def get_campaign_client(admin: Any = Depends(require_admin)) -> BiffoAPIClient:
+    """A plain, bearer-token client for this plugin's own generated-CRUD
+    tables — `marketing_campaign` and `marketing_asset` — scoped to the
+    calling admin's own forwarded token, exactly like `admin_app._core`.
+    """
+    return BiffoAPIClient(token=admin.token)
+
+
+class GenerateStillRequest(BaseModel):
+    prompt: str = Field(min_length=1, max_length=4000)
+    #: Ties this generation to the agent chain that produced the prompt, if
+    #: any — optional, because an operator can also type a prompt directly
+    #: with no chain behind it at all.
+    causation_id: str | None = Field(default=None, max_length=255)
+
+
+class GenerateStillResponse(BaseModel):
+    asset: dict[str, Any]
+    media: dict[str, Any]
+    url: str
+    ledger: dict[str, Any]
+
+
+def _core_error(exc: BiffoAPIError, *, not_found: str | None = None) -> HTTPException:
+    """Map a Core failure to the HTTP status a caller should see.
+
+    A 404 is only ever "the thing you named does not exist" when the caller
+    passes `not_found` for exactly that lookup — reusing 404 for an
+    unrelated Core failure would read as "campaign not found" when the real
+    cause is something else entirely. Storage's own 503 ("not configured
+    here") passes through as-is, matching `internal_plugin_storage.py`'s own
+    posture in Core. Everything else is 502: Core answered, but not with
+    something a retry of *this* request fixes — mirrors
+    `admin_app._pipeline_error_to_http`.
+    """
+    if not_found is not None and exc.status_code == status.HTTP_404_NOT_FOUND:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=not_found)
+    if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+        return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=exc.detail)
+    return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=exc.detail)
+
+
+async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[str, Any]:
+    """presign -> direct upload -> confirm.
+
+    This Lambda plays the role a browser plays for a user-supplied file (see
+    the module docstring): the presigned POST Core mints is just an HTTP
+    request, and nothing about it requires a browser to send it.
+    """
+    try:
+        presigned = await core_client.post(
+            f"{_STORAGE_PATH}/presign",
+            json={"filename": image.filename, "content_type": image.content_type},
+        )
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+
+    if len(image.content) > presigned["max_bytes"]:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"Generated image is {len(image.content)} bytes, over this "
+                f"deployment's {presigned['max_bytes']}-byte ceiling."
+            ),
+        )
+
+    async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as upload_client:
+        try:
+            upload = await upload_client.post(
+                presigned["url"],
+                data=presigned["fields"],
+                files={"file": (image.filename, image.content, image.content_type)},
+            )
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Upload to object storage failed: {exc}",
+            ) from exc
+
+    if upload.status_code not in (200, 201, 204):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Upload to object storage failed: {upload.status_code}",
+        )
+
+    try:
+        return await core_client.post(f"{_STORAGE_PATH}/confirm", json={"key": presigned["key"]})
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+
+
+@router.post("/campaigns/{campaign_id}/stills", status_code=status.HTTP_201_CREATED)
+async def generate_still_route(
+    campaign_id: str,
+    body: GenerateStillRequest,
+    provider: ImageProvider = Depends(get_image_provider),
+    core_client: BiffoAPIClient = Depends(get_core_client),
+    campaign_client: BiffoAPIClient = Depends(get_campaign_client),
+) -> GenerateStillResponse:
+    """Generate one still, store it, ledger its cost (or its absence), and
+    record it as this campaign's approved source creative.
+    """
+    campaign_id = _validated_campaign_id(campaign_id)
+
+    try:
+        await campaign_client.get(f"/campaigns/{campaign_id}")
+    except BiffoAPIError as exc:
+        raise _core_error(exc, not_found="Campaign not found.") from exc
+
+    try:
+        image = await provider.generate_still(prompt=body.prompt)
+    except ImageProviderError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    media = await _upload(core_client, image)
+
+    try:
+        ledger = await core_client.post(
+            _LEDGER_PATH,
+            json={
+                "media_kind": "image",
+                "provider": image.provider,
+                "model": image.model,
+                "units": image.units,
+                "unit_kind": image.unit_kind,
+                "cost_usd": image.cost_usd,
+                "causation_id": body.causation_id,
+            },
+        )
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+
+    try:
+        asset = await campaign_client.post(
+            "/assets",
+            json={
+                "campaign_id": campaign_id,
+                "media_kind": "image",
+                "placement": None,
+                "media_id": media["id"],
+                "is_source": True,
+            },
+        )
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+
+    try:
+        url_resp = await core_client.get(f"{_STORAGE_PATH}/{media['id']}/url")
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+
+    return GenerateStillResponse(
+        asset=asset,
+        media=media,
+        url=url_resp["url"],
+        ledger={
+            "id": ledger["id"],
+            "cost_usd": image.cost_usd,
+            "unpriced": image.cost_usd is None,
+        },
+    )

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -1,0 +1,106 @@
+"""`OpenAIImageProvider` (M6) — over `httpx.MockTransport`, never the network.
+
+Exercises the adapter's own contract: parse a still out of OpenAI's response
+shape, and turn every way it can go wrong into `ImageProviderError` rather
+than an unhandled exception or a silently-empty result.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+
+import marketing.image_provider as image_provider
+from marketing.image_provider import GeneratedImage, ImageProviderError, OpenAIImageProvider
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nnot a real png but bytes are bytes"
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode()
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY", "sk-test-not-real")  # noqa: S105
+    image_provider.reset_api_key_cache()
+    yield
+    image_provider.reset_api_key_cache()
+
+
+def _provider(handler) -> OpenAIImageProvider:
+    """An `OpenAIImageProvider` whose one outbound call is served by
+    `handler` over an in-memory transport — no socket, ever."""
+    return OpenAIImageProvider(transport=httpx.MockTransport(handler))
+
+
+async def test_generate_still_parses_the_image_and_reports_unpriced() -> None:
+    """OpenAI's Images API returns no price at all (the module docstring's
+    whole point) — so a successful generation must be `cost_usd=None`, never
+    a fabricated `0.0`."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer sk-test-not-real"
+        return httpx.Response(200, json={"data": [{"b64_json": _PNG_B64}]})
+
+    image = await _provider(handler).generate_still(prompt="a friendly logo")
+
+    assert isinstance(image, GeneratedImage)
+    assert image.content == _PNG_BYTES
+    assert image.content_type == "image/png"
+    assert image.provider == "openai"
+    assert image.model == "gpt-image-1"
+    assert image.units == 1.0
+    assert image.unit_kind == "image"
+    assert image.cost_usd is None
+
+
+async def test_generate_still_sends_the_prompt() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": [{"b64_json": _PNG_B64}]})
+
+    await _provider(handler).generate_still(prompt="a friendly logo, flat style")
+
+    assert seen["body"]["prompt"] == "a friendly logo, flat style"
+    assert seen["body"]["model"] == "gpt-image-1"
+
+
+async def test_generate_still_raises_on_a_non_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": {"message": "bad prompt"}})
+
+    with pytest.raises(ImageProviderError, match="400"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_data_is_empty() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": []})
+
+    with pytest.raises(ImageProviderError, match="no image data"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_b64_json_is_missing() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"url": "https://example.com/img.png"}]})
+
+    with pytest.raises(ImageProviderError, match="b64_json"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_without_a_configured_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", raising=False)
+    image_provider.reset_api_key_cache()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should never reach the transport with no key")
+
+    with pytest.raises(ImageProviderError, match="No image provider API key"):
+        await _provider(handler).generate_still(prompt="anything")

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -1,0 +1,389 @@
+"""The still-image generation route (M6, issue #5), over fakes for the
+provider, the internal (SigV4) Core client, and the bearer campaign client —
+plus a patched `httpx.AsyncClient` for the one raw upload POST this route
+makes directly to object storage.
+
+Fakes rather than mocks, matching this repo's convention
+(`test_marketing_mint_route.py`, `test_marketing_pipeline_routes.py`): what is
+worth asserting is what got written to the ledger and to `marketing_asset`,
+and a fake that records both says that directly.
+
+A standalone app with only `image_routes.router` — not `admin_app.build_app()`
+— so these tests do not depend on whatever else lands in `admin_app.py`
+concurrently, and so overriding `image_routes.require_admin` cannot be
+confused with `admin_app.require_admin` (two different dependency callables,
+per the module's own docstring on why routes live here rather than there).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from biffo_plugin_sdk import BiffoAPIError
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from marketing import image_routes
+from marketing.image_provider import GeneratedImage, ImageProviderError
+
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000006"
+_MEDIA_ID = "media-1"
+_LEDGER_ID = "ledger-1"
+_PRESIGN_URL = "https://s3.example.invalid/upload"
+
+
+class _FakeImageProvider:
+    """Proves issue #5's requirement 3: this is a second `ImageProvider`
+    implementation, and the route needed no change to accept it."""
+
+    def __init__(self, *, cost_usd: float | None = None, content: bytes = b"fake-bytes") -> None:
+        self.cost_usd = cost_usd
+        self.content = content
+        self.prompts: list[str] = []
+
+    async def generate_still(self, *, prompt: str) -> GeneratedImage:
+        self.prompts.append(prompt)
+        return GeneratedImage(
+            content=self.content,
+            content_type="image/png",
+            filename="fake.png",
+            provider="fake-provider",
+            model="fake-model-1",
+            units=1.0,
+            unit_kind="image",
+            cost_usd=self.cost_usd,
+        )
+
+
+class _FailingImageProvider:
+    async def generate_still(self, *, prompt: str) -> GeneratedImage:
+        raise ImageProviderError("the fake provider always fails")
+
+
+class _FakeCoreClient:
+    """Stands in for the SigV4-signed internal client: storage presign/
+    confirm/url and the media-generations ledger."""
+
+    def __init__(self, *, max_bytes: int = 10_000_000, presign_status: int | None = None) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+        self._max_bytes = max_bytes
+        self._presign_status = presign_status
+
+    async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        self.calls.append(("POST", path, json))
+        if path == f"{image_routes._STORAGE_PATH}/presign":
+            if self._presign_status is not None:
+                raise BiffoAPIError(self._presign_status, "storage unavailable")
+            return {
+                "key": "plugins/marketing/default/generated.png",
+                "url": _PRESIGN_URL,
+                "fields": {"key": "plugins/marketing/default/generated.png"},
+                "max_bytes": self._max_bytes,
+                "expires_in": 900,
+            }
+        if path == f"{image_routes._STORAGE_PATH}/confirm":
+            return {
+                "id": _MEDIA_ID,
+                "owner_plugin": "system:marketing",
+                "storage_key": (json or {})["key"],
+                "filename": "generated.png",
+                "mime_type": "image/png",
+                "size_bytes": len(b"fake-bytes"),
+            }
+        if path == image_routes._LEDGER_PATH:
+            return {"id": _LEDGER_ID, "created_at": "2026-08-10T00:00:00Z"}
+        raise AssertionError(f"unexpected POST {path}")
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append(("GET", path, params))
+        if path == f"{image_routes._STORAGE_PATH}/{_MEDIA_ID}/url":
+            return {"url": "https://s3.example.invalid/signed-get", "expires_in": 300}
+        raise AssertionError(f"unexpected GET {path}")
+
+
+class _FakeCampaignClient:
+    """Stands in for the bearer-token client over the plugin's own
+    generated-CRUD tables (`marketing_campaign`, `marketing_asset`)."""
+
+    def __init__(self, *, exists: bool = True) -> None:
+        self.exists = exists
+        self.created_assets: list[dict[str, Any]] = []
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        if path == f"/campaigns/{_CAMPAIGN}":
+            if not self.exists:
+                raise BiffoAPIError(404, "not found")
+            return {"id": _CAMPAIGN}
+        raise AssertionError(f"unexpected GET {path}")
+
+    async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        if path == "/assets":
+            row = {**(json or {}), "id": f"asset-{len(self.created_assets) + 1}"}
+            self.created_assets.append(row)
+            return row
+        raise AssertionError(f"unexpected POST {path}")
+
+
+def _admin_user() -> Any:
+    return type("U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"})()
+
+
+def _app(
+    *,
+    provider,
+    core_client: _FakeCoreClient,
+    campaign_client: _FakeCampaignClient,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(image_routes.router)
+    app.dependency_overrides[image_routes.require_admin] = _admin_user
+    app.dependency_overrides[image_routes.get_image_provider] = lambda: provider
+    app.dependency_overrides[image_routes.get_core_client] = lambda: core_client
+    app.dependency_overrides[image_routes.get_campaign_client] = lambda: campaign_client
+    return app
+
+
+@pytest.fixture
+def _s3_upload_ok(monkeypatch: pytest.MonkeyPatch):
+    """Patches the module's `httpx.AsyncClient` so the one raw upload POST
+    `_upload` makes lands on an in-memory transport rather than a socket —
+    the s3-facing half of the flow that no `BiffoAPIClient` fake covers,
+    since it is a plain `httpx` call by design (a presigned POST needs no
+    SigV4 signature; S3 verifies the presign's own signature instead)."""
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    class _PatchedClient(real_async_client):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedClient)
+    return calls
+
+
+@pytest.fixture
+def _s3_upload_failing(monkeypatch: pytest.MonkeyPatch):
+    """As `_s3_upload_ok`, but S3 refuses the upload."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="access denied")
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    class _PatchedClient(real_async_client):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedClient)
+
+
+# ── the happy paths ──────────────────────────────────────────────────────────
+
+
+def test_generates_stores_and_ledgers_an_unpriced_still(_s3_upload_ok) -> None:
+    """Requirement 2 of issue #5, unpriced half: no price returned must be
+    *visible* as `unpriced`, never a silent zero."""
+    provider = _FakeImageProvider(cost_usd=None)
+    core = _FakeCoreClient()
+    campaign = _FakeCampaignClient()
+    client = TestClient(_app(provider=provider, core_client=core, campaign_client=campaign))
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "a friendly logo, flat style"}
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+
+    # Requirement 1: stored and retrievable by signed URL.
+    assert body["url"] == "https://s3.example.invalid/signed-get"
+    assert body["media"]["id"] == _MEDIA_ID
+
+    # Requirement 2: ledgered, visibly unpriced.
+    assert body["ledger"]["id"] == _LEDGER_ID
+    assert body["ledger"]["cost_usd"] is None
+    assert body["ledger"]["unpriced"] is True
+
+    # The ONE approved creative, never a placement render.
+    assert body["asset"]["is_source"] is True
+    assert body["asset"]["media_id"] == _MEDIA_ID
+    assert body["asset"]["campaign_id"] == _CAMPAIGN
+    assert body["asset"]["placement"] is None
+    assert campaign.created_assets == [body["asset"]]
+
+    assert provider.prompts == ["a friendly logo, flat style"]
+
+    ledger_call = next(c for c in core.calls if c[1] == image_routes._LEDGER_PATH)
+    assert ledger_call[2]["media_kind"] == "image"
+    assert ledger_call[2]["provider"] == "fake-provider"
+    assert ledger_call[2]["model"] == "fake-model-1"
+    assert ledger_call[2]["units"] == 1.0
+    assert ledger_call[2]["unit_kind"] == "image"
+    assert ledger_call[2]["cost_usd"] is None
+
+
+def test_generates_stores_and_ledgers_a_priced_still(_s3_upload_ok) -> None:
+    """Requirement 2, priced half — proves the ledger write carries a real
+    cost through when the provider returns one, not just the unpriced path."""
+    provider = _FakeImageProvider(cost_usd=0.04)
+    core = _FakeCoreClient()
+    campaign = _FakeCampaignClient()
+    client = TestClient(_app(provider=provider, core_client=core, campaign_client=campaign))
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "a mountain at dusk"})
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["ledger"]["cost_usd"] == 0.04
+    assert body["ledger"]["unpriced"] is False
+
+
+def test_causation_id_travels_to_the_ledger(_s3_upload_ok) -> None:
+    core = _FakeCoreClient()
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/stills",
+        json={"prompt": "anything", "causation_id": "chain-42"},
+    )
+
+    assert resp.status_code == 201
+    ledger_call = next(c for c in core.calls if c[1] == image_routes._LEDGER_PATH)
+    assert ledger_call[2]["causation_id"] == "chain-42"
+
+
+def test_swapping_the_provider_needs_no_route_change(_s3_upload_ok) -> None:
+    """Requirement 3 of issue #5, made concrete: a *second* `ImageProvider`
+    implementation (this test module's own `_FakeImageProvider`, distinct
+    from `OpenAIImageProvider`) drives the same route through the same
+    storage/ledger/asset flow with no change to `image_routes.py`."""
+    provider = _FakeImageProvider(cost_usd=None, content=b"a completely different fake payload")
+    client = TestClient(
+        _app(
+            provider=provider, core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "swap me in"})
+
+    assert resp.status_code == 201
+    assert resp.json()["asset"]["is_source"] is True
+
+
+# ── failure paths ────────────────────────────────────────────────────────────
+
+
+def test_404s_an_unknown_campaign() -> None:
+    client = TestClient(
+        _app(
+            provider=_FakeImageProvider(),
+            core_client=_FakeCoreClient(),
+            campaign_client=_FakeCampaignClient(exists=False),
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 404
+
+
+def test_404s_a_malformed_campaign_id() -> None:
+    """The SSRF guard: not-a-UUID must 404, never reach a Core call built
+    from the raw path segment (`admin_app`'s module docstring names the
+    CodeQL finding this mirrors)."""
+    campaign_client = _FakeCampaignClient()
+    client = TestClient(
+        _app(
+            provider=_FakeImageProvider(),
+            core_client=_FakeCoreClient(),
+            campaign_client=campaign_client,
+        )
+    )
+
+    resp = client.post("/campaigns/not-a-uuid-at-all/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 404
+    # And the guard fired before any Core call was made with the raw value.
+    assert campaign_client.created_assets == []
+
+
+def test_502s_when_the_provider_fails() -> None:
+    client = TestClient(
+        _app(
+            provider=_FailingImageProvider(),
+            core_client=_FakeCoreClient(),
+            campaign_client=_FakeCampaignClient(),
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    assert "always fails" in resp.json()["detail"]
+
+
+def test_502s_when_the_generated_image_exceeds_the_storage_ceiling() -> None:
+    core = _FakeCoreClient(max_bytes=4)  # smaller than any real payload
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    assert "byte ceiling" in resp.json()["detail"]
+
+
+def test_502s_when_the_upload_is_refused(_s3_upload_failing) -> None:
+    client = TestClient(
+        _app(
+            provider=_FakeImageProvider(),
+            core_client=_FakeCoreClient(),
+            campaign_client=_FakeCampaignClient(),
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+
+
+def test_storage_unavailable_passes_through_as_503() -> None:
+    """`internal_plugin_storage.py`'s own posture in Core: an unconfigured
+    bucket is a deployment that has not been wired, not a bug in this
+    request — 503, not 502."""
+    core = _FakeCoreClient(presign_status=503)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 503
+
+
+def test_rejects_an_empty_prompt() -> None:
+    client = TestClient(
+        _app(
+            provider=_FakeImageProvider(),
+            core_client=_FakeCoreClient(),
+            campaign_client=_FakeCampaignClient(),
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": ""})
+
+    assert resp.status_code == 422


### PR DESCRIPTION
Refs #5.

## What this does

Still-image generation behind a provider port, per M6's three parts:

1. **Provider port** — `src/marketing/image_provider.py` defines `ImageProvider`
   (a `Protocol` with one method, `generate_still`), a `GeneratedImage` result
   type, and one real implementation, `OpenAIImageProvider` (`gpt-image-1`).
   Nothing outside this module names a vendor/model/SDK, so a second provider
   is a new class implementing the same Protocol — proven in tests by a fake
   provider driving the same route with no code change.
2. **Cost recorded per generation** — every generation POSTs to Core's
   internal `media-generations` ledger (SigV4-signed, `system:marketing`),
   carrying `provider`/`model`/`units`/`unit_kind`/`cost_usd`. OpenAI's Images
   API returns no price at all, so real generations are correctly `unpriced`
   (`cost_usd=None`), never a fabricated `0.0` — the route echoes
   `unpriced: true/false` back so a caller never has to infer it.
3. **Assets stored via Core's plugin object storage** — presign → upload →
   confirm (`head_object`-verified) against `/internal/plugins/me/storage/*`.
   The documented flow is "browser PUT"; there is no browser in a
   machine-generated flow, so this Lambda plays that role instead — a
   presigned POST is just an HTTP request. Bytes never pass through Core's
   own Lambda, which only signs and later verifies.

The route (`POST /campaigns/{id}/stills`, in a new `image_routes.py`) creates
the campaign's `marketing_asset` row with `is_source=True` — the one approved
creative `render.py` (M5, untouched here) later crops into placements. It is
the only path in this plugin that calls a provider to *create* image bytes.

## Boundaries respected

- `render.py`, `links.py`, `config.py`, `pipeline.py`, `web-admin/`,
  `biffo.plugin.json` — untouched.
- `admin_app.py` gains exactly one import + one `include_router` line, ahead
  of the `StaticFiles` mount (still last). Routes live in `image_routes.py`
  instead, specifically so this doesn't collide with other concurrent work in
  `admin_app.py`.
- `image_routes.py` duplicates `admin_app._validated_campaign_id` (the
  CodeQL-driven SSRF guard) rather than importing it, to avoid a circular
  import back into the module this router is included into — noted in both
  modules' docstrings.

## Tests

`tests/test_marketing_image_provider.py` — `OpenAIImageProvider` over
`httpx.MockTransport` (an injectable `transport` param), no network calls:
successful parse, prompt forwarding, non-200, empty `data`, missing
`b64_json`, missing API key.

`tests/test_marketing_image_routes.py` — the route over fakes for the
provider, the internal (SigV4) client, and the bearer campaign client, plus a
patched `httpx.AsyncClient` for the one raw upload POST. Covers: priced and
unpriced generation, `causation_id` propagation, a second `ImageProvider`
implementation needing no route change, unknown/malformed campaign id (404),
provider failure (502), oversized generation vs. the storage ceiling (502),
refused upload (502), storage unconfigured (503 passthrough), empty prompt
(422).

Full suite: `uv run pytest` — 192 passed. `ruff check` / `ruff format --check`
/ `pyright` all clean.

## What I could not verify

- **No live OpenAI key is configured in this environment**, so
  `OpenAIImageProvider`'s real HTTP call has never been exercised against the
  actual API — only against a mocked transport whose shape I modelled from
  OpenAI's documented response format. If that shape has drifted, this would
  fail at the parsing step in a live deployment.
- **No live Core deployment was exercised.** The presign→upload→confirm
  flow, the ledger write, and the asset write are all verified against fakes
  matching the routers I read in `biffo-template`'s `services/api/src/api/
  routers/internal_plugin_storage.py` and `internal_media_generations.py` —
  not against a running instance. I did not deploy or call a live endpoint.
- **Partial-failure ordering**: the ledger write happens before the
  `marketing_asset` write, deliberately (spend visibility over asset
  visibility — see `image_routes.py`), so a failure between them leaves a
  ledger row with no linked asset, though the uploaded object is still
  recorded in Core's `plugin_media` table via `confirm`. No cross-step saga/
  rollback is built for this milestone.
- **Credential provisioning** (SSM parameter + `aws ssm put-parameter`) is
  wired the way `config.public_base_url` documents but has not itself been
  exercised against real SSM — the direct-env path is what every test uses.
