### PR TITLE
test(marketing): second fixture UUID tripping secret scan

### DIFF
--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 from marketing import admin_app, pipeline
 from marketing.definitions import RESEARCH_SYNTHESIS_AGENT_NAME
 
-_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000002"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000cd"
 
 
 class _FakeCore:


### PR DESCRIPTION
`_CAMPAIGN` in `test_marketing_pipeline_routes.py` ended in twelve digits (`...000000000002`), which `.gitleaks.toml`'s `biffo-aws-account-id` rule matches. Same trap as #14 — second occurrence.

This repo's own gate does not catch it; tabsii-platform's does, when the tests are vendored in with the plugin. So it is found one repo and one CI cycle downstream of where it is written, every time. Filed that config gap as #19 rather than fixing it here.

175 passed.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)