### PR TITLE
feat(marketing): channel plan agent (M4)

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -237,10 +237,11 @@ async def _core(method: str, path: str, token: str, **kw: Any) -> httpx.Response
 # `_core`'s Cognito-bearer-token calls cannot reach (ADR-0009 gates it on IAM,
 # not a JWT).
 
-#: Only the two kinds this milestone builds. `channel_plan` is
-#: `definitions.ARTEFACT_KINDS`'s third member and is not wired to a pipeline
-#: yet — a later milestone's job, not this one's to fake.
-_PIPELINE_ARTEFACT_KINDS = ("research", "positioning")
+#: The kinds a pipeline stage exists for. All three of
+#: `definitions.ARTEFACT_KINDS` as of M4 (issue #3) — `channel_plan` reuses
+#: this same generic read/approve/reject dispatch; only `_advance_artefact`
+#: below and `channel_plan_routes.py`'s starter route are kind-specific.
+_PIPELINE_ARTEFACT_KINDS = ("research", "positioning", "channel_plan")
 
 _AGENT_RUNS_PATH = "/api/v1/internal/agent-runs"
 
@@ -367,17 +368,22 @@ async def _advance_artefact(
             gateway, chain_id=artefact["causation_id"], research_run_ids=research_run_ids
         )
     else:
+        # positioning and channel_plan are both single, un-fanned-out runs —
+        # `agent_run_id` is stamped on creation by their respective starter
+        # routes (`start_positioning_route` here, `start_channel_plan_route`
+        # in `channel_plan_routes.py`). A row edited directly through
+        # generated CRUD could lack it, and "there is no run to advance" is a
+        # real, distinct failure from any pipeline error.
         run_id = artefact.get("agent_run_id")
         if not run_id:
-            # Cannot happen via the routes below — `start_positioning_route`
-            # always stamps `agent_run_id` on creation — but a row edited
-            # directly through generated CRUD could lack it, and "there is no
-            # run to advance" is a real, distinct failure from any pipeline
-            # error.
             raise pipeline.MalformedOutputError(
-                "This positioning artefact has no agent_run_id to advance."
+                f"This {kind} artefact has no agent_run_id to advance."
             )
-        result = await pipeline.advance_positioning(gateway, run_id=run_id)
+        result = (
+            await pipeline.advance_channel_plan(gateway, run_id=run_id)
+            if kind == "channel_plan"
+            else await pipeline.advance_positioning(gateway, run_id=run_id)
+        )
 
     if result is None:
         return artefact  # still in flight; nothing to propose yet
@@ -589,6 +595,17 @@ def build_app() -> FastAPI:
     # not here, so this file gains only this one line. See that module's
     # docstring for why.
     app.include_router(image_router)
+
+    # Channel-plan (M4) routes live in their own module, imported here —
+    # rather than at this module's top level — so this file's own diff stays
+    # small: `channel_plan_routes` reaches back into this module for the
+    # shared `require_admin`/`get_agent_gateway`/`_core`/`_latest_artefact`
+    # helpers, and importing it at top level would be a real circular import
+    # (those names do not exist yet at that point in this module's own
+    # execution). By the time `build_app()` runs, they do.
+    from .channel_plan_routes import router as channel_plan_router
+
+    app.include_router(channel_plan_router)
 
     # LAST. See the module docstring: a StaticFiles mount at "/" swallows
     # everything registered after it, so anything below this line is unreachable.

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -51,7 +52,7 @@ from pydantic import BaseModel, Field
 
 from . import pipeline
 from .config import public_base_url
-from .definitions import MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
+from .definitions import ARTEFACT_KINDS, MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
 from .image_routes import router as image_router
 from .links import destination_with_utms, mint_token, tracked_url
 
@@ -237,11 +238,27 @@ async def _core(method: str, path: str, token: str, **kw: Any) -> httpx.Response
 # `_core`'s Cognito-bearer-token calls cannot reach (ADR-0009 gates it on IAM,
 # not a JWT).
 
-#: The kinds a pipeline stage exists for. All three of
-#: `definitions.ARTEFACT_KINDS` as of M4 (issue #3) — `channel_plan` reuses
-#: this same generic read/approve/reject dispatch; only `_advance_artefact`
-#: below and `channel_plan_routes.py`'s starter route are kind-specific.
+#: The kinds a pipeline stage exists for — an explicit, opt-in subset of
+#: `definitions.ARTEFACT_KINDS` (which also lists table-level kinds that may
+#: not have a wired stage yet, as `channel_plan` itself did not until M4).
+#: Kept as its own tuple rather than reused directly so that adding a kind to
+#: `ARTEFACT_KINDS` cannot, by itself, make routes below start dispatching to
+#: it before a stage actually exists — the assertion just below is what stops
+#: this tuple drifting to name a kind `ARTEFACT_KINDS` does not.
+#:
+#: Kind-specific code, all of it: `_advance_artefact`'s branch on `kind`
+#: below, `pipeline.flatten_citations`'s dispatch on the result *type* (not
+#: `kind` — it never sees the string), and each stage's own starter route
+#: (`start_research_route`/`start_positioning_route` here,
+#: `start_channel_plan_route` in `channel_plan_routes.py`). Everything else
+#: — `get_artefact_route`/`approve_artefact_route`/`reject_artefact_route` —
+#: is generic over any kind in this tuple.
 _PIPELINE_ARTEFACT_KINDS = ("research", "positioning", "channel_plan")
+if not set(_PIPELINE_ARTEFACT_KINDS) <= set(ARTEFACT_KINDS):
+    raise RuntimeError(
+        "_PIPELINE_ARTEFACT_KINDS must stay a subset of definitions.ARTEFACT_KINDS "
+        f"(got {_PIPELINE_ARTEFACT_KINDS!r} against {ARTEFACT_KINDS!r})"
+    )
 
 _AGENT_RUNS_PATH = "/api/v1/internal/agent-runs"
 
@@ -354,6 +371,18 @@ def _pipeline_error_to_http(exc: pipeline.PipelineError) -> HTTPException:
     return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
 
 
