### PR TITLE
fix(marketing): name the plugin's nav entry, and drop the scaffold page

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -464,13 +464,8 @@
   "ui_components": [
     {
       "type": "nav-link",
-      "label": "Example Plugin",
+      "label": "Marketing",
       "path": "/admin/marketing"
-    },
-    {
-      "type": "page",
-      "label": "Widgets",
-      "path": "/admin/marketing/widgets"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
`biffo.plugin.json` still carried the scaffold's `ui_components` verbatim:

```json
{"type": "nav-link", "label": "Example Plugin", "path": "/admin/marketing"}
{"type": "page",     "label": "Widgets",       "path": "/admin/marketing/widgets"}
```

An operator would have seen **"Example Plugin"** in their portal nav, linking to a Widgets page that does not exist and never did.

The label is the only string a person reads to find this feature, so it is the one thing that cannot be left as scaffold residue. The Widgets entry is **deleted rather than renamed** — there is no second page to point at; the admin SPA is one surface, served at `/api/v1/plugins/marketing/admin/`.

Found while tracing where the UI actually surfaces for an operator, before re-syncing the plugin into the instance.

234 passed.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)