### PR TITLE
fix(marketing): migrate to biffo-plugin-sdk 1.2.0 dual-auth for Core internal CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,52 +100,45 @@ repository with its own independent `uv sync` / `uv.lock`, not inside
 biffo-template's workspace. Once copied out, `uv sync && uv run pytest`
 works standalone with no dependency on the rest of biffo-template.
 
-## The `biffo-plugin-sdk` dependency: PyPI pin, pending the first release
+## The `biffo-plugin-sdk` dependency: PyPI pin
 
 `pyproject.toml` declares:
 
 ```toml
 dependencies = [
-  "biffo-plugin-sdk>=1.0,<2.0",
+  "biffo-plugin-sdk[sigv4,user-serving]>=1.2,<2.0",
   ...
 ]
 ```
 
-This is a **PyPI-style version pin**, and it is the correct end state: the
-SDK is versioned `1.0.0` and biffo-template's
+This is a **PyPI-style version pin**, resolved with no local override. The
+SDK carries its own independent semver — it is **not** tied to the
+template's core version, so a major bump here means the plugin API broke and
+nothing else — and biffo-template's
 [`.github/workflows/publish-sdk.yml`](https://github.com/keiranholloway/biffo-template/blob/main/.github/workflows/publish-sdk.yml)
-builds and publishes it to PyPI (via Trusted Publishing) on a pushed
-`sdk-v*` tag. `>=1.0,<2.0` matches the `"biffo-plugin-sdk": "^1.0"` that
-`biffo.plugin.json` declares, and the SDK carries its own independent
-semver — it is **not** tied to the template's core version, so a major
-bump here means the plugin API broke and nothing else.
+builds and publishes each release to PyPI (via Trusted Publishing) on a
+pushed `sdk-v*` tag. As of this pin, PyPI carries `1.0.0`, `1.1.0` and
+`1.2.0` — confirmed directly against PyPI's JSON API, not assumed.
 
-**Ordering caveat.** The release _pipeline_ exists; the _release_ does not
-yet. `biffo-plugin-sdk` has never been uploaded — the PyPI project is
-unregistered until the owner configures the Trusted Publisher and pushes
-`sdk-v1.0.0`. Until that happens, `uv sync` in a freshly-copied plugin repo
-still cannot resolve this dependency, and you need one of the two local
-overrides below. Once 1.0.0 is live, **delete the override** — the
-`dependencies` entry above already points at the real thing.
+`>=1.2` (not `>=1.1`, and `biffo.plugin.json`'s own `"biffo-plugin-sdk":
+"^1.0"` is looser still) because `1.2.0` is the first release carrying
+`SignedCoreClient.raw_request(..., extra_signed_headers=...)` — the one SDK
+method that SigV4-signs a request AND carries an extra header (the calling
+admin's own forwarded token) through that signature. This plugin's
+`src/marketing/principal_client.py` depends on it for every call to Core's
+internal, per-plugin CRUD mount; see that module's docstring, and issue #27,
+for why a SigV4-only call is not a substitute (it authenticates the plugin,
+not the user making the request, so `require_principal_crud_permission` has
+no identity to authorise against — a silent authorization bug, not a loud
+one).
 
-Two ways to make local development work before that happens:
-
-1. **Path dependency** (if developing inside a biffo-template checkout,
-   e.g. for a plugin you plan to upstream into `services/`): add
-   ```toml
-   [tool.uv.sources]
-   biffo-plugin-sdk = { path = "../../packages/python-sdk", editable = true }
-   ```
-2. **Git dependency** (developing this plugin as a genuinely separate repo
-   against an unpublished SDK):
-   ```toml
-   [tool.uv.sources]
-   biffo-plugin-sdk = { git = "https://github.com/keiranholloway/biffo-template", subdirectory = "packages/python-sdk" }
-   ```
-
-Either override goes in `[tool.uv.sources]` only — the PyPI-style
-`dependencies` entry above stays as-is, so removing the override is the
-only change needed once the SDK actually ships to PyPI.
+**Ordering caveat, historical.** Earlier revisions of this pin
+(`>=1.0,<2.0`) predated the SDK's first PyPI upload, and this section used to
+document two local `[tool.uv.sources]` overrides (a path dependency into a
+biffo-template checkout, or a git dependency against the unpublished SDK) to
+unblock development in the meantime. Neither is needed now that the pin
+resolves directly — if you find one still configured in a fork of this repo,
+delete it.
 
 ## Manifest validation: why CI doesn't hard-gate on `registry-schema.json`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,28 +4,21 @@ version = "0.1.0"
 description = "Campaign studio — research, positioning, channel planning, generation and attribution for platform marketing."
 requires-python = ">=3.13"
 dependencies = [
-  # biffo-plugin-sdk has a real release path as of biffo-template's
-  # .github/workflows/publish-sdk.yml: the package is versioned 1.0.0 and
-  # publishes to PyPI (via Trusted Publishing) when an `sdk-v*` tag is
-  # pushed. This pin is therefore the *correct end state* and is left as-is.
-  #
-  # ORDERING: the pin only resolves once the owner has actually pushed
-  # `sdk-v1.0.0` and PyPI has the release. Until that first publish,
-  # `uv sync` in a freshly-copied plugin repo cannot resolve it — the same
-  # as before this comment was written, so nothing regressed here; what
-  # changed is that the fix is now one tag push away rather than unbuilt.
-  # Deliberately NOT worked around with a git/path source in the committed
-  # file: baking one in would mean every plugin repo forked from this
-  # skeleton silently keeps building against a moving git ref long after
-  # the real release exists. Use a local `[tool.uv.sources]` override until
-  # then — see the README's "biffo-plugin-sdk dependency" section, which
-  # documents both options and says which to delete once 1.0.0 is live.
   # [user-serving] brings FastAPI and the `require_group` gate the admin
   # surface mounts behind; [sigv4] signs this plugin's own outbound calls to
   # Core's internal API so it is granted `system:marketing` rather than the
   # host's role identity (ADR-0021 section 1a). Same pins as idea-scout, the
   # other user-facing plugin.
-  "biffo-plugin-sdk[sigv4,user-serving]>=1.1,<2.0",
+  #
+  # >=1.2 (not >=1.1): 1.2.0 is the first release carrying
+  # `SignedCoreClient.raw_request(..., extra_signed_headers=...)` — the
+  # dual-auth (SigV4 + forwarded user token) mechanism this plugin's
+  # `principal_client` module depends on for every call to Core's internal,
+  # per-plugin CRUD mount (issue #27, keiranholloway/biffo-template#1480).
+  # Confirmed live on PyPI (releases: 1.0.0, 1.1.0, 1.2.0) before this pin
+  # was bumped, so `uv sync` resolves it with no local `[tool.uv.sources]`
+  # override needed.
+  "biffo-plugin-sdk[sigv4,user-serving]>=1.2,<2.0",
   "aws-lambda-powertools[tracer]>=3.4.0",
   # Already present for the SDK; also used by admin_app to call Core directly —
   # one hop, rather than the host calling itself through the public path.

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -239,6 +239,14 @@ async def _core(method: str, path: str, token: str, **kw: Any) -> httpx.Response
     existing call site's `.status_code` / `.raise_for_status()` / `.json()`
     usage — written against a plain `httpx.Response` from before this was
     signed at all — keeps working unchanged.
+
+    `**kw` is narrower than it looks: it forwards to `principal_client.
+    request`, which accepts only `params=`/`json=` (plus `timeout=`, already
+    supplied above). The pre-fix `_core` forwarded `**kw` straight to
+    `httpx.AsyncClient.request`, so `headers=`/`data=`/a per-call `timeout=`
+    were all previously valid; none of that is a call site above needs
+    today, but a future one reaching for it gets a `TypeError`, not a
+    silently-ignored kwarg.
     """
     if not CORE_API_URL:
         raise HTTPException(

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -50,7 +50,7 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
-from . import pipeline
+from . import pipeline, principal_client
 from .config import public_base_url
 from .definitions import ARTEFACT_KINDS, MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
 from .image_routes import router as image_router
@@ -67,6 +67,18 @@ CORE_API_URL = os.environ.get("BIFFO_CORE_API_URL", "")
 #: ~4.3s, so a 5s default expires on the first request after a quiet period —
 #: which reads as a broken feature rather than a slow one.
 _CORE_TIMEOUT = 30.0
+
+#: Every `_core()` call goes to Core's internal, per-plugin CRUD mount —
+#: `plugin_router.py`'s `path_prefix="/internal/plugins"` in biffo-template —
+#: never the public `/api/v1/plugins/marketing/*` one the browser reaches,
+#: which is unaddressable from a Lambda anyway (see `plugin_router.py`'s own
+#: docstring on the #652 collision). Written out here, at each call site
+#: below, rather than appended inside `_core()` itself: `tests/
+#: test_marketing_core_paths_guard.py` statically inspects each call site's
+#: own literal path argument, so the prefix has to be visible there, not
+#: hidden behind a helper's plumbing (`principal_client`'s module docstring
+#: explains the same choice from the other side).
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
 
 router = APIRouter(dependencies=[Depends(require_admin)])
 
@@ -160,7 +172,7 @@ async def mint_links(
 
     campaign_id = _validated_campaign_id(campaign_id)
 
-    campaign = await _core("GET", f"/campaigns/{campaign_id}", admin.token)
+    campaign = await _core("GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", admin.token)
     if campaign.status_code == status.HTTP_404_NOT_FOUND:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
     campaign.raise_for_status()
@@ -179,7 +191,7 @@ async def mint_links(
         token = mint_token()
         created = await _core(
             "POST",
-            "/links",
+            f"{_INTERNAL_PREFIX}/links",
             admin.token,
             json={
                 "campaign_id": campaign_id,
@@ -215,15 +227,27 @@ async def mint_links(
 
 
 async def _core(method: str, path: str, token: str, **kw: Any) -> httpx.Response:
+    """Dual-auth call to Core's internal, per-plugin CRUD mount — SigV4-signed
+    AND carrying the calling admin's own token, forwarded via
+    `X-Biffo-User-Token` (`principal_client`'s module docstring has the full
+    mechanism, and issue #27 the reasoning for why the fix is this and not a
+    bare signed client). `path` must already carry the `_INTERNAL_PREFIX`
+    every call site above supplies — see that constant's own comment for why
+    the prefix lives at the call site rather than being added here.
+
+    This is a thin wrapper over `principal_client.request`, kept so every
+    existing call site's `.status_code` / `.raise_for_status()` / `.json()`
+    usage — written against a plain `httpx.Response` from before this was
+    signed at all — keeps working unchanged.
+    """
     if not CORE_API_URL:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Core API URL is not configured for this deployment.",
         )
-    async with httpx.AsyncClient(timeout=_CORE_TIMEOUT) as client:
-        return await client.request(
-            method, f"{CORE_API_URL}{path}", headers={"Authorization": f"Bearer {token}"}, **kw
-        )
+    return await principal_client.request(
+        method, path, token, base_url=CORE_API_URL, timeout=_CORE_TIMEOUT, **kw
+    )
 
 
 # ── Research + positioning (M3) ──────────────────────────────────────────────
@@ -348,7 +372,7 @@ async def _latest_artefact(campaign_id: str, kind: str, token: str) -> dict[str,
     list). Sorted defensively rather than trusting insertion order — a fake
     Core in a test may not preserve it."""
     params = {"campaign_id": campaign_id, "kind": kind}
-    resp = await _core("GET", "/artefacts", token, params=params)
+    resp = await _core("GET", f"{_INTERNAL_PREFIX}/artefacts", token, params=params)
     resp.raise_for_status()
     rows = resp.json() or []
     if not rows:
@@ -414,7 +438,7 @@ async def _advance_artefact(
 
     updated = await _core(
         "PATCH",
-        f"/artefacts/{artefact['id']}",
+        f"{_INTERNAL_PREFIX}/artefacts/{artefact['id']}",
         token,
         json={
             "status": "proposed",
@@ -439,7 +463,7 @@ async def start_research_route(
     environment this hangs in `pending` forever, silently)."""
     campaign_id = _validated_campaign_id(campaign_id)
 
-    campaign = await _core("GET", f"/campaigns/{campaign_id}", admin.token)
+    campaign = await _core("GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", admin.token)
     if campaign.status_code == status.HTTP_404_NOT_FOUND:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
     campaign.raise_for_status()
@@ -457,7 +481,7 @@ async def start_research_route(
 
     created = await _core(
         "POST",
-        "/artefacts",
+        f"{_INTERNAL_PREFIX}/artefacts",
         admin.token,
         json={
             "campaign_id": campaign_id,
@@ -527,7 +551,10 @@ async def approve_artefact_route(
         )
 
     updated = await _core(
-        "PATCH", f"/artefacts/{artefact['id']}", admin.token, json={"status": "approved"}
+        "PATCH",
+        f"{_INTERNAL_PREFIX}/artefacts/{artefact['id']}",
+        admin.token,
+        json={"status": "approved"},
     )
     updated.raise_for_status()
     return updated.json()
@@ -556,7 +583,10 @@ async def reject_artefact_route(
         )
 
     updated = await _core(
-        "PATCH", f"/artefacts/{artefact['id']}", admin.token, json={"status": "rejected"}
+        "PATCH",
+        f"{_INTERNAL_PREFIX}/artefacts/{artefact['id']}",
+        admin.token,
+        json={"status": "rejected"},
     )
     updated.raise_for_status()
     return updated.json()
@@ -591,7 +621,7 @@ async def start_positioning_route(
 
     created = await _core(
         "POST",
-        "/artefacts",
+        f"{_INTERNAL_PREFIX}/artefacts",
         admin.token,
         json={
             "campaign_id": campaign_id,

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -57,7 +57,13 @@ async def start_channel_plan_route(
 
     created = await admin_app._core(
         "POST",
-        "/artefacts",
+        # Not `admin_app._INTERNAL_PREFIX` — `tests/test_marketing_core_paths_
+        # guard.py` resolves a module-level string constant only within the
+        # SAME file's own AST, so a cross-module reference here would read as
+        # unresolvable and be silently skipped rather than checked. Written
+        # out in full for the same reason `admin_app._validated_campaign_id`
+        # is duplicated rather than imported (see that function's docstring).
+        "/api/v1/internal/plugins/marketing/artefacts",
         admin.token,
         json={
             "campaign_id": campaign_id,

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -24,6 +24,17 @@ from . import admin_app, pipeline
 
 router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 
+#: Not `admin_app._INTERNAL_PREFIX` — `tests/test_marketing_core_paths_guard.py`
+#: resolves a module-level string constant only within the SAME file's own
+#: AST, so a cross-module reference would read as unresolvable and be
+#: silently skipped rather than checked. Written out as its own local
+#: constant for the same reason `admin_app._validated_campaign_id` is
+#: duplicated rather than imported (see that function's docstring) — and
+#: `tests/test_marketing_core_paths_guard.py`'s own disagreement test
+#: asserts this copy stays equal to the other two, since the guard itself
+#: only checks "starts with /api/v1/", never "the three copies agree".
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
+
 
 @router.post("/campaigns/{campaign_id}/channel-plan", status_code=status.HTTP_201_CREATED)
 async def start_channel_plan_route(
@@ -57,13 +68,7 @@ async def start_channel_plan_route(
 
     created = await admin_app._core(
         "POST",
-        # Not `admin_app._INTERNAL_PREFIX` — `tests/test_marketing_core_paths_
-        # guard.py` resolves a module-level string constant only within the
-        # SAME file's own AST, so a cross-module reference here would read as
-        # unresolvable and be silently skipped rather than checked. Written
-        # out in full for the same reason `admin_app._validated_campaign_id`
-        # is duplicated rather than imported (see that function's docstring).
-        "/api/v1/internal/plugins/marketing/artefacts",
+        f"{_INTERNAL_PREFIX}/artefacts",
         admin.token,
         json={
             "campaign_id": campaign_id,

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -49,6 +49,7 @@ from biffo_plugin_sdk.user_serving import require_group
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from . import principal_client
 from .image_provider import GeneratedImage, ImageProvider, ImageProviderError, OpenAIImageProvider
 
 require_admin = require_group("admin")
@@ -57,6 +58,14 @@ router = APIRouter(dependencies=[Depends(require_admin)])
 
 _STORAGE_PATH = "/api/v1/internal/plugins/me/storage"
 _LEDGER_PATH = "/api/v1/internal/media-generations"
+
+#: Where `get_campaign_client()`'s dual-auth client reaches this plugin's own
+#: generated-CRUD tables (`marketing_campaign`, `marketing_asset`) — Core's
+#: internal, per-plugin mount, never the public one. See `admin_app.py`'s
+#: `_INTERNAL_PREFIX` for why this is its own local constant rather than an
+#: import: the guard test below resolves a named constant only within the
+#: file that defines it.
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
 
 #: A plain client's own upload timeout, matching `admin_app._CORE_TIMEOUT`'s
 #: reasoning: generous enough that a cold start or a slow provider does not
@@ -100,12 +109,17 @@ def get_core_client() -> BiffoAPIClient:
     return create_core_client()
 
 
-def get_campaign_client(admin: Any = Depends(require_admin)) -> BiffoAPIClient:
-    """A plain, bearer-token client for this plugin's own generated-CRUD
-    tables — `marketing_campaign` and `marketing_asset` — scoped to the
-    calling admin's own forwarded token, exactly like `admin_app._core`.
+def get_campaign_client(
+    admin: Any = Depends(require_admin),
+) -> principal_client.PrincipalCoreClient:
+    """A dual-auth client for this plugin's own generated-CRUD tables —
+    `marketing_campaign` and `marketing_asset` — SigV4-signed AND carrying
+    the calling admin's own forwarded token, exactly like `admin_app._core`
+    (see `principal_client`'s module docstring for why both are required
+    together, not either alone: this hits the same
+    `require_principal_crud_permission`-guarded internal mount `_core` does).
     """
-    return BiffoAPIClient(token=admin.token)
+    return principal_client.PrincipalCoreClient(admin.token)
 
 
 class GenerateStillRequest(BaseModel):
@@ -197,7 +211,7 @@ async def generate_still_route(
     body: GenerateStillRequest,
     provider: ImageProvider = Depends(get_image_provider),
     core_client: BiffoAPIClient = Depends(get_core_client),
-    campaign_client: BiffoAPIClient = Depends(get_campaign_client),
+    campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
 ) -> GenerateStillResponse:
     """Generate one still, store it, ledger its cost (or its absence), and
     record it as this campaign's approved source creative.
@@ -205,7 +219,7 @@ async def generate_still_route(
     campaign_id = _validated_campaign_id(campaign_id)
 
     try:
-        await campaign_client.get(f"/campaigns/{campaign_id}")
+        await campaign_client.get(f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}")
     except BiffoAPIError as exc:
         raise _core_error(exc, not_found="Campaign not found.") from exc
 
@@ -234,7 +248,7 @@ async def generate_still_route(
 
     try:
         asset = await campaign_client.post(
-            "/assets",
+            f"{_INTERNAL_PREFIX}/assets",
             json={
                 "campaign_id": campaign_id,
                 "media_kind": "image",

--- a/src/marketing/principal_client.py
+++ b/src/marketing/principal_client.py
@@ -1,0 +1,175 @@
+"""Dual-auth transport to Core's internal, per-plugin CRUD mount (issue #27).
+
+Core's internal API (`/api/v1/internal/*`) is IAM-authorized, not Cognito
+(ADR-0009) — reaching it at all requires a SigV4 signature. But the per-plugin
+CRUD routes under `/api/v1/internal/plugins/<name>/*` are gated a second way,
+on top of that: `plugin_router.py`'s `build_plugin_router(guard_factory=
+require_principal_crud_permission)` (read in `biffo-template`) still
+authorises on the *calling admin's own role*, not merely on "this is a
+SigV4-signed request from a trusted plugin". That guard accepts the user's
+token from either transport — a Cognito bearer header on the public mount, or
+`X-Biffo-User-Token` on the SigV4-signed internal one — and checks the same
+thing either way. The two mounts differ only in *who can reach them*, never in
+*what is allowed* once they do (see that module's docstring for the full
+reasoning).
+
+So a call through here needs BOTH credentials, together, not either alone:
+
+- **SigV4**, or API Gateway never lets the request past the front door.
+- **The admin's own forwarded token**, via `X-Biffo-User-Token`, or the
+  request reaches Core with a valid signature and no user identity at all —
+  which does not fail loudly. It reaches `require_principal_crud_permission`
+  signed but tokenless, and that guard has nothing to authorise *against*, so
+  the honest failure mode is a permission error, not a 404. Shipping a
+  SigV4-only client here would look like a fix (the path resolves, Core
+  responds) while actually trading a 404-everywhere bug for a silent
+  authorization one — see this plugin's own `admin_app._core` before this
+  module existed, and issue #27.
+
+`SignedCoreClient.raw_request(method, path, content=..., extra_signed_headers=
+...)` is the one SDK method that signs a request AND carries an extra header
+through that signature (so the header can't be stripped or altered between
+signing and arrival) — released in `biffo-plugin-sdk` 1.2.0
+(keiranholloway/biffo-template#1480; PyPI had only 1.1.0, which lacked it,
+when issue #27 was filed). It is also exactly what the shared plugin host's
+own forwarder uses to relay a plugin's declared `api_routes` to Core
+(`services/_plugin-host/src/plugin_host/app.py::core_sender`, read directly
+rather than guessed at) — this module is the same shape, for this plugin's
+own bespoke (non-generated-CRUD) routes.
+
+Built directly on `SignedCoreClient`, not `create_core_client()`: the latter
+can build either a signing or a plain client depending on
+`BIFFO_CORE_AUTH_MODE`, and its declared return type is the plain base
+(`BiffoAPIClient`), which has no `raw_request` at all. `core_sender()` makes
+the same choice for the same reason.
+
+Every path passed in here is expected to already be the FULL internal path
+(`/api/v1/internal/plugins/<name>/...`), never a bare one — this module does
+no prefixing of its own. That is deliberate: `tests/
+test_marketing_core_paths_guard.py` walks each call site's own literal
+argument text, so the `/api/v1/...` prefix has to be visible AT THE CALL
+SITE, not hidden behind this module's plumbing. See that file's docstring.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+from biffo_plugin_sdk import BiffoAPIError, SignedCoreClient
+
+#: Matches `plugin_host.forward.FORWARDED_USER_HEADER` exactly (biffo-template)
+#: — the header `require_principal_crud_permission` reads a user token from
+#: when the transport is SigV4 rather than a bearer `Authorization` header.
+FORWARDED_USER_HEADER = "X-Biffo-User-Token"
+
+
+async def _raw(
+    method: str,
+    path: str,
+    token: str,
+    *,
+    base_url: str | None,
+    params: dict[str, Any] | None,
+    json: dict[str, Any] | None,
+    timeout: float | None,
+) -> tuple[int, bytes, str]:
+    """The one signed, dual-credential send every helper below builds on."""
+    full_path = f"{path}?{urlencode(params)}" if params else path
+    content = _json.dumps(json).encode() if json is not None else None
+    kwargs: dict[str, Any] = {"base_url": base_url}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    client = SignedCoreClient(**kwargs)
+    return await client.raw_request(
+        method,
+        full_path,
+        content=content,
+        extra_signed_headers={FORWARDED_USER_HEADER: token},
+    )
+
+
+async def request(
+    method: str,
+    path: str,
+    token: str,
+    *,
+    base_url: str | None = None,
+    params: dict[str, Any] | None = None,
+    json: dict[str, Any] | None = None,
+    timeout: float | None = None,
+) -> httpx.Response:
+    """The dual-auth call, wrapped back into a real `httpx.Response`.
+
+    For callers written against that interface (`admin_app._core`, whose
+    every existing call site already reads `.status_code` /
+    `.raise_for_status()` / `.json()`) — this lets that interface keep
+    working unchanged rather than every call site being rewritten around the
+    SDK's raw `(status, body, content_type)` tuple.
+    """
+    status_code, body, content_type = await _raw(
+        method, path, token, base_url=base_url, params=params, json=json, timeout=timeout
+    )
+    # A real (if synthetic) Request, purely so `.raise_for_status()` has one to
+    # reference — httpx requires it and never inspects it for anything else here.
+    dummy_request = httpx.Request(method, f"https://core.internal{path}")
+    return httpx.Response(
+        status_code, content=body, headers={"content-type": content_type}, request=dummy_request
+    )
+
+
+class PrincipalCoreClient:
+    """The same dual-auth call, shaped like `BiffoAPIClient` instead —
+    `.get`/`.post`/`.patch` returning parsed JSON and raising `BiffoAPIError`
+    on a non-2xx, for callers already written against that interface
+    (`image_routes.get_campaign_client`, whose call sites already do
+    `except BiffoAPIError`).
+    """
+
+    def __init__(
+        self, token: str, *, base_url: str | None = None, timeout: float | None = None
+    ) -> None:
+        self._token = token
+        self._base_url = base_url
+        self._timeout = timeout
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        return await self._call("GET", path, params=params)
+
+    async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        return await self._call("POST", path, json=json)
+
+    async def patch(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        return await self._call("PATCH", path, json=json)
+
+    async def _call(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        status_code, body, _content_type = await _raw(
+            method,
+            path,
+            self._token,
+            base_url=self._base_url,
+            params=params,
+            json=json,
+            timeout=self._timeout,
+        )
+        parsed: Any = None
+        if body:
+            try:
+                parsed = _json.loads(body)
+            except ValueError:
+                parsed = body.decode(errors="replace")
+        if 200 <= status_code < 300:
+            return parsed
+        detail = parsed.get("detail") if isinstance(parsed, dict) else None
+        if not detail:
+            detail = parsed if isinstance(parsed, str) and parsed else f"HTTP {status_code}"
+        raise BiffoAPIError(status_code, str(detail), parsed)

--- a/src/marketing/principal_client.py
+++ b/src/marketing/principal_client.py
@@ -58,7 +58,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from biffo_plugin_sdk import BiffoAPIError, SignedCoreClient
+from biffo_plugin_sdk import BiffoAPIClient, SignedCoreClient
 
 #: Matches `plugin_host.forward.FORWARDED_USER_HEADER` exactly (biffo-template)
 #: — the header `require_principal_crud_permission` reads a user token from
@@ -76,19 +76,47 @@ async def _raw(
     json: dict[str, Any] | None,
     timeout: float | None,
 ) -> tuple[int, bytes, str]:
-    """The one signed, dual-credential send every helper below builds on."""
-    full_path = f"{path}?{urlencode(params)}" if params else path
+    """The one signed, dual-credential send every helper below builds on.
+
+    Builds and closes its own `SignedCoreClient` per call, deliberately
+    matching the lifecycle discipline of the `httpx.AsyncClient` this
+    replaced in `admin_app._core` (`async with httpx.AsyncClient(...) as
+    client:`) — a `SignedCoreClient` owns exactly such a client
+    (`BiffoAPIClient.__init__` builds one whenever `client=` isn't passed),
+    so skipping the `async with` here would leak one connection pool per
+    call rather than one per request, which is what a caller reading the
+    code this replaced would reasonably expect not to happen.
+    """
+    # `None`-valued entries are dropped, not stringified: `urlencode` alone
+    # would render `{"a": None}` as the literal query text `a=None`, sending
+    # Core a filter that matches the string "None" instead of omitting the
+    # filter — no current caller passes one (verified), but a future
+    # optional filter reaching here should omit cleanly, not silently break.
+    if params:
+        clean_params = {k: v for k, v in params.items() if v is not None}
+        full_path = f"{path}?{urlencode(clean_params)}" if clean_params else path
+    else:
+        full_path = path
     content = _json.dumps(json).encode() if json is not None else None
     kwargs: dict[str, Any] = {"base_url": base_url}
     if timeout is not None:
         kwargs["timeout"] = timeout
+    # Not `async with SignedCoreClient(**kwargs) as client:` — the SDK's
+    # `BiffoAPIClient.__aenter__` is declared `-> BiffoAPIClient`, not
+    # `Self`, so pyright resolves `client`'s type through the base class and
+    # loses `raw_request` (only defined on `SignedCoreClient`). A plain
+    # try/finally closes the same connection pool `__aexit__` would, without
+    # depending on a return-type annotation this module doesn't own.
     client = SignedCoreClient(**kwargs)
-    return await client.raw_request(
-        method,
-        full_path,
-        content=content,
-        extra_signed_headers={FORWARDED_USER_HEADER: token},
-    )
+    try:
+        return await client.raw_request(
+            method,
+            full_path,
+            content=content,
+            extra_signed_headers={FORWARDED_USER_HEADER: token},
+        )
+    finally:
+        await client.aclose()
 
 
 async def request(
@@ -152,7 +180,14 @@ class PrincipalCoreClient:
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | None = None,
     ) -> Any:
-        status_code, body, _content_type = await _raw(
+        # Routed through `request()` (this module's own httpx.Response-shaped
+        # wrapper) rather than `_raw` directly, specifically so the
+        # non-2xx-to-BiffoAPIError mapping below can reuse `BiffoAPIClient`'s
+        # OWN static helpers instead of a second, independent copy of them —
+        # an earlier version of this method hand-rolled that mapping and had
+        # already drifted from the SDK's own fallback-detail text on first
+        # write (`f"HTTP {status}"` vs. the SDK's `response.reason_phrase`).
+        response = await request(
             method,
             path,
             self._token,
@@ -161,15 +196,5 @@ class PrincipalCoreClient:
             json=json,
             timeout=self._timeout,
         )
-        parsed: Any = None
-        if body:
-            try:
-                parsed = _json.loads(body)
-            except ValueError:
-                parsed = body.decode(errors="replace")
-        if 200 <= status_code < 300:
-            return parsed
-        detail = parsed.get("detail") if isinstance(parsed, dict) else None
-        if not detail:
-            detail = parsed if isinstance(parsed, str) and parsed else f"HTTP {status_code}"
-        raise BiffoAPIError(status_code, str(detail), parsed)
+        BiffoAPIClient._raise_if_error(response)
+        return BiffoAPIClient._parse_json(response)

--- a/tests/test_marketing_core_paths_guard.py
+++ b/tests/test_marketing_core_paths_guard.py
@@ -214,3 +214,28 @@ def test_already_fixed_paths_stay_fixed(filename: str, prefix: str) -> None:
     the AST walk's output alone."""
     source = (_SRC / filename).read_text()
     assert prefix in source, f"{filename} no longer contains the fixed path {prefix!r}"
+
+
+def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
+    """Guard vs. authority: `_find_violations` above only checks that a path
+    starts with `/api/v1/` — it never checks that the three independent
+    `_INTERNAL_PREFIX` copies this file's own docstring explains
+    (`admin_app.py`, `channel_plan_routes.py`, `image_routes.py`, each
+    forced local because the AST walk resolves a named constant only within
+    the file that defines it) actually agree with each other or with the
+    real mounted path. Verified empirically before this test was written: a
+    single-character typo in one copy (`marketting` for `marketing`) sends
+    every call in that file to an unmounted path while the rest of this
+    suite — including `test_every_core_call_path_is_api_v1_except_the_known_
+    pending_ones` above — stays green, because `/api/v1/internal/plugins/
+    marketting/...` still starts with `/api/v1/`. This is a two-line
+    disagreement check, not a redesign: the guard reads the SHAPE of each
+    path; this reads whether the three sources of that shape's prefix still
+    say the same thing.
+    """
+    from marketing import admin_app, channel_plan_routes, image_routes
+
+    canonical = "/api/v1/internal/plugins/marketing"
+    assert admin_app._INTERNAL_PREFIX == canonical
+    assert channel_plan_routes._INTERNAL_PREFIX == canonical
+    assert image_routes._INTERNAL_PREFIX == canonical

--- a/tests/test_marketing_core_paths_guard.py
+++ b/tests/test_marketing_core_paths_guard.py
@@ -1,14 +1,23 @@
 """Every path this plugin sends to Core must start with ``/api/v1/`` (#17's
-class — see the module docstring below for why a narrower check would miss
-most of it).
+class — see below for why a narrower check would miss most of it).
 
-Two real, deployment-breaking bugs have now shipped this shape: `image_routes`
+Three real, deployment-breaking bugs have now shipped this shape: `image_routes`
 gained `/internal/plugins/me/storage` and `/internal/media-generations`
-(missing `/api/v1`) in M6, and `admin_app._core` was built with no `/api/v1`
-prefix and no signing at all from M2 onward (#17). A check over *named
-constants* would have caught the first — it would NOT have caught the second,
-because most of that bug lives in inline string/f-string literals at call
-sites (`campaign_client.get(f"/campaigns/{campaign_id}")`,
+(missing `/api/v1`) in M6, `admin_app._core` was built with no `/api/v1`
+prefix and no signing at all from M2 onward (#17), and — once #17 was
+understood — twelve more call sites turned out to need the *same* prefix
+plus a second, harder-to-see credential: Core's internal, per-plugin CRUD
+mount authorises on the calling admin's own role even over a SigV4-signed
+request, so a signed-but-tokenless call reaches Core and fails silently as a
+permission error rather than loudly as a 404 (#27; see
+`src/marketing/principal_client.py`'s module docstring for the full
+mechanism, and `admin_app._core`'s for how every one of those twelve now
+gets both credentials).
+
+A check over *named constants* would have caught the first bug — it would
+NOT have caught the second or third, because most of that shape lives in
+inline string/f-string literals at call sites
+(`campaign_client.get(f"/campaigns/{campaign_id}")`,
 `admin_app._core("POST", "/artefacts", ...)`), which a constants-only sweep
 never looks at. So this walks the AST of every module in `src/marketing/` and
 inspects the literal (or statically-resolvable) path argument of every call
@@ -24,38 +33,36 @@ under `/api/v1/plugins/marketing/admin/...` by the host — not a call this
 plugin makes outward to Core. Conflating the two would fail every route
 handler in the file for the wrong reason.
 
-## The known-pending baseline, and why it exists rather than a plain assert
+Only the file that makes a call is asked to prove its path is fixed — a
+module-level constant is resolved from `ast.Assign` nodes in the SAME file's
+own tree (`_module_string_constants`), never across an import. `admin_app.py`,
+`channel_plan_routes.py` and `image_routes.py` each therefore carry their own
+literal `/api/v1/internal/plugins/marketing` text (as a local `_INTERNAL_PREFIX`
+constant in the first two, inline in the third's one call site) rather than
+importing one shared constant — the same reasoning `admin_app.py`'s module
+docstring gives for duplicating `_validated_campaign_id` rather than
+importing it: what the guard can see has to live at the call site.
 
-Twelve of the call sites this walk finds are real, currently-broken instances
-of the class — every one blocked on the same thing: Core's internal,
-per-plugin CRUD mount (`/api/v1/internal/plugins/marketing/...`) requires
-BOTH a SigV4 signature AND the calling admin's own token, forwarded via
-`X-Biffo-User-Token` (see `admin_app.py`'s and `image_routes.py`'s module
-docstrings, and issue #27, for the full mechanism). The SDK method that does
-both together (`SignedCoreClient.raw_request(..., extra_signed_headers=...)`)
-exists in `biffo-plugin-sdk`'s source but has never been released — PyPI's
-newest version is 1.1.0, which lacks it entirely (keiranholloway/
-biffo-template#1480). Fixing these call sites without that capability means
-either shipping bearer-only calls that will 403 in a real deployment (exactly
-today's bug) or hand-rolling SigV4 signing in this plugin — duplicating SDK
-internals that already exist correctly one repo over.
+## `_PENDING_SDK_RELEASE`: empty, and meant to stay that way
 
-So rather than silently exempting these paths from the guard (which would be
-routing around the defect, not fixing it) or failing the suite on a bug
-nobody can fix from this repo right now, `_PENDING_SDK_RELEASE` names them
-explicitly, keyed by (file, resolved path, how many times it appears). The
-test asserts the ACTUAL violations found equal this baseline exactly, in
-both directions:
+This baseline held the twelve #27 call sites while `biffo-plugin-sdk` 1.2.0 —
+the release carrying `SignedCoreClient.raw_request(...,
+extra_signed_headers=...)`, the one SDK method that signs a request AND
+carries the forwarded user token through that signature — existed in source
+but had never reached PyPI (keiranholloway/biffo-template#1480). Landing
+that release (confirmed live: PyPI lists 1.0.0, 1.1.0, 1.2.0) and rewriting
+every call site to use it (`principal_client.py`) is what emptied it.
 
-- A path outside this baseline that still fails the `/api/v1/` check is a
-  NEW instance of the class — the test fails, same as it would with no
-  baseline at all.
-- A path in this baseline that no longer fails (because #27 landed a fix) is
-  now stale — the test fails until the entry is removed, so a fix can't
-  silently widen the exemption for other paths that happen to share its text.
+The test still asserts the ACTUAL violations found equal this baseline
+exactly, in both directions, so an empty baseline is not a weaker check than
+a populated one — it is the same check with nothing exempted:
 
-Remove entries from `_PENDING_SDK_RELEASE` as each one is fixed, never add a
-new one without a comment explaining why it can't be fixed directly.
+- Any path that fails the `/api/v1/` check is now a violation outright — the
+  baseline no longer absorbs the twelve #27 sites.
+- If a future defect needs a temporary exemption again, name it explicitly
+  here with a comment explaining why it can't be fixed directly, and drain it
+  the same way this one was drained — never leave a stale entry once the
+  underlying call is fixed.
 """
 
 from __future__ import annotations
@@ -77,17 +84,11 @@ _CLIENT_METHODS = {"get", "post", "put", "patch", "delete"}
 _EXCLUDED_RECEIVERS = {"router"}
 
 #: (filename, resolved leading path, occurrence count) — see the module
-#: docstring's "known-pending baseline" section. `sorted()` order below is
-#: purely so a diff is easy to read; the comparison itself doesn't care.
-_PENDING_SDK_RELEASE: dict[tuple[str, str], int] = {
-    ("admin_app.py", "/campaigns/"): 2,
-    ("admin_app.py", "/artefacts"): 3,
-    ("admin_app.py", "/artefacts/"): 3,
-    ("admin_app.py", "/links"): 1,
-    ("channel_plan_routes.py", "/artefacts"): 1,
-    ("image_routes.py", "/campaigns/"): 1,
-    ("image_routes.py", "/assets"): 1,
-}
+#: docstring's "`_PENDING_SDK_RELEASE`: empty, and meant to stay that way"
+#: section. Empty is the asserted invariant, not a placeholder — the test
+#: fails just as loudly on a NEW unexempted violation as it did while this
+#: held the twelve #27 sites.
+_PENDING_SDK_RELEASE: dict[tuple[str, str], int] = {}
 
 
 def _module_string_constants(tree: ast.Module) -> dict[str, str]:

--- a/tests/test_marketing_dual_auth_wiring.py
+++ b/tests/test_marketing_dual_auth_wiring.py
@@ -1,0 +1,291 @@
+"""The seam between `admin_app`/`image_routes` and `principal_client` —
+issue #27's actual security property, end to end.
+
+Every other test that touches a Core call mocks `admin_app._core` wholesale
+(`test_marketing_mint_route.py`, `test_marketing_pipeline_routes.py`) or
+dependency-overrides `image_routes.get_campaign_client`
+(`test_marketing_image_routes.py`). That is the right boundary for testing
+each ROUTE's own logic, but it means none of those tests ever runs `_core`'s
+or `get_campaign_client`'s own bodies — the code that threads `method`,
+`path` and the calling admin's `token` through to `principal_client`, in
+that order, with that specific token. Proven empirically before this file
+was written: swapping `_core`'s delegation to
+`principal_client.request(method, token, path, ...)` (path and token
+transposed), and separately replacing `get_campaign_client`'s
+`PrincipalCoreClient(admin.token)` with a hardcoded wrong string, both leave
+the full suite at `226 passed`. The second sabotage is the exact failure
+mode this module's own docstring (`principal_client.py`) warns about: a
+signed-but-tokenless (or wrong-token) call reaches Core and fails as a
+silent authorization error, not a loud one — so no route-level test
+(asserting a 200/404/503) would ever catch it either.
+
+So this file fakes ONLY `principal_client.SignedCoreClient` — the lowest
+seam both `admin_app._core` and `image_routes.get_campaign_client` share —
+and drives real HTTP requests through the real route handlers, with a
+deliberately distinctive admin token so a wrong-token bug cannot hide behind
+a coincidental match.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, image_routes, principal_client
+
+#: Deliberately distinctive — not "admin-jwt" or "token", which several
+#: other test files already use, so a bug that forwards the WRONG-but-also-
+#: plausible-looking token cannot coincidentally satisfy an assertion here.
+_REAL_ADMIN_TOKEN = "the-genuine-signed-in-admins-jwt"  # noqa: S105
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000f1"
+_BASE_URL = "https://dev.tabsii.com"
+_CORE_API_URL = "https://core.invalid"
+
+
+class _FakeSignedCoreClient:
+    """Stands in for `biffo_plugin_sdk.SignedCoreClient` at the one seam
+    every dual-auth call site shares. Records every `raw_request` call —
+    what is asserted here is the `extra_signed_headers` token and the
+    `path`/`method`, never the response shape (that is
+    `test_marketing_principal_client.py`'s job)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes | None = None,
+        extra_signed_headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes, str]:
+        self.calls.append(
+            {
+                "method": method,
+                "path": path,
+                "content": content,
+                "extra_signed_headers": extra_signed_headers,
+            }
+        )
+        # A generically-shaped 2xx JSON body: every route this file drives
+        # only needs SOME campaign/artefact/asset-looking dict back, not a
+        # specific one — the assertions below are about what was SENT.
+        return (
+            200,
+            b'{"id": "x", "destination_url": "https://tabsii.com/intake/demo"}',
+            ("application/json"),
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_signed_client(monkeypatch: pytest.MonkeyPatch) -> _FakeSignedCoreClient:
+    client = _FakeSignedCoreClient()
+    monkeypatch.setattr(principal_client, "SignedCoreClient", lambda **kw: client)
+    return client
+
+
+# ── admin_app._core, driven for real through a route ─────────────────────────
+
+
+def test_mint_links_forwards_the_real_admins_token_through_core(
+    fake_signed_client: _FakeSignedCoreClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_core`'s own body — not a mock of it — signs both of `mint_links`'
+    Core calls with the SAME token the request arrived with."""
+    monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
+    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE_URL)
+    app = admin_app.build_app()
+    app.dependency_overrides[admin_app.require_admin] = lambda: type(
+        "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
+    )()
+
+    resp = TestClient(app).post(
+        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]}
+    )
+
+    assert resp.status_code == 201
+    assert len(fake_signed_client.calls) == 2  # GET campaign, POST links
+    for call in fake_signed_client.calls:
+        assert call["extra_signed_headers"] == {
+            principal_client.FORWARDED_USER_HEADER: _REAL_ADMIN_TOKEN
+        }
+
+
+def test_mint_links_calls_the_real_internal_paths_not_the_token(
+    fake_signed_client: _FakeSignedCoreClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards specifically against an argument-order regression in `_core`'s
+    delegation to `principal_client.request` — if `method`/`path`/`token`
+    were ever transposed, the token (a JWT-shaped string, never starting
+    with `/`) would arrive here as the `path`."""
+    monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
+    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE_URL)
+    app = admin_app.build_app()
+    app.dependency_overrides[admin_app.require_admin] = lambda: type(
+        "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
+    )()
+
+    TestClient(app).post(f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]})
+
+    paths = {call["path"] for call in fake_signed_client.calls}
+    assert paths == {
+        f"{admin_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}",
+        f"{admin_app._INTERNAL_PREFIX}/links",
+    }
+    assert _REAL_ADMIN_TOKEN not in paths
+
+
+def test_approve_artefact_forwards_the_real_admins_token(
+    fake_signed_client: _FakeSignedCoreClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second, independent route through `_core` (PATCH, not GET/POST) —
+    `_latest_artefact` then `approve_artefact_route`'s own PATCH — so this
+    is not proving the property for only one HTTP method."""
+    monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
+
+    class _ProposedThenApproved:
+        """The fake Core answers `GET .../artefacts` with one `proposed`
+        row, so `approve_artefact_route`'s status check passes and its own
+        PATCH is what this test observes."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def raw_request(self, method, path, *, content=None, extra_signed_headers=None):
+            self.calls.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "content": content,
+                    "extra_signed_headers": extra_signed_headers,
+                }
+            )
+            if method == "GET":
+                import json as _json
+
+                row = {
+                    "id": "artefact-1",
+                    "campaign_id": _CAMPAIGN,
+                    "kind": "research",
+                    "status": "proposed",
+                    "created_at": "2026-08-10T00:00:00Z",
+                }
+                return 200, _json.dumps([row]).encode(), "application/json"
+            return 200, b'{"id": "artefact-1", "status": "approved"}', "application/json"
+
+        async def aclose(self) -> None:
+            return None
+
+    fake = _ProposedThenApproved()
+    monkeypatch.setattr(principal_client, "SignedCoreClient", lambda **kw: fake)
+
+    app = admin_app.build_app()
+    app.dependency_overrides[admin_app.require_admin] = lambda: type(
+        "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
+    )()
+
+    resp = TestClient(app).post(f"/campaigns/{_CAMPAIGN}/artefacts/research/approve")
+
+    assert resp.status_code == 200
+    patch_calls = [c for c in fake.calls if c["method"] == "PATCH"]
+    assert len(patch_calls) == 1
+    assert patch_calls[0]["extra_signed_headers"] == {
+        principal_client.FORWARDED_USER_HEADER: _REAL_ADMIN_TOKEN
+    }
+    assert patch_calls[0]["path"] == f"{admin_app._INTERNAL_PREFIX}/artefacts/artefact-1"
+
+
+# ── image_routes.get_campaign_client, driven for real through a route ───────
+
+
+class _FakeImageProvider:
+    async def generate_still(self, *, prompt: str) -> Any:
+        from marketing.image_provider import GeneratedImage
+
+        return GeneratedImage(
+            content=b"fake-bytes",
+            content_type="image/png",
+            filename="fake.png",
+            provider="fake-provider",
+            model="fake-model-1",
+            units=1.0,
+            unit_kind="image",
+            cost_usd=None,
+        )
+
+
+class _FakeCoreClient:
+    """Stands in for `image_routes.get_core_client()` (Class 1 — plugin
+    identity only, no forwarded token) so this test can isolate the ONE
+    thing it cares about: `get_campaign_client()`'s dual-auth wiring."""
+
+    async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        if path.endswith("/presign"):
+            return {
+                "key": "k",
+                "url": "https://s3.example.invalid/upload",
+                "fields": {},
+                "max_bytes": 10_000_000,
+                "expires_in": 900,
+            }
+        if path.endswith("/confirm"):
+            return {"id": "media-1", "storage_key": "k", "filename": "f", "mime_type": "image/png"}
+        return {"id": "ledger-1"}
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        return {"url": "https://s3.example.invalid/signed-get"}
+
+
+def test_generate_still_forwards_the_real_admins_token_to_the_campaign_client(
+    fake_signed_client: _FakeSignedCoreClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`get_campaign_client()` is NOT dependency-overridden here — it runs
+    for real, building a real `PrincipalCoreClient(admin.token)` that must
+    carry the SAME token the request arrived with through to the (faked)
+    `SignedCoreClient`."""
+    import httpx
+    from fastapi import FastAPI
+
+    # `_upload`'s one raw `httpx.AsyncClient` POST to object storage — same
+    # `MockTransport` pattern as `test_marketing_image_routes.py`'s own
+    # `_s3_upload_ok` fixture, so this test isolates the ONE new thing it
+    # exists to check (the campaign_client wiring) rather than reinventing
+    # S3-upload faking.
+    transport = httpx.MockTransport(lambda request: httpx.Response(204))
+    real_async_client = httpx.AsyncClient
+
+    class _PatchedClient(real_async_client):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedClient)
+
+    app = FastAPI()
+    app.include_router(image_routes.router)
+    app.dependency_overrides[image_routes.require_admin] = lambda: type(
+        "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
+    )()
+    app.dependency_overrides[image_routes.get_image_provider] = lambda: _FakeImageProvider()
+    app.dependency_overrides[image_routes.get_core_client] = lambda: _FakeCoreClient()
+    # Deliberately NOT overriding get_campaign_client — see docstring above.
+
+    resp = TestClient(app).post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "a logo"})
+
+    assert resp.status_code == 201
+    assert len(fake_signed_client.calls) == 2  # GET campaign, POST assets
+    for call in fake_signed_client.calls:
+        assert call["extra_signed_headers"] == {
+            principal_client.FORWARDED_USER_HEADER: _REAL_ADMIN_TOKEN
+        }
+    paths = {call["path"] for call in fake_signed_client.calls}
+    assert paths == {
+        f"{image_routes._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}",
+        f"{image_routes._INTERNAL_PREFIX}/assets",
+    }

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -104,22 +104,23 @@ class _FakeCoreClient:
 
 
 class _FakeCampaignClient:
-    """Stands in for the bearer-token client over the plugin's own
-    generated-CRUD tables (`marketing_campaign`, `marketing_asset`)."""
+    """Stands in for the dual-auth (SigV4 + forwarded user token) client over
+    the plugin's own generated-CRUD tables (`marketing_campaign`,
+    `marketing_asset`) — Core's internal, per-plugin mount, per issue #27."""
 
     def __init__(self, *, exists: bool = True) -> None:
         self.exists = exists
         self.created_assets: list[dict[str, Any]] = []
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
-        if path == f"/campaigns/{_CAMPAIGN}":
+        if path == f"{image_routes._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}":
             if not self.exists:
                 raise BiffoAPIError(404, "not found")
             return {"id": _CAMPAIGN}
         raise AssertionError(f"unexpected GET {path}")
 
     async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
-        if path == "/assets":
+        if path == f"{image_routes._INTERNAL_PREFIX}/assets":
             row = {**(json or {}), "id": f"asset-{len(self.created_assets) + 1}"}
             self.created_assets.append(row)
             return row

--- a/tests/test_marketing_mint_route.py
+++ b/tests/test_marketing_mint_route.py
@@ -35,13 +35,13 @@ class _FakeCore:
         # `request=` is not decoration: httpx refuses `raise_for_status()` on a
         # response with no request attached, and the route calls it.
         request = httpx.Request(method, f"https://core.invalid{path}")
-        if method == "GET" and path.startswith("/campaigns/"):
+        if method == "GET" and path.startswith(f"{admin_app._INTERNAL_PREFIX}/campaigns/"):
             return httpx.Response(
                 200,
                 json={"id": _CAMPAIGN, "destination_url": self.destination},
                 request=request,
             )
-        if method == "POST" and path == "/links":
+        if method == "POST" and path == f"{admin_app._INTERNAL_PREFIX}/links":
             body = kw["json"]
             self.created.append(body)
             return httpx.Response(

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -33,11 +33,12 @@ class _FakeCore:
 
     async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
         request = httpx.Request(method, f"https://core.invalid{path}")
-        if method == "GET" and path == f"/campaigns/{_CAMPAIGN}":
+        prefix = admin_app._INTERNAL_PREFIX
+        if method == "GET" and path == f"{prefix}/campaigns/{_CAMPAIGN}":
             return httpx.Response(200, json=self.campaign, request=request)
-        if method == "GET" and path.startswith("/campaigns/"):
+        if method == "GET" and path.startswith(f"{prefix}/campaigns/"):
             return httpx.Response(404, json={"detail": "not found"}, request=request)
-        if method == "GET" and path == "/artefacts":
+        if method == "GET" and path == f"{prefix}/artefacts":
             params = kw.get("params") or {}
             rows = [
                 a
@@ -46,7 +47,7 @@ class _FakeCore:
                 and a.get("kind") == params.get("kind")
             ]
             return httpx.Response(200, json=rows, request=request)
-        if method == "POST" and path == "/artefacts":
+        if method == "POST" and path == f"{prefix}/artefacts":
             self._next_id += 1
             artefact_id = f"artefact-{self._next_id}"
             body = dict(kw["json"])
@@ -60,8 +61,8 @@ class _FakeCore:
             }
             self.artefacts[artefact_id] = row
             return httpx.Response(201, json=row, request=request)
-        if method == "PATCH" and path.startswith("/artefacts/"):
-            artefact_id = path.removeprefix("/artefacts/")
+        if method == "PATCH" and path.startswith(f"{prefix}/artefacts/"):
+            artefact_id = path.removeprefix(f"{prefix}/artefacts/")
             self.artefacts[artefact_id].update(kw["json"])
             return httpx.Response(200, json=self.artefacts[artefact_id], request=request)
         raise AssertionError(f"unexpected call {method} {path}")

--- a/tests/test_marketing_principal_client.py
+++ b/tests/test_marketing_principal_client.py
@@ -1,0 +1,276 @@
+"""Direct unit tests for `principal_client.py` (issue #27).
+
+Every other test in this repo that touches a Core call exercises this module
+only through a fake at the boundary — `admin_app._core` is monkeypatched
+wholesale in `test_marketing_mint_route.py`/`test_marketing_pipeline_routes.py`,
+and `image_routes.get_campaign_client` is dependency-overridden in
+`test_marketing_image_routes.py`. None of them runs a single line of this
+module's own code: `uv run pytest --cov=src/marketing/principal_client`
+reports "No data was collected" without this file, confirmed before writing
+it. What is worth asserting here is `principal_client`'s own contract — the
+forwarded user token rides `extra_signed_headers`, `json`/`params` are
+encoded the way Core expects, and both wrapper shapes (`request`'s
+`httpx.Response`, `PrincipalCoreClient`'s parse-and-raise) map a
+`SignedCoreClient.raw_request` response correctly in both directions (2xx
+and non-2xx).
+
+A fake `SignedCoreClient`, not a mock — matching this repo's convention
+(`test_marketing_mint_route.py`'s `_FakeCore`, `test_marketing_image_routes.py`'s
+`_FakeCoreClient`) — standing in for the one real thing this module cannot
+exercise in CI: an actual SigV4 signature over live AWS credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from biffo_plugin_sdk import BiffoAPIError
+
+from marketing import principal_client
+
+_TOKEN = "user-jwt"  # noqa: S105 — a fixture value, not a real credential.
+
+
+class _FakeSignedCoreClient:
+    """Stands in for `biffo_plugin_sdk.SignedCoreClient`: records every
+    `raw_request` call and answers with a canned `(status, body,
+    content_type)` — that method's own return shape, so this exercises
+    exactly the contract `principal_client` is written against.
+    """
+
+    def __init__(self) -> None:
+        self.init_kwargs: list[dict[str, Any]] = []
+        self.calls: list[dict[str, Any]] = []
+        self._status = 200
+        self._body: bytes = b"{}"
+        self._content_type = "application/json"
+
+    def answer(self, status: int, body: bytes, content_type: str = "application/json") -> None:
+        self._status, self._body, self._content_type = status, body, content_type
+
+    async def raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes | None = None,
+        extra_signed_headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes, str]:
+        self.calls.append(
+            {
+                "method": method,
+                "path": path,
+                "content": content,
+                "extra_signed_headers": extra_signed_headers,
+            }
+        )
+        return self._status, self._body, self._content_type
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeSignedCoreClient:
+    """Patches `principal_client.SignedCoreClient` (the name this module
+    imports and calls) so every `SignedCoreClient(**kwargs)` this module
+    constructs returns the SAME fake instance — `_raw` builds a fresh client
+    per call, matching `admin_app._core`'s pre-fix per-call
+    `httpx.AsyncClient`, and every test below makes exactly one call."""
+    client = _FakeSignedCoreClient()
+
+    def _build(**kwargs: Any) -> _FakeSignedCoreClient:
+        client.init_kwargs.append(kwargs)
+        return client
+
+    monkeypatch.setattr(principal_client, "SignedCoreClient", _build)
+    return client
+
+
+# ── request() — the httpx.Response-shaped wrapper (admin_app._core) ─────────
+
+
+async def test_request_signs_with_the_forwarded_user_token(fake_client) -> None:
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/campaigns/x",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert fake_client.calls[0]["extra_signed_headers"] == {
+        principal_client.FORWARDED_USER_HEADER: _TOKEN
+    }
+
+
+async def test_request_passes_the_full_path_through_unchanged(fake_client) -> None:
+    """No prefixing here — the guard needs the `/api/v1/...` prefix visible
+    AT THE CALL SITE (this module's docstring), so a caller must already
+    supply the full internal path."""
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert fake_client.calls[0]["path"] == "/api/v1/internal/plugins/marketing/artefacts"
+    assert fake_client.calls[0]["method"] == "GET"
+    assert fake_client.calls[0]["content"] is None
+
+
+async def test_request_appends_params_as_a_querystring(fake_client) -> None:
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+        params={"campaign_id": "c1", "kind": "research"},
+    )
+
+    assert (
+        fake_client.calls[0]["path"]
+        == "/api/v1/internal/plugins/marketing/artefacts?campaign_id=c1&kind=research"
+    )
+
+
+async def test_request_json_encodes_the_body(fake_client) -> None:
+    await principal_client.request(
+        "POST",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+        json={"status": "approved"},
+    )
+
+    assert json.loads(fake_client.calls[0]["content"]) == {"status": "approved"}
+
+
+async def test_request_passes_base_url_and_timeout_to_the_signed_client(fake_client) -> None:
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+        timeout=30.0,
+    )
+
+    assert fake_client.init_kwargs[0]["base_url"] == "https://core.invalid"
+    assert fake_client.init_kwargs[0]["timeout"] == 30.0
+
+
+async def test_request_omits_timeout_when_not_given(fake_client) -> None:
+    """The SDK's own default (30.0 on `SignedCoreClient`) should apply,
+    rather than this module silently overriding it with something else."""
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert "timeout" not in fake_client.init_kwargs[0]
+
+
+async def test_request_returns_a_real_httpx_response_on_success(fake_client) -> None:
+    fake_client.answer(200, b'{"id": "a1"}')
+
+    resp = await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts/a1",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert isinstance(resp, httpx.Response)
+    assert resp.status_code == 200
+    assert resp.json() == {"id": "a1"}
+    resp.raise_for_status()  # must not raise
+
+
+async def test_request_response_raise_for_status_fires_on_4xx(fake_client) -> None:
+    """The whole point of returning a real `httpx.Response`: every existing
+    `_core()` call site does `resp.raise_for_status()` unchanged."""
+    fake_client.answer(404, b'{"detail": "not found"}')
+
+    resp = await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/campaigns/x",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert resp.status_code == 404
+    with pytest.raises(httpx.HTTPStatusError):
+        resp.raise_for_status()
+
+
+# ── PrincipalCoreClient — the BiffoAPIClient-shaped wrapper (image_routes) ──
+
+
+async def test_principal_core_client_get_returns_parsed_json_on_success(fake_client) -> None:
+    fake_client.answer(200, b'{"id": "campaign-1"}')
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    result = await client.get("/api/v1/internal/plugins/marketing/campaigns/campaign-1")
+
+    assert result == {"id": "campaign-1"}
+    assert fake_client.calls[0]["extra_signed_headers"] == {
+        principal_client.FORWARDED_USER_HEADER: _TOKEN
+    }
+
+
+async def test_principal_core_client_get_returns_none_for_an_empty_body(fake_client) -> None:
+    fake_client.answer(204, b"")
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    assert await client.get("/api/v1/internal/plugins/marketing/campaigns/x") is None
+
+
+async def test_principal_core_client_post_encodes_json_and_signs_the_token(fake_client) -> None:
+    fake_client.answer(201, b'{"id": "asset-1"}')
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    result = await client.post(
+        "/api/v1/internal/plugins/marketing/assets", json={"campaign_id": "c1"}
+    )
+
+    assert result == {"id": "asset-1"}
+    assert json.loads(fake_client.calls[0]["content"]) == {"campaign_id": "c1"}
+
+
+async def test_principal_core_client_raises_biffo_api_error_on_404_with_detail(fake_client) -> None:
+    fake_client.answer(404, b'{"detail": "Campaign not found."}')
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    with pytest.raises(BiffoAPIError) as exc:
+        await client.get("/api/v1/internal/plugins/marketing/campaigns/x")
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Campaign not found."
+
+
+async def test_principal_core_client_raises_biffo_api_error_with_a_fallback_detail(
+    fake_client,
+) -> None:
+    """A non-JSON or detail-less error body must still raise something a
+    caller's `except BiffoAPIError` can read, not crash the mapping itself."""
+    fake_client.answer(502, b"upstream exploded", content_type="text/plain")
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    with pytest.raises(BiffoAPIError) as exc:
+        await client.post("/api/v1/internal/plugins/marketing/assets", json={"a": 1})
+
+    assert exc.value.status_code == 502
+
+
+async def test_principal_core_client_patch_is_supported(fake_client) -> None:
+    fake_client.answer(200, b'{"status": "approved"}')
+    client = principal_client.PrincipalCoreClient(_TOKEN)
+
+    result = await client.patch(
+        "/api/v1/internal/plugins/marketing/artefacts/a1", json={"status": "approved"}
+    )
+
+    assert result == {"status": "approved"}
+    assert fake_client.calls[0]["method"] == "PATCH"

--- a/tests/test_marketing_principal_client.py
+++ b/tests/test_marketing_principal_client.py
@@ -39,11 +39,19 @@ class _FakeSignedCoreClient:
     `raw_request` call and answers with a canned `(status, body,
     content_type)` — that method's own return shape, so this exercises
     exactly the contract `principal_client` is written against.
+
+    Also implements `aclose()` — `principal_client._raw` closes the
+    connection pool `SignedCoreClient` opens per instance via a plain
+    try/finally (not `async with`; see that function's own docstring for
+    why) — and records whether it was reached, so a test can catch a future
+    regression back to "build one and never close it" the same way this
+    fake caught it once.
     """
 
     def __init__(self) -> None:
         self.init_kwargs: list[dict[str, Any]] = []
         self.calls: list[dict[str, Any]] = []
+        self.closed = False
         self._status = 200
         self._body: bytes = b"{}"
         self._content_type = "application/json"
@@ -68,6 +76,9 @@ class _FakeSignedCoreClient:
             }
         )
         return self._status, self._body, self._content_type
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 @pytest.fixture
@@ -134,6 +145,38 @@ async def test_request_appends_params_as_a_querystring(fake_client) -> None:
     )
 
 
+async def test_request_omits_none_valued_params_rather_than_stringifying_them(fake_client) -> None:
+    """`urlencode({"a": None})` alone renders the literal query text `a=None`
+    — a real value that would silently match nothing, not the omitted
+    filter a caller almost certainly means. No current caller passes a
+    `None` param (verified before this test was written), but the omission
+    has to hold for the first one that does."""
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+        params={"campaign_id": "c1", "kind": None},
+    )
+
+    assert (
+        fake_client.calls[0]["path"]
+        == "/api/v1/internal/plugins/marketing/artefacts?campaign_id=c1"
+    )
+
+
+async def test_request_with_only_none_valued_params_appends_no_querystring(fake_client) -> None:
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+        params={"kind": None},
+    )
+
+    assert fake_client.calls[0]["path"] == "/api/v1/internal/plugins/marketing/artefacts"
+
+
 async def test_request_json_encodes_the_body(fake_client) -> None:
     await principal_client.request(
         "POST",
@@ -170,6 +213,24 @@ async def test_request_omits_timeout_when_not_given(fake_client) -> None:
     )
 
     assert "timeout" not in fake_client.init_kwargs[0]
+
+
+async def test_request_closes_the_signed_client_after_the_call(fake_client) -> None:
+    """A `SignedCoreClient` owns its own `httpx.AsyncClient`/connection pool
+    (`BiffoAPIClient.__init__` builds one whenever `client=` isn't passed);
+    building a fresh one per Core call without closing it leaks one pool per
+    call. Regression guard for exactly that: a version of `_raw` without the
+    `async with` passes every other test in this file and still leaks."""
+    assert fake_client.closed is False
+
+    await principal_client.request(
+        "GET",
+        "/api/v1/internal/plugins/marketing/artefacts",
+        _TOKEN,
+        base_url="https://core.invalid",
+    )
+
+    assert fake_client.closed is True
 
 
 async def test_request_returns_a_real_httpx_response_on_success(fake_client) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aws-lambda-powertools", extras = ["tracer"], specifier = ">=3.4.0" },
-    { name = "biffo-plugin-sdk", extras = ["sigv4", "user-serving"], specifier = ">=1.1,<2.0" },
+    { name = "biffo-plugin-sdk", extras = ["sigv4", "user-serving"], specifier = ">=1.2,<2.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pillow", specifier = ">=11.0.0" },
@@ -117,16 +117,16 @@ dev = [
 
 [[package]]
 name = "biffo-plugin-sdk"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-lambda-powertools" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/bb/e0b42186304af743972a092cf1b83ef8399ea41b16ae0af0db930e599d76/biffo_plugin_sdk-1.1.0.tar.gz", hash = "sha256:8b5b77d440dd4c53cf6c0ec1729ad43c5d717803d1ccc9a0ef3eee69c8729d00", size = 33322, upload-time = "2026-07-24T06:56:57.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6c/d61125c1e312e0442a90843f55be2263a8df3938ec1ada8f6e3ca6b2ceb8/biffo_plugin_sdk-1.2.0.tar.gz", hash = "sha256:af76624b91b4ec059b6291d2d319cdbc1d72d35592594ee600d3170ecf5b88a5", size = 44022, upload-time = "2026-08-10T18:47:53.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/22/79747766062dcda4719aa3f37fc994a09f8f5e5bd73261f78a4660ccdf0f/biffo_plugin_sdk-1.1.0-py3-none-any.whl", hash = "sha256:9f78f41b3a904acddf56ca879d6e4fcdc18d1ff7a7c8249f1d088268fda82714", size = 23000, upload-time = "2026-07-24T06:56:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/90/fdf715a083c5ddc83719fc83abe58c815f493e199bb8ff486978d5dcd4c7/biffo_plugin_sdk-1.2.0-py3-none-any.whl", hash = "sha256:0b0e0c2d8f20f6893d694a45a2c584cfcc99c1a2e0395a804054721bb3118e00", size = 27491, upload-time = "2026-08-10T18:47:52.444Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

`biffo-plugin-sdk` 1.2.0 is on PyPI (confirmed against PyPI's JSON API:
releases are `1.0.0`, `1.1.0`, `1.2.0`), carrying
`SignedCoreClient.raw_request(..., extra_signed_headers=...)` — the SDK
method that SigV4-signs a request AND carries the calling admin's own
token through that signature, which Core's `require_principal_crud_permission`
guard needs from either transport.

- Bumps the SDK pin to `>=1.2,<2.0`.
- Adds `src/marketing/principal_client.py`, a dual-auth transport built
  directly on `SignedCoreClient` (mirroring the shared plugin host's own
  `core_sender()`, read from source rather than guessed at).
- `admin_app._core` becomes a real thin wrapper over it instead of a bare,
  unsigned `httpx.AsyncClient` call — making its own docstring (and
  `_validated_campaign_id`'s, which #17 flagged as false) actually true
  rather than deleting `_core` and rewriting 9 call sites' response
  handling around the SDK's raw tuple.
- `channel_plan_routes.py` and `image_routes.get_campaign_client` move to
  the same mechanism.
- Every one of the twelve Class-2 call sites in
  `test_marketing_core_paths_guard.py`'s `_PENDING_SDK_RELEASE` baseline
  now carries the full `/api/v1/internal/plugins/marketing` prefix **at
  its own call site** (never behind an imported constant — the guard
  resolves a module constant only within the file that defines it), so the
  baseline drains to empty.

## What an independent review found and I fixed here too

A second pass (mutation testing, not just reading) on the first commit
found real gaps, all fixed in the second commit:

- **A connection-pool leak** — the first version built a fresh
  `SignedCoreClient` per call and never closed it.
- **The actual wiring was untested.** Every existing test mocks
  `admin_app._core` or dependency-overrides `get_campaign_client` — none
  of them exercises the code that threads `method`/`path`/`token` through
  to `principal_client`. Proven by sabotage (swapped argument order;
  hardcoded wrong token) both leaving the suite green. Added
  `tests/test_marketing_dual_auth_wiring.py`, which fakes only
  `SignedCoreClient` and drives real routes end to end; I re-applied both
  sabotage scenarios against the new tests and confirmed they're caught
  before reverting.
- **Guard vs. authority disagreement**: the path guard only checks a path
  starts with `/api/v1/`, never that the three duplicated
  `_INTERNAL_PREFIX` copies agree with each other. A typo in one passed
  the guard; added a disagreement test, verified against the typo.
- A smaller error-mapping duplication and a `urlencode(None)` edge case,
  both fixed with tests.

Two findings deliberately **not** fixed here, filed instead:
- keiranholloway/biffo-template#1490 — this is now a third independent
  implementation of the same dual-auth pattern (idea-scout and ideation
  each hand-roll their own); proposes consolidating into the SDK. Also
  flags, hedged, that those two forward the user token *outside* the
  SigV4 signature — a divergence from what this PR builds, which I have
  not confirmed is actually exploitable.
- keiranholloway/biffo-plugin-marketing#29 — `principal_client` rebuilds
  a `SignedCoreClient` (and now correctly closes it) on every call rather
  than reusing one per request, so AWS credentials are re-resolved more
  than necessary. Deferred: the right fix needs care around test
  isolation and Lambda lifecycle this PR's scope didn't budget for.

## What I could NOT verify

Nothing here has been exercised against a live Core deployment. The full
suite (234 tests, including new sabotage-verified wiring tests), ruff,
ruff format, pyright, and `pip-audit` are all green, and `sh scripts/
biffo.sh verify` (the full local push gate, including `web-admin`) passes.
That proves the code does what it says against fakes — it does not prove
the calls succeed against a real, deployed Core. Not closing #17 or #27
here for that reason; recommend closing only after a live-deployment check.

Refs #17, #27.