+#: `research` is fanned out and handled as its own branch below — its advance
+#: function takes `chain_id`/`research_run_ids`, not a single `run_id`, so it
+#: cannot share this mapping's call shape. Every other stage is a single,
+#: un-fanned-out run, and shares exactly the shape `advance(gateway,
+#: run_id=...)`: adding one grows this dict by one line, not `_advance_artefact`
+#: by a new branch.
+_SINGLE_RUN_ADVANCERS: dict[str, Callable[..., Any]] = {
+    "positioning": pipeline.advance_positioning,
+    "channel_plan": pipeline.advance_channel_plan,
+}
+
+
 async def _advance_artefact(
     artefact: dict[str, Any], kind: str, gateway: pipeline.AgentGateway, token: str
 ) -> dict[str, Any]:
@@ -368,9 +397,8 @@ async def _advance_artefact(
             gateway, chain_id=artefact["causation_id"], research_run_ids=research_run_ids
         )
     else:
-        # positioning and channel_plan are both single, un-fanned-out runs —
-        # `agent_run_id` is stamped on creation by their respective starter
-        # routes (`start_positioning_route` here, `start_channel_plan_route`
+        # `agent_run_id` is stamped on creation by each stage's own starter
+        # route (`start_positioning_route` here, `start_channel_plan_route`
         # in `channel_plan_routes.py`). A row edited directly through
         # generated CRUD could lack it, and "there is no run to advance" is a
         # real, distinct failure from any pipeline error.
@@ -379,11 +407,7 @@ async def _advance_artefact(
             raise pipeline.MalformedOutputError(
                 f"This {kind} artefact has no agent_run_id to advance."
             )
-        result = (
-            await pipeline.advance_channel_plan(gateway, run_id=run_id)
-            if kind == "channel_plan"
-            else await pipeline.advance_positioning(gateway, run_id=run_id)
-        )
+        result = await _SINGLE_RUN_ADVANCERS[kind](gateway, run_id=run_id)
 
     if result is None:
         return artefact  # still in flight; nothing to propose yet

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -1,0 +1,71 @@
+"""Channel-plan (M4, issue #3) admin route — the one thing that is new for
+this milestone beyond what `admin_app.py` already dispatches generically
+(``get_artefact_route``/``approve_artefact_route``/``reject_artefact_route``
+already cover ``channel_plan`` once it is a known kind).
+
+Kept in its own module, deliberately, rather than added inline in
+``admin_app.py`` next to ``start_positioning_route``: several agents can be
+working in this repo at once, and ``admin_app.py`` is exactly the kind of file
+more than one of them touches. This module reaches back into ``admin_app`` for
+the handful of helpers every route in that file already shares
+(``require_admin``, ``get_agent_gateway``, ``_core``, ``_validated_campaign_id``,
+``_latest_artefact``) rather than duplicating them — see ``admin_app.build_app``
+for why the include is a lazy, in-function import rather than a top-level one.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from . import admin_app, pipeline
+
+router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
+
+
+@router.post("/campaigns/{campaign_id}/channel-plan", status_code=status.HTTP_201_CREATED)
+async def start_channel_plan_route(
+    campaign_id: str,
+    gateway: pipeline.AgentGateway = Depends(admin_app.get_agent_gateway),
+    admin: Any = Depends(admin_app.require_admin),
+) -> dict[str, Any]:
+    """Start the single channel-plan agent, requiring an **approved**
+    positioning artefact — mirrors ``start_positioning_route``'s gate
+    exactly: `proposed` positioning must not be usable here, or the approval
+    step for positioning is decorative."""
+    campaign_id = admin_app._validated_campaign_id(campaign_id)
+
+    positioning = await admin_app._latest_artefact(campaign_id, "positioning", admin.token)
+    if positioning is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No positioning artefact for this campaign yet.",
+        )
+    try:
+        pipeline.require_approved(positioning.get("status") or "", what="The positioning artefact")
+    except pipeline.ArtefactNotApprovedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    raw_body = positioning.get("body")
+    positioning_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+
+    causation_id, run_id = await pipeline.start_channel_plan(
+        gateway, positioning_body=positioning_body
+    )
+
+    created = await admin_app._core(
+        "POST",
+        "/artefacts",
+        admin.token,
+        json={
+            "campaign_id": campaign_id,
+            "kind": "channel_plan",
+            "status": "pending",
+            "causation_id": causation_id,
+            "agent_run_id": run_id,
+        },
+    )
+    created.raise_for_status()
+    return created.json()

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -12,7 +12,7 @@ converted at every boundary for no gain.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -89,6 +89,7 @@ RESEARCH_AUDIENCE_AGENT_NAME = "marketing-research-audience"
 RESEARCH_COMPETITIVE_AGENT_NAME = "marketing-research-competitive"
 RESEARCH_SYNTHESIS_AGENT_NAME = "marketing-research-synthesis"
 POSITIONING_AGENT_NAME = "marketing-positioning"
+CHANNEL_PLAN_AGENT_NAME = "marketing-channel-plan"
 
 #: The two research angles, in fan-out order. A tuple, like idea-scout's
 #: ``RESEARCH_AGENT_NAMES``, so the pipeline fans out over exactly these and
@@ -103,6 +104,7 @@ RESEARCH_AGENT_NAMES: tuple[str, ...] = (
 FINDINGS_TOOL_NAME = "submit_research_findings"
 RESEARCH_SYNTHESIS_TOOL_NAME = "submit_research_synthesis"
 POSITIONING_TOOL_NAME = "submit_positioning"
+CHANNEL_PLAN_TOOL_NAME = "submit_channel_plan"
 
 
 # ── Structured artefacts ─────────────────────────────────────────────────────
@@ -185,6 +187,40 @@ class Positioning(BaseModel):
     segments: list[Segment] = Field(default_factory=list)
     pillars: list[MessagePillar] = Field(default_factory=list)
     ctas: list[CallToAction] = Field(default_factory=list)
+
+
+class ChannelRecommendation(BaseModel):
+    """One recommended channel, organic or paid, grounded in the approved
+    positioning. Same citation discipline as `Segment`/`MessagePillar`/
+    `CallToAction`: `sources` has no default and a minimum length of one, so
+    a recommendation with no evidence cannot be built."""
+
+    channel: str = Field(
+        description="The channel, named specifically (e.g. 'Instagram Reels', 'Google Search ads')."
+    )
+    motion: Literal["organic", "paid"] = Field(
+        description="Whether this is an organic or a paid channel."
+    )
+    rank: int = Field(ge=1, description="This channel's priority within its motion — 1 is highest.")
+    rationale: str = Field(
+        description=(
+            "Why this channel fits, grounded in the positioning's segments, pillars or "
+            "CTAs — not generic channel wisdom."
+        )
+    )
+    sources: list[Source] = Field(
+        min_length=1, description="Positioning sources supporting this recommendation."
+    )
+
+
+class ChannelPlan(BaseModel):
+    """The channel-plan agent's full output — the reviewable artefact behind
+    the third approval gate (M4). Organic and paid recommendations share one
+    list, distinguished by `ChannelRecommendation.motion`, rather than two
+    separate lists: ranking is only meaningful within a motion, and a single
+    list keeps that scoped to the field the rank is relative to."""
+
+    channels: list[ChannelRecommendation] = Field(default_factory=list)
 
 
 # ── Prompts ──────────────────────────────────────────────────────────────────
@@ -298,6 +334,41 @@ Return your answer by calling the `{POSITIONING_TOOL_NAME}` tool exactly
 once. Do not answer in prose.
 """
 
+CHANNEL_PLAN_INSTRUCTIONS = f"""\
+You are the campaign studio's channel strategist. You are given one
+**approved** positioning artefact — audience segments, message pillars and
+calls to action, each carrying the sources that support it. Nothing else. You
+do not have web access and must not claim to.
+
+Recommend channels for this campaign, covering BOTH motions:
+1. **Organic** channels — where this audience already spends attention,
+   reachable without paid distribution.
+2. **Paid** channels — where paid distribution would reach this audience
+   fastest or most precisely.
+
+Rank the channels within each motion (1 = highest priority) and give each a
+rationale an operator can disagree with: name exactly which segment, pillar or
+CTA the recommendation follows from. A channel recommendation with no evidence
+behind it is the most confident-sounding fabrication in this pipeline —
+"run paid social" or "post on LinkedIn" reads as correct whether or not
+anyone researched it, so generic channel wisdom is not an acceptable
+rationale.
+
+Every recommendation must carry `sources`: copy the relevant `Source` objects
+(url and note) from the positioning you were given — verbatim, not reworded.
+Never invent a source, and never recommend a channel that cites nothing: if
+the positioning does not support recommending a channel, do not recommend it.
+
+If the positioning is too thin to support any recommendation in a motion,
+return fewer channels (or none) for that motion rather than inventing content
+to fill it — a channel plan that recommends nothing beats one that recommends
+plausibly.
+
+{_UNTRUSTED_INPUT_RULE}
+Return your answer by calling the `{CHANNEL_PLAN_TOOL_NAME}` tool exactly
+once. Do not answer in prose.
+"""
+
 #: Keyed by research agent name, in ``RESEARCH_AGENT_NAMES`` order — the
 #: pipeline looks each one up rather than duplicating the pairing.
 RESEARCH_INSTRUCTIONS: dict[str, str] = {
@@ -313,19 +384,21 @@ RESEARCH_INSTRUCTIONS: dict[str, str] = {
 #: docstring for why (an unlisted alias is accepted today but is undocumented
 #: behaviour, not a documented guarantee).
 DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-4:online"
-#: Neither synthesis nor positioning searches — both reason over what they are
-#: given — so neither needs `:online`.
+#: Neither synthesis, positioning nor channel planning searches — all three
+#: reason over what they are given — so none of them needs `:online`.
 DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-4.8"
 DEFAULT_POSITIONING_MODEL = "anthropic/claude-opus-4.8"
+DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-opus-4.8"
 
 # Matches idea-scout's research budget: enough turns to search several times
 # and still answer. Every turn has an invoice attached and this plugin fans out
 # two of these per research run, so raising it is a cost decision.
 RESEARCH_MAX_TURNS = 8
-# Neither synthesis nor positioning searches; one turn to answer, plus headroom
-# for a retried tool call.
+# Neither synthesis, positioning nor channel planning searches; one turn to
+# answer, plus headroom for a retried tool call.
 SYNTHESIS_MAX_TURNS = 3
 POSITIONING_MAX_TURNS = 3
+CHANNEL_PLAN_MAX_TURNS = 3
 
 
 def research_definition(*, model: str, instructions: str) -> dict[str, Any]:
@@ -367,6 +440,17 @@ def positioning_definition(*, model: str, instructions: str) -> dict[str, Any]:
     }
 
 
+def channel_plan_definition(*, model: str, instructions: str) -> dict[str, Any]:
+    """The channel-plan agent's run definition — no tools; it reasons over
+    the approved positioning artefact it is given in ``input_payload``."""
+    return {
+        "instructions": instructions,
+        "model": model,
+        "tools": [],
+        "max_turns": CHANNEL_PLAN_MAX_TURNS,
+    }
+
+
 def findings_tool_schema() -> dict[str, Any]:
     """The output tool a research agent calls to return its findings."""
     return {
@@ -401,5 +485,18 @@ def positioning_tool_schema() -> dict[str, Any]:
             "name": POSITIONING_TOOL_NAME,
             "description": "Submit the audience segments, message pillars and CTAs.",
             "parameters": Positioning.model_json_schema(),
+        },
+    }
+
+
+def channel_plan_tool_schema() -> dict[str, Any]:
+    """The output tool the channel-plan agent calls to return its ranked
+    organic and paid channel recommendations."""
+    return {
+        "type": "function",
+        "function": {
+            "name": CHANNEL_PLAN_TOOL_NAME,
+            "description": "Submit the ranked organic and paid channel recommendations.",
+            "parameters": ChannelPlan.model_json_schema(),
         },
     }

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -1,5 +1,5 @@
-"""Research + positioning orchestration (M3) — fan-out/fan-in over Core's
-agent-run seam, and the citation-enforcement guard that turns a research run
+"""Research + positioning + channel-plan orchestration (M3 + M4) — fan-out/fan-in
+over Core's agent-run seam, and the citation-enforcement guard that turns a run
 with no evidence into a hard failure rather than a beautifully formatted
 document.
 
@@ -14,14 +14,19 @@ actually built (a plain ``SignedCoreClient``, ADR-0009/ADR-0021 §1a).
 **The zero-citation guard is the milestone, not a detail.** Biffo's agent
 ``web_search`` is silently unavailable on dev (an empty Brave key), and an
 agent given a tool it cannot use does not error — it fabricates. Structurally,
-a ``ResearchFinding``/``Segment``/``MessagePillar``/``CallToAction`` cannot be
-built with an empty ``sources`` list (``definitions.py``'s
-``Field(min_length=1)``) — but an agent can still honestly report *zero*
-findings, or Core's transcript can carry no usable tool call at all, and both
-of those are still "nothing to show an operator". ``extract_research_synthesis``
-and ``extract_positioning`` catch that aggregate case: a run whose entire
-output cites nothing raises :class:`NoCitationsError` rather than returning an
-artefact body an admin route could propose.
+a ``ResearchFinding``/``Segment``/``MessagePillar``/``CallToAction``/
+``ChannelRecommendation`` cannot be built with an empty ``sources`` list
+(``definitions.py``'s ``Field(min_length=1)``) — but an agent can still
+honestly report *zero* findings, or Core's transcript can carry no usable tool
+call at all, and both of those are still "nothing to show an operator".
+``extract_research_synthesis``, ``extract_positioning`` and
+``extract_channel_plan`` catch that aggregate case: a run whose entire output
+cites nothing raises :class:`NoCitationsError` rather than returning an
+artefact body an admin route could propose. M4 (issue #3) is that same guard
+applied one stage further down the chain, for the same reason stated there: a
+channel recommendation with no evidence is the most confident-sounding
+fabrication in the pipeline, because channel advice reads as generic wisdom
+whether or not anyone researched it.
 """
 
 from __future__ import annotations
@@ -34,6 +39,10 @@ from typing import Any, Protocol
 from pydantic import ValidationError
 
 from .definitions import (
+    CHANNEL_PLAN_AGENT_NAME,
+    CHANNEL_PLAN_INSTRUCTIONS,
+    CHANNEL_PLAN_TOOL_NAME,
+    DEFAULT_CHANNEL_PLAN_MODEL,
     DEFAULT_POSITIONING_MODEL,
     DEFAULT_RESEARCH_MODEL,
     DEFAULT_SYNTHESIS_MODEL,
@@ -45,10 +54,13 @@ from .definitions import (
     RESEARCH_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_AGENT_NAME,
     RESEARCH_SYNTHESIS_TOOL_NAME,
+    ChannelPlan,
     Positioning,
     ResearchFindingSet,
     ResearchSynthesis,
     Source,
+    channel_plan_definition,
+    channel_plan_tool_schema,
     findings_tool_schema,
     positioning_definition,
     positioning_tool_schema,
@@ -183,7 +195,35 @@ def extract_positioning(messages: list[dict[str, Any]]) -> Positioning:
     return positioning
 
 
-def flatten_citations(output: ResearchSynthesis | Positioning) -> list[dict[str, Any]]:
+def extract_channel_plan(messages: list[dict[str, Any]]) -> ChannelPlan:
+    """The channel-plan agent's output, or a hard failure — the same two
+    failure modes as :func:`extract_positioning`, for the same reason (M4,
+    issue #3): a channel recommendation is exactly as fabricable as a
+    positioning claim, and arguably the most confident-sounding one in the
+    whole pipeline, because channel advice reads as generic wisdom whether or
+    not anyone researched it."""
+    data = _tool_call_arguments(messages, CHANNEL_PLAN_TOOL_NAME)
+    if data is None:
+        raise MalformedOutputError(
+            f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call"
+        )
+    try:
+        plan = ChannelPlan.model_validate(data)
+    except ValidationError as exc:
+        raise MalformedOutputError(str(exc)) from exc
+
+    total = _total_citations(*(c.sources for c in plan.channels))
+    if total == 0:
+        raise NoCitationsError(
+            "The channel-plan run cited nothing from the approved positioning. Nothing "
+            "was produced — try running channel planning again."
+        )
+    return plan
+
+
+def flatten_citations(
+    output: ResearchSynthesis | Positioning | ChannelPlan,
+) -> list[dict[str, Any]]:
     """Every :class:`Source` across an artefact's structured output,
     deduplicated by URL in first-seen order — what is written to
     ``marketing_artefact.citations``.
@@ -195,12 +235,14 @@ def flatten_citations(output: ResearchSynthesis | Positioning) -> list[dict[str,
     """
     if isinstance(output, ResearchSynthesis):
         groups: list[list[Source]] = [f.sources for f in output.findings]
-    else:
+    elif isinstance(output, Positioning):
         groups = [
             *(s.sources for s in output.segments),
             *(p.sources for p in output.pillars),
             *(c.sources for c in output.ctas),
         ]
+    else:
+        groups = [c.sources for c in output.channels]
     seen: set[str] = set()
     flat: list[dict[str, Any]] = []
     for sources in groups:
@@ -405,6 +447,44 @@ async def advance_positioning(gateway: AgentGateway, *, run_id: str) -> Position
     if not view.succeeded:
         raise RunNotSucceededError("The positioning run did not complete successfully.")
     return extract_positioning(view.messages)
+
+
+async def start_channel_plan(
+    gateway: AgentGateway,
+    *,
+    positioning_body: dict[str, Any],
+    channel_plan_model: str = DEFAULT_CHANNEL_PLAN_MODEL,
+) -> tuple[str, str]:
+    """Request the single channel-plan agent (M4), given the *approved*
+    positioning artefact's body as its whole input.
+
+    Mirrors :func:`start_positioning` exactly, one stage further down the
+    chain: a single-run chain, not fanned out, because nothing fans in on it.
+    """
+    causation_id = str(uuid.uuid4())
+    run_id = await gateway.request_agent_run(
+        agent_name=CHANNEL_PLAN_AGENT_NAME,
+        definition=channel_plan_definition(
+            model=channel_plan_model,
+            instructions=CHANNEL_PLAN_INSTRUCTIONS,
+        ),
+        output_tool=channel_plan_tool_schema(),
+        input_payload={"positioning": positioning_body},
+        causation_id=causation_id,
+    )
+    return causation_id, run_id
+
+
+async def advance_channel_plan(gateway: AgentGateway, *, run_id: str) -> ChannelPlan | None:
+    """Read the channel-plan run, advancing nothing else — mirrors
+    :func:`advance_positioning`: a single run, not a chain, so there is no
+    fan-in to discover."""
+    view = await gateway.get_agent_run(run_id=run_id)
+    if view is None or not view.is_terminal:
+        return None
+    if not view.succeeded:
+        raise RunNotSucceededError("The channel-plan run did not complete successfully.")
+    return extract_channel_plan(view.messages)
 
 
 def require_approved(status: str, *, what: str) -> None:

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -33,10 +33,11 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from .definitions import (
     CHANNEL_PLAN_AGENT_NAME,
@@ -139,6 +140,39 @@ def _total_citations(*source_lists: list[Source]) -> int:
     return sum(len(sources) for sources in source_lists)
 
 
+def _extract_cited_artefact[T: BaseModel](
+    messages: list[dict[str, Any]],
+    *,
+    tool_name: str,
+    model_cls: type[T],
+    citation_groups: Callable[[T], list[list[Source]]],
+    malformed_message: str,
+    no_citations_message: str,
+) -> T:
+    """The shared skeleton behind :func:`extract_research_synthesis`,
+    :func:`extract_positioning` and :func:`extract_channel_plan`: fetch the
+    last call to ``tool_name``, validate it against ``model_cls``, and
+    enforce the zero-citation guard over ``citation_groups(result)``.
+
+    Kept as one implementation rather than three near-identical copies
+    precisely because the guard is "the milestone, not a detail" (this
+    module's docstring) — three copies is three places a change to the guard
+    itself (or a fix to it) can drift out of step.
+    """
+    data = _tool_call_arguments(messages, tool_name)
+    if data is None:
+        raise MalformedOutputError(malformed_message)
+    try:
+        result = model_cls.model_validate(data)
+    except ValidationError as exc:
+        raise MalformedOutputError(str(exc)) from exc
+
+    total = _total_citations(*citation_groups(result))
+    if total == 0:
+        raise NoCitationsError(no_citations_message)
+    return result
+
+
 def extract_research_synthesis(messages: list[dict[str, Any]]) -> ResearchSynthesis:
     """The research-synthesis agent's output, or a hard failure.
 
@@ -148,23 +182,19 @@ def extract_research_synthesis(messages: list[dict[str, Any]]) -> ResearchSynthe
     finding little, there is no redundancy at the synthesis step: nothing else
     produces the ``research`` artefact, so there is nothing to degrade to.
     """
-    data = _tool_call_arguments(messages, RESEARCH_SYNTHESIS_TOOL_NAME)
-    if data is None:
-        raise MalformedOutputError(
+    return _extract_cited_artefact(
+        messages,
+        tool_name=RESEARCH_SYNTHESIS_TOOL_NAME,
+        model_cls=ResearchSynthesis,
+        citation_groups=lambda r: [f.sources for f in r.findings],
+        malformed_message=(
             f"the research-synthesis run produced no {RESEARCH_SYNTHESIS_TOOL_NAME} tool call"
-        )
-    try:
-        synthesis = ResearchSynthesis.model_validate(data)
-    except ValidationError as exc:
-        raise MalformedOutputError(str(exc)) from exc
-
-    total = _total_citations(*(f.sources for f in synthesis.findings))
-    if total == 0:
-        raise NoCitationsError(
+        ),
+        no_citations_message=(
             "The research run fetched zero URLs. Nothing was found to cite, so no "
             "artefact was produced — try running research again."
-        )
-    return synthesis
+        ),
+    )
 
 
 def extract_positioning(messages: list[dict[str, Any]]) -> Positioning:
@@ -172,27 +202,21 @@ def extract_positioning(messages: list[dict[str, Any]]) -> Positioning:
     failure modes as :func:`extract_research_synthesis`, for the same reason:
     a positioning claim is exactly as fabricable as a research finding, and an
     operator reviewing it needs the same guarantee."""
-    data = _tool_call_arguments(messages, POSITIONING_TOOL_NAME)
-    if data is None:
-        raise MalformedOutputError(
-            f"the positioning run produced no {POSITIONING_TOOL_NAME} tool call"
-        )
-    try:
-        positioning = Positioning.model_validate(data)
-    except ValidationError as exc:
-        raise MalformedOutputError(str(exc)) from exc
-
-    total = _total_citations(
-        *(s.sources for s in positioning.segments),
-        *(p.sources for p in positioning.pillars),
-        *(c.sources for c in positioning.ctas),
-    )
-    if total == 0:
-        raise NoCitationsError(
+    return _extract_cited_artefact(
+        messages,
+        tool_name=POSITIONING_TOOL_NAME,
+        model_cls=Positioning,
+        citation_groups=lambda r: [
+            *(s.sources for s in r.segments),
+            *(p.sources for p in r.pillars),
+            *(c.sources for c in r.ctas),
+        ],
+        malformed_message=f"the positioning run produced no {POSITIONING_TOOL_NAME} tool call",
+        no_citations_message=(
             "The positioning run cited nothing from the approved research. Nothing "
             "was produced — try running positioning again."
-        )
-    return positioning
+        ),
+    )
 
 
 def extract_channel_plan(messages: list[dict[str, Any]]) -> ChannelPlan:
@@ -202,23 +226,17 @@ def extract_channel_plan(messages: list[dict[str, Any]]) -> ChannelPlan:
     positioning claim, and arguably the most confident-sounding one in the
     whole pipeline, because channel advice reads as generic wisdom whether or
     not anyone researched it."""
-    data = _tool_call_arguments(messages, CHANNEL_PLAN_TOOL_NAME)
-    if data is None:
-        raise MalformedOutputError(
-            f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call"
-        )
-    try:
-        plan = ChannelPlan.model_validate(data)
-    except ValidationError as exc:
-        raise MalformedOutputError(str(exc)) from exc
-
-    total = _total_citations(*(c.sources for c in plan.channels))
-    if total == 0:
-        raise NoCitationsError(
+    return _extract_cited_artefact(
+        messages,
+        tool_name=CHANNEL_PLAN_TOOL_NAME,
+        model_cls=ChannelPlan,
+        citation_groups=lambda r: [c.sources for c in r.channels],
+        malformed_message=f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call",
+        no_citations_message=(
             "The channel-plan run cited nothing from the approved positioning. Nothing "
             "was produced — try running channel planning again."
-        )
-    return plan
+        ),
+    )
 
 
 def flatten_citations(
@@ -241,8 +259,15 @@ def flatten_citations(
             *(p.sources for p in output.pillars),
             *(c.sources for c in output.ctas),
         ]
-    else:
+    elif isinstance(output, ChannelPlan):
         groups = [c.sources for c in output.channels]
+    else:
+        # Exhaustive over this function's own type hint — a new artefact type
+        # reaching here without a branch of its own must fail loudly rather
+        # than silently reusing another stage's `.channels`/`.segments`
+        # shape (issue found in review: the pre-M4 version of this function
+        # had exactly one `else`, quietly assumed to mean "positioning").
+        raise TypeError(f"flatten_citations: unsupported artefact output type {type(output)!r}")
     seen: set[str] = set()
     flat: list[dict[str, Any]] = []
     for sources in groups:

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -29,6 +29,7 @@ from marketing.pipeline import (
     extract_positioning,
     extract_research_findings,
     extract_research_synthesis,
+    flatten_citations,
 )
 
 
@@ -247,3 +248,46 @@ def test_extract_research_findings_returns_the_set_when_valid() -> None:
     assert result is not None
     assert result.angle == "audience"
     assert result.findings[0].sources[0].url == "https://example.com/z"
+
+
+# ── flatten_citations — dispatches on the result TYPE, not a `kind` string ───
+
+
+def test_flatten_citations_of_a_channel_plan_dedupes_by_url() -> None:
+    plan = extract_channel_plan(
+        _tool_call(
+            "submit_channel_plan",
+            {
+                "channels": [
+                    {
+                        "channel": "Instagram Reels",
+                        "motion": "organic",
+                        "rank": 1,
+                        "rationale": "r",
+                        "sources": [{"url": "https://example.com/dup", "note": "a"}],
+                    },
+                    {
+                        "channel": "Google Search ads",
+                        "motion": "paid",
+                        "rank": 1,
+                        "rationale": "r",
+                        "sources": [{"url": "https://example.com/dup", "note": "b"}],
+                    },
+                ]
+            },
+        )
+    )
+
+    citations = flatten_citations(plan)
+
+    assert citations == [{"url": "https://example.com/dup", "note": "a"}]
+
+
+def test_flatten_citations_raises_on_an_unsupported_output_type() -> None:
+    """A defensive check, not a reachable path today: every real caller only
+    ever passes what `extract_research_synthesis`/`extract_positioning`/
+    `extract_channel_plan` return. Exercised directly so a fourth artefact
+    type added here without its own branch fails loudly instead of quietly
+    reusing `ChannelPlan`'s `.channels` shape."""
+    with pytest.raises(TypeError):
+        flatten_citations(object())  # type: ignore[arg-type]

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -1,16 +1,19 @@
-"""The citation-enforcement guard (M3) — the milestone, not a detail.
+"""The citation-enforcement guard (M3, extended to channel planning in M4) —
+the milestone, not a detail.
 
 Biffo's agent `web_search` is silently unavailable on dev (an empty Brave
 key), and an agent given a tool it cannot use does not error — it fabricates.
 Audience research is precisely where that is invisible: plausible, confident,
-well-structured, and entirely invented.
+well-structured, and entirely invented. Channel planning (issue #3) is
+arguably worse: "run paid social" reads as correct whether or not anyone
+researched it, because it is indistinguishable from generic marketing advice.
 
-These tests are the fail-first proof for the guard: `extract_research_synthesis`
-and `extract_positioning` must refuse to hand back an artefact whose entire
-output cites nothing, rather than let it through as a "thin but valid" result.
-Written before `marketing.pipeline` existed, so the first commit in this
-milestone's history fails on `ModuleNotFoundError` — the second commit is the
-implementation that makes it pass.
+These tests are the fail-first proof for the guard: `extract_research_synthesis`,
+`extract_positioning` and `extract_channel_plan` must refuse to hand back an
+artefact whose entire output cites nothing, rather than let it through as a
+"thin but valid" result. Written before `marketing.pipeline` existed, so the
+first commit in this milestone's history fails on `ModuleNotFoundError` — the
+second commit is the implementation that makes it pass.
 """
 
 from __future__ import annotations
@@ -22,6 +25,7 @@ import pytest
 from marketing.pipeline import (
     MalformedOutputError,
     NoCitationsError,
+    extract_channel_plan,
     extract_positioning,
     extract_research_findings,
     extract_research_synthesis,
@@ -64,6 +68,15 @@ def test_positioning_with_no_segments_pillars_or_ctas_raises_no_citations() -> N
 
     with pytest.raises(NoCitationsError):
         extract_positioning(messages)
+
+
+def test_channel_plan_with_no_channels_raises_no_citations() -> None:
+    """Same guard, the channel-plan half (M4, issue #3): an empty channel list
+    cites nothing and must not be proposed to an operator as evidenced."""
+    messages = _tool_call("submit_channel_plan", {"channels": []})
+
+    with pytest.raises(NoCitationsError):
+        extract_channel_plan(messages)
 
 
 # ── The guard does not fire on genuine content ───────────────────────────────
@@ -113,6 +126,36 @@ def test_positioning_with_a_grounded_segment_succeeds() -> None:
     assert positioning.segments[0].name == "Multi-location operators"
 
 
+def test_channel_plan_with_organic_and_paid_channels_succeeds() -> None:
+    """Both motions are representable in one call, and citations are checked
+    in aggregate across the whole list, not per-motion."""
+    messages = _tool_call(
+        "submit_channel_plan",
+        {
+            "channels": [
+                {
+                    "channel": "Instagram Reels",
+                    "motion": "organic",
+                    "rank": 1,
+                    "rationale": "Multi-location operators already discuss this there.",
+                    "sources": [{"url": "https://example.com/thread", "note": "A forum thread."}],
+                },
+                {
+                    "channel": "Google Search ads",
+                    "motion": "paid",
+                    "rank": 1,
+                    "rationale": "Captures the specific search intent the research surfaced.",
+                    "sources": [{"url": "https://example.com/thread", "note": "A forum thread."}],
+                },
+            ]
+        },
+    )
+
+    plan = extract_channel_plan(messages)
+
+    assert {c.motion for c in plan.channels} == {"organic", "paid"}
+
+
 # ── Missing or malformed tool calls are a different failure ─────────────────
 
 
@@ -129,6 +172,11 @@ def test_positioning_with_no_tool_call_raises_malformed() -> None:
         extract_positioning([{"role": "assistant", "content": "Here is my positioning..."}])
 
 
+def test_channel_plan_with_no_tool_call_raises_malformed() -> None:
+    with pytest.raises(MalformedOutputError):
+        extract_channel_plan([{"role": "assistant", "content": "Here is my channel plan..."}])
+
+
 def test_research_finding_cannot_be_built_with_empty_sources() -> None:
     """The structural half of the guard, exercised directly: unlike idea-scout's
     `Finding.sources` (which defaults to `[]`), a `ResearchFinding` with no
@@ -139,6 +187,18 @@ def test_research_finding_cannot_be_built_with_empty_sources() -> None:
 
     with pytest.raises(ValidationError):
         ResearchFinding(signal="x", why_it_matters="y", sources=[])
+
+
+def test_channel_recommendation_cannot_be_built_with_empty_sources() -> None:
+    """Same structural half of the guard, for `ChannelRecommendation` (M4)."""
+    from pydantic import ValidationError
+
+    from marketing.definitions import ChannelRecommendation
+
+    with pytest.raises(ValidationError):
+        ChannelRecommendation(
+            channel="Instagram Reels", motion="organic", rank=1, rationale="x", sources=[]
+        )
 
 
 # ── extract_research_findings — per-angle, degrades rather than fails ────────

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -15,6 +15,7 @@ import pytest
 
 from marketing import pipeline
 from marketing.definitions import (
+    CHANNEL_PLAN_AGENT_NAME,
     POSITIONING_AGENT_NAME,
     RESEARCH_AGENT_NAMES,
     RESEARCH_SYNTHESIS_AGENT_NAME,
@@ -277,6 +278,83 @@ async def test_advance_positioning_raises_when_the_run_failed() -> None:
 
     with pytest.raises(pipeline.RunNotSucceededError):
         await pipeline.advance_positioning(gateway, run_id=run_id)
+
+
+# ── start_channel_plan / advance_channel_plan (M4) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body() -> None:
+    gateway = _FakeGateway()
+    positioning_body = {"segments": [], "pillars": [], "ctas": []}
+
+    causation_id, run_id = await pipeline.start_channel_plan(
+        gateway, positioning_body=positioning_body
+    )
+
+    assert len(gateway.requested) == 1
+    requested = gateway.requested[0]
+    assert requested.agent_name == CHANNEL_PLAN_AGENT_NAME
+    assert requested.causation_id == causation_id
+    assert requested.input_payload == {"positioning": positioning_body}
+    assert run_id  # a real id was returned
+
+
+@pytest.mark.asyncio
+async def test_advance_channel_plan_returns_none_while_running() -> None:
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_channel_plan(gateway, positioning_body={})
+
+    result = await pipeline.advance_channel_plan(gateway, run_id=run_id)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_advance_channel_plan_returns_the_plan_once_succeeded() -> None:
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_channel_plan(gateway, positioning_body={})
+    gateway.complete(
+        run_id,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "submit_channel_plan",
+                            "arguments": {
+                                "channels": [
+                                    {
+                                        "channel": "Instagram Reels",
+                                        "motion": "organic",
+                                        "rank": 1,
+                                        "rationale": "r",
+                                        "sources": [{"url": "https://example.com/y", "note": "n"}],
+                                    }
+                                ]
+                            },
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = await pipeline.advance_channel_plan(gateway, run_id=run_id)
+
+    assert isinstance(result, pipeline.ChannelPlan)
+    assert result.channels[0].channel == "Instagram Reels"
+
+
+@pytest.mark.asyncio
+async def test_advance_channel_plan_raises_when_the_run_failed() -> None:
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_channel_plan(gateway, positioning_body={})
+    gateway.complete(run_id, status="failed")
+
+    with pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_channel_plan(gateway, run_id=run_id)
 
 
 # ── require_approved ──────────────────────────────────────────────────────────

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -192,6 +192,50 @@ def _positioning_call(url: str = "https://example.com/thread") -> list[dict[str,
     ]
 
 
+def _channel_plan_call(url: str = "https://example.com/thread") -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "submit_channel_plan",
+                        "arguments": {
+                            "channels": [
+                                {
+                                    "channel": "Instagram Reels",
+                                    "motion": "organic",
+                                    "rank": 1,
+                                    "rationale": "r",
+                                    "sources": [{"url": url, "note": "n"}],
+                                },
+                                {
+                                    "channel": "Google Search ads",
+                                    "motion": "paid",
+                                    "rank": 1,
+                                    "rationale": "r",
+                                    "sources": [{"url": url, "note": "n"}],
+                                },
+                            ]
+                        },
+                    }
+                }
+            ],
+        }
+    ]
+
+
+def _empty_channel_plan_call() -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "submit_channel_plan", "arguments": {"channels": []}}}
+            ],
+        }
+    ]
+
+
 # ── start research ────────────────────────────────────────────────────────────
 
 
@@ -237,7 +281,7 @@ def test_start_research_404s_an_unknown_campaign(ctx) -> None:
 
 def test_get_artefact_404s_an_unknown_kind(ctx) -> None:
     client, _core, _gateway = ctx
-    assert client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan").status_code == 404
+    assert client.get(f"/campaigns/{_CAMPAIGN}/artefacts/not_a_real_kind").status_code == 404
 
 
 def test_get_artefact_404s_when_none_exists_yet(ctx) -> None:
@@ -396,3 +440,112 @@ def test_get_positioning_artefact_proposes_once_it_succeeds(ctx) -> None:
     assert body["status"] == "proposed"
     stored_body = json.loads(body["body"])
     assert stored_body["segments"][0]["name"] == "Segment"
+
+
+# ── channel plan (M4, issue #3) ───────────────────────────────────────────────
+
+
+def _propose_and_approve_positioning(client, core, gateway) -> dict[str, Any]:
+    """Research approved, positioning proposed AND approved — the state
+    `start_channel_plan_route` requires."""
+    _propose_research(client, core, gateway)
+    client.post(f"/campaigns/{_CAMPAIGN}/artefacts/research/approve")
+    started = client.post(f"/campaigns/{_CAMPAIGN}/positioning").json()
+    gateway.complete(started["agent_run_id"], messages=_positioning_call())
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/positioning")  # advances pending -> proposed
+    return client.post(f"/campaigns/{_CAMPAIGN}/artefacts/positioning/approve").json()
+
+
+def test_start_channel_plan_refuses_when_positioning_is_not_approved(ctx) -> None:
+    """The gate enforcement itself, mirroring `test_start_positioning_refuses_
+    when_research_is_not_approved`: `proposed` positioning must not be usable
+    by the channel-plan stage, or the positioning approval gate is
+    decorative."""
+    client, core, gateway = ctx
+    _propose_research(client, core, gateway)
+    client.post(f"/campaigns/{_CAMPAIGN}/artefacts/research/approve")
+    started = client.post(f"/campaigns/{_CAMPAIGN}/positioning").json()
+    gateway.complete(started["agent_run_id"], messages=_positioning_call())
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/positioning")  # proposed, not approved
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    assert resp.status_code == 409
+    assert gateway.requested == [
+        r for r in gateway.requested if r["agent_name"] != "marketing-channel-plan"
+    ]
+
+
+def test_start_channel_plan_refuses_when_no_positioning_exists(ctx) -> None:
+    client, _core, _gateway = ctx
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+    assert resp.status_code == 404
+
+
+def test_start_channel_plan_runs_once_positioning_is_approved(ctx) -> None:
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["kind"] == "channel_plan"
+    assert body["status"] == "pending"
+    channel_plan_requests = [
+        r for r in gateway.requested if r["agent_name"] == "marketing-channel-plan"
+    ]
+    assert len(channel_plan_requests) == 1
+    assert channel_plan_requests[0]["input_payload"]["positioning"]["segments"][0]["name"] == (
+        "Segment"
+    )
+
+
+def test_get_channel_plan_artefact_proposes_organic_and_paid_once_it_succeeds(ctx) -> None:
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    run_id = started["agent_run_id"]
+    gateway.complete(run_id, messages=_channel_plan_call())
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "proposed"
+    stored_body = json.loads(body["body"])
+    motions = {c["motion"] for c in stored_body["channels"]}
+    assert motions == {"organic", "paid"}
+
+
+def test_get_channel_plan_artefact_502s_a_zero_citation_run_and_leaves_it_pending(ctx) -> None:
+    """The milestone's guard at the HTTP boundary, the channel-plan half: a
+    run that cited nothing must not be proposed as if it were evidenced."""
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    run_id = started["agent_run_id"]
+    gateway.complete(run_id, messages=_empty_channel_plan_call())
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 502
+    assert core.artefacts[started["id"]]["status"] == "pending", "must not have been proposed"
+
+
+def test_channel_plan_artefact_can_be_approved(ctx) -> None:
+    """The same generic approve route already covers `channel_plan` once it
+    is a known kind — nothing channel-plan-specific in `approve_artefact_route`
+    itself, so this is the confirmation that wiring holds end to end."""
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    gateway.complete(started["agent_run_id"], messages=_channel_plan_call())
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")  # proposes it
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan/approve")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"


### PR DESCRIPTION
## What

M4 — the channel plan agent: a single agent over **approved** positioning
producing ranked channels, organic and paid, each with a rationale.

Reuses M3's machinery wholesale rather than reinventing it:
- `pipeline.start_channel_plan` / `advance_channel_plan` mirror
  `start_positioning` / `advance_positioning` exactly — a single, un-fanned-out
  run over the same `AgentGateway` seam.
- `extract_channel_plan` enforces the same zero-citation guard
  (`NoCitationsError`) as research/positioning: a run whose entire output
  cites nothing fails outright rather than proposing an artefact with no
  evidence behind it. Issue #3 is explicit about why this matters here
  specifically — a channel recommendation with no evidence is the most
  confident-sounding fabrication in the pipeline, because channel advice
  reads as generic wisdom whether or not anyone researched it.
- The `proposed` → `approved` gate is the same generic
  `get_artefact_route` / `approve_artefact_route` / `reject_artefact_route`
  dispatch `admin_app.py` already had — `channel_plan` is just added to
  `_PIPELINE_ARTEFACT_KINDS`.
- `start_channel_plan_route` requires the **approved** positioning artefact
  (`pipeline.require_approved`), mirroring `start_positioning_route`'s own
  gate over research.
- `ChannelPlan.channels: list[ChannelRecommendation]`, with
  `ChannelRecommendation.motion: Literal["organic", "paid"]` — both motions
  representable in one schema, ranked within their own motion.

## Why `channel_plan_routes.py` is a new module

`start_channel_plan_route` is the one genuinely new route this milestone
needs. It lives in its own module rather than inline in `admin_app.py`
because other agents may be working in that file concurrently — the
`admin_app.py` diff here is deliberately small: extending
`_PIPELINE_ARTEFACT_KINDS`, a `channel_plan` branch in `_advance_artefact`,
and one lazy `include_router` call inside `build_app()` (lazy so it isn't a
real circular import — `channel_plan_routes` reaches back into `admin_app`
for `require_admin`/`get_agent_gateway`/`_core`/`_latest_artefact`). The
`StaticFiles` mount stays last.

## Not touched

`render.py`, `links.py`, `config.py`, `web-admin/`, `biffo.plugin.json` —
`channel_plan` was already `definitions.ARTEFACT_KINDS`'s third member and
`marketing_artefact`'s columns already cover it; no manifest change needed.

## Review

An independent `/code-review` pass over this diff found five real issues
(two duplicated-logic risks, one misleading comment, one weak `else`, one
dispatch that didn't scale to a fourth stage) — all fixed in the second
commit. It also found a sixth: the citation guard checks citation *count*,
not that a cited URL actually came from the artefact's own approved input.
That gap is pre-existing in `extract_positioning` since M3 and out of this
milestone's scope, so it's filed as #22 rather than fixed here.

One tradeoff kept deliberately: `channel_plan_routes.py` reaches into
`admin_app`'s underscore-prefixed helpers (`_core`, `_validated_campaign_id`,
`_latest_artefact`) rather than promoting them to public names. Promoting
them would touch every existing call site inside `admin_app.py` — exactly the
concurrent-edit surface this milestone's brief asked to avoid in that file.

## What I could not verify

This is unverified against a live deployment — no running Core/agent-runtime
session was available. Everything here is proven against fakes (the same
fake-`AgentGateway`/fake-Core convention `test_marketing_pipeline_routes.py`
already uses for M3), `uv run pytest` (189 passed), `ruff`, and `pyright`.
I did not exercise a real agent run against Core's internal API, so I can't
confirm the model actually returns citations shaped the way `ChannelPlan`
expects, or that `agent_fan_in`/the SigV4 path behaves the same one stage
further down the chain as it does for positioning.

Refs #3
