### PR TITLE
feat(marketing): results dashboard — clicks per campaign, leads/cost unmeasurable

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -669,6 +669,14 @@ def build_app() -> FastAPI:
 
     app.include_router(channel_plan_router)
 
+    # Results dashboard (M8, issue #7) — same reasoning as channel_plan_router
+    # above: a lazy, in-function import keeps this file's diff to one include
+    # line while `results_routes` reaches back into this module for
+    # `require_admin`/`_core`.
+    from .results_routes import router as results_router
+
+    app.include_router(results_router)
+
     # LAST. See the module docstring: a StaticFiles mount at "/" swallows
     # everything registered after it, so anything below this line is unreachable.
     static = _static_dir()

--- a/src/marketing/results_routes.py
+++ b/src/marketing/results_routes.py
@@ -1,0 +1,246 @@
+"""Results dashboard (M8, issue #7): clicks, leads, conversions and cost per
+campaign.
+
+## The measurement discipline is the feature
+
+Every share this endpoint renders carries its denominator and an explicit
+unmeasurable count. "No data" is a different, structurally distinct thing
+from "zero" throughout — a confident number that is wrong in a systematic
+direction is worse than a missing one. This estate has already paid for that
+specific mistake once: a share computed over only the "classifiable" inputs
+read 80% where the true figure, once the excluded slice was counted, was
+47.1%. Nothing here computes a share over a filtered population and reports
+it as if it covered the whole one.
+
+This also never blurs pack engagement with publishing. This plugin calls no
+platform APIs, so impressions, reach and engagement are unmeasurable **by
+construction** — not absent because nobody wired them up yet, but because
+there is nothing this deployment could ever call to learn them. Nothing below
+renders a click, a mint, or a download count as if it said anything about
+who saw a post.
+
+## Clicks are measured; leads, conversions and cost are not — yet
+
+`marketing_click` and `marketing_link` are this plugin's own generated-CRUD
+tables (declared in `biffo.plugin.json`), reachable through the same
+internal, SigV4-signed mount every other route in this file uses
+(`admin_app._core`, `_INTERNAL_PREFIX`). Clicks per campaign, and the
+paid/organic split, are real numbers computed from real rows this plugin
+wrote itself.
+
+Leads (`public.demo_requests`, tabsii-platform) and cost
+(`tabsii.lead_source_costs`, DDL module 049) are **not** reachable from here
+today, and this is a genuinely missing capability rather than an oversight in
+this module. Both surfaces exist and are queried in `tabsii-platform`, but
+neither is registered under `/api/v1/internal/*` — the only tree a
+SigV4-signed plugin call can reach at all (`services/api/src/api/main.py`'s
+full router-registration list has no `internal_*` router for either table).
+`demo_requests` sits behind Core's own `/api/v1/admin/demo-requests`, gated
+by `require_admin`, which is built on `require_auth`
+(`services/api/src/api/middleware/auth.py`) — bearer-`Authorization`-only,
+with no forwarded-token acceptance the way `require_principal` (the guard
+`require_principal_crud_permission` uses) has. `lead_source_costs` sits
+behind tabsii-CRM's `/api/v1/data/lead_source_costs` and
+`/api/v1/analytics/pipeline/*`, gated on RBAC permission codes
+(`leads.read`, `lead_source_costs.read`) that have nothing to do with the
+"admin" Cognito group this plugin's own admin surface authorises on. Even if
+either surface were reachable, `demo_requests.status` has no mutation path
+yet (`demo_requests_admin.py`'s own docstring: "there's no mutation surface
+yet"), so "conversion" has no signal to read regardless of transport.
+
+So "no data" here is not a placeholder for effort not yet spent on a query —
+it is the honest, current state of a real transport gap, filed as issue #31.
+Until that closes, every campaign's leads, conversions and cost render as
+**unmeasurable**, never as zero: reporting zero would claim "we looked, and
+nothing happened," which is not a claim this plugin can make today.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from . import admin_app
+
+router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
+
+#: Not `admin_app._INTERNAL_PREFIX` — `tests/test_marketing_core_paths_guard.py`
+#: resolves a module-level string constant only within the SAME file's own
+#: AST, so a cross-module reference would read as unresolvable and be
+#: silently skipped rather than checked. Written out as its own local
+#: constant, matching `channel_plan_routes.py`/`image_routes.py`; that guard
+#: file's own disagreement test asserts every copy stays equal, since the
+#: AST walk itself only checks "starts with /api/v1/", never "the copies
+#: agree with each other or the real mounted path".
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
+
+#: Core's generic `list` route defaults to 50 rows a page and caps a single
+#: page at 200 (`routing/crud_handlers.py`, tabsii-platform). Mirrored here
+#: as a literal rather than imported — this plugin has no dependency on
+#: Core's own package — and used as the page size `_list_all` below asks
+#: for explicitly, so a campaign with more clicks than one page cannot
+#: silently under-count.
+_LIST_PAGE_SIZE = 200
+
+#: Why leads/conversions/cost cannot be computed from here today — see the
+#: module docstring for the full mechanism. Surfaced verbatim in the
+#: response so a caller reading only the JSON, not this file, still gets the
+#: real reason rather than a bare `false`.
+_UNMEASURABLE_REASON = (
+    "No route reachable from this plugin's internal Core transport exposes this yet "
+    "(tracked in issue #31) — 'unmeasurable' means the transport does not exist, "
+    "not that the count is zero."
+)
+
+
+class ClickBreakdown(BaseModel):
+    """Clicks for one campaign, with their own denominator discipline.
+
+    `total` is the denominator; `paid` + `organic` + `unknown_channel_type`
+    always sum to it. `marketing_link.is_paid` is nullable — a link minted
+    before this column mattered, or a future caller of the mint route that
+    never sets it — and folding that into `organic` (a falsy `None`) would
+    be exactly the "share over classifiable inputs" mistake this milestone
+    exists to avoid. `unknown_channel_type` is what keeps that count visible
+    instead of silently disappearing into a bucket that looks like an
+    answer.
+    """
+
+    total: int
+    paid: int
+    organic: int
+    unknown_channel_type: int
+
+
+class UnmeasuredMetric(BaseModel):
+    """A metric this endpoint cannot compute at all today.
+
+    Deliberately not a bare `null` or a `0`: `measurable` is always `False`
+    on every instance this module constructs, and `reason` says why, so a
+    caller reading the JSON — not just this file's docstring — can tell "no
+    data" from "zero" without guessing. `denominator` is the population this
+    metric would be a share of once it becomes measurable (e.g. total clicks,
+    for a click-to-lead rate) when that population is itself known here;
+    `None` when it isn't (e.g. a conversion rate's denominator is a lead
+    count this plugin cannot see either).
+    """
+
+    measurable: bool = False
+    denominator: int | None = None
+    reason: str = _UNMEASURABLE_REASON
+
+
+class CampaignResults(BaseModel):
+    campaign_id: str
+    campaign_name: str
+    clicks: ClickBreakdown
+    leads: UnmeasuredMetric
+    conversions: UnmeasuredMetric
+    cost: UnmeasuredMetric
+
+
+class ResultsResponse(BaseModel):
+    campaigns: list[CampaignResults]
+    #: Clicks whose `campaign_id` names no campaign this call could see (the
+    #: campaign was deleted after the click landed, or — defensively — a row
+    #: this plugin did not expect). Counted rather than silently dropped from
+    #: every campaign's total: an omission here is exactly the kind of
+    #: invisible exclusion the module docstring's 80%-vs-47.1% example warns
+    #: about, just one level up from a single campaign's own numbers.
+    unattributed_clicks: int
+
+
+async def _list_all(path: str, token: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every row Core holds for `path`/`params` — not just the first page.
+
+    Core's generic list route defaults to 50 rows and caps a single page at
+    `_LIST_PAGE_SIZE` (see that constant). A campaign with more clicks than
+    one page would silently under-count if this stopped after the first
+    response; paged explicitly here for the same reason nothing below
+    collapses "don't know" into a bucket that looks like a real answer.
+    """
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        resp = await admin_app._core(
+            "GET", path, token, params={**params, "limit": _LIST_PAGE_SIZE, "offset": offset}
+        )
+        resp.raise_for_status()
+        batch = resp.json() or []
+        rows.extend(batch)
+        if len(batch) < _LIST_PAGE_SIZE:
+            return rows
+        offset += _LIST_PAGE_SIZE
+
+
+def _click_breakdown(
+    clicks: list[dict[str, Any]], links_by_id: dict[str, dict[str, Any]]
+) -> ClickBreakdown:
+    paid = organic = unknown = 0
+    for click in clicks:
+        link = links_by_id.get(click.get("link_id") or "")
+        is_paid = link.get("is_paid") if link is not None else None
+        if is_paid is None:
+            unknown += 1
+        elif is_paid:
+            paid += 1
+        else:
+            organic += 1
+    return ClickBreakdown(
+        total=len(clicks), paid=paid, organic=organic, unknown_channel_type=unknown
+    )
+
+
+@router.get("/results")
+async def results(admin: Any = Depends(admin_app.require_admin)) -> ResultsResponse:
+    """Clicks, leads, conversions and cost, per campaign.
+
+    Three list calls against this plugin's own tables — campaigns, links,
+    clicks — each paged in full via `_list_all`, then joined in memory:
+    `marketing_click.link_id` -> `marketing_link.is_paid` for the paid/organic
+    split, and `marketing_click.campaign_id` -> `marketing_campaign.id` for
+    the per-campaign grouping. See the module docstring for why leads,
+    conversions and cost are reported as `UnmeasuredMetric` rather than
+    computed: no reachable Core surface carries them yet.
+    """
+    campaigns = await _list_all(f"{_INTERNAL_PREFIX}/campaigns", admin.token, {})
+    links = await _list_all(f"{_INTERNAL_PREFIX}/links", admin.token, {})
+    clicks = await _list_all(f"{_INTERNAL_PREFIX}/clicks", admin.token, {})
+
+    links_by_id = {link["id"]: link for link in links if link.get("id")}
+    known_campaign_ids = {campaign["id"] for campaign in campaigns if campaign.get("id")}
+
+    clicks_by_campaign: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    unattributed = 0
+    for click in clicks:
+        campaign_id = click.get("campaign_id")
+        if campaign_id is not None and campaign_id in known_campaign_ids:
+            clicks_by_campaign[campaign_id].append(click)
+        else:
+            unattributed += 1
+
+    out: list[CampaignResults] = []
+    for campaign in campaigns:
+        campaign_id = campaign["id"]
+        breakdown = _click_breakdown(clicks_by_campaign.get(campaign_id, []), links_by_id)
+        out.append(
+            CampaignResults(
+                campaign_id=campaign_id,
+                campaign_name=campaign.get("name") or "",
+                clicks=breakdown,
+                # `denominator=breakdown.total`: once leads become reachable,
+                # a click-to-lead rate's population is exactly this
+                # campaign's click count. `conversions`/`cost` have no known
+                # denominator here — a conversion rate is a share of leads,
+                # which this plugin cannot see either, and cost is an amount
+                # rather than a share at all.
+                leads=UnmeasuredMetric(denominator=breakdown.total),
+                conversions=UnmeasuredMetric(),
+                cost=UnmeasuredMetric(),
+            )
+        )
+
+    return ResultsResponse(campaigns=out, unattributed_clicks=unattributed)

--- a/tests/test_marketing_core_paths_guard.py
+++ b/tests/test_marketing_core_paths_guard.py
@@ -218,24 +218,28 @@ def test_already_fixed_paths_stay_fixed(filename: str, prefix: str) -> None:
 
 def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
     """Guard vs. authority: `_find_violations` above only checks that a path
-    starts with `/api/v1/` — it never checks that the three independent
+    starts with `/api/v1/` — it never checks that the four independent
     `_INTERNAL_PREFIX` copies this file's own docstring explains
-    (`admin_app.py`, `channel_plan_routes.py`, `image_routes.py`, each
-    forced local because the AST walk resolves a named constant only within
-    the file that defines it) actually agree with each other or with the
-    real mounted path. Verified empirically before this test was written: a
-    single-character typo in one copy (`marketting` for `marketing`) sends
-    every call in that file to an unmounted path while the rest of this
-    suite — including `test_every_core_call_path_is_api_v1_except_the_known_
-    pending_ones` above — stays green, because `/api/v1/internal/plugins/
-    marketting/...` still starts with `/api/v1/`. This is a two-line
-    disagreement check, not a redesign: the guard reads the SHAPE of each
-    path; this reads whether the three sources of that shape's prefix still
-    say the same thing.
+    (`admin_app.py`, `channel_plan_routes.py`, `image_routes.py`,
+    `results_routes.py`, each forced local because the AST walk resolves a
+    named constant only within the file that defines it) actually agree with
+    each other or with the real mounted path. Verified empirically before
+    this test was written: a single-character typo in one copy
+    (`marketting` for `marketing`) sends every call in that file to an
+    unmounted path while the rest of this suite — including
+    `test_every_core_call_path_is_api_v1_except_the_known_pending_ones`
+    above — stays green, because `/api/v1/internal/plugins/marketting/...`
+    still starts with `/api/v1/`. This is a two-line disagreement check, not
+    a redesign: the guard reads the SHAPE of each path; this reads whether
+    the sources of that shape's prefix still say the same thing. A new file
+    gaining its own `_INTERNAL_PREFIX` copy (`results_routes.py`, M8) belongs
+    here the same day it's added — this list is the class fix, not a
+    one-time sweep.
     """
-    from marketing import admin_app, channel_plan_routes, image_routes
+    from marketing import admin_app, channel_plan_routes, image_routes, results_routes
 
     canonical = "/api/v1/internal/plugins/marketing"
     assert admin_app._INTERNAL_PREFIX == canonical
     assert channel_plan_routes._INTERNAL_PREFIX == canonical
     assert image_routes._INTERNAL_PREFIX == canonical
+    assert results_routes._INTERNAL_PREFIX == canonical

--- a/tests/test_marketing_results_routes.py
+++ b/tests/test_marketing_results_routes.py
@@ -1,0 +1,208 @@
+"""The results dashboard (M8, issue #7), over a fake Core.
+
+Fakes rather than mocks, matching this repo's `test_marketing_mint_route.py`
+convention: a fake that actually stores rows and answers `GET .../clicks`
+with a real page of them proves the wiring (method, path, and — new here —
+the `limit`/`offset` pagination params `_list_all` sends) rather than merely
+asserting a call happened with some argument order a reviewer has to trust.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, results_routes
+
+_CAMPAIGN_A = "b3f1c0de-0000-4000-8000-0000000000fa"
+_CAMPAIGN_B = "b3f1c0de-0000-4000-8000-0000000000fb"
+_DELETED_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000fc"
+
+
+class _FakeCore:
+    """An in-memory `marketing_campaign`/`marketing_link`/`marketing_click`
+    store, paged the same way the real Core `list` route is (limit/offset,
+    default order is whatever insertion order gave it — this fake doesn't
+    need to match Core's `created_at DESC` ordering, since nothing under
+    test depends on row order)."""
+
+    def __init__(self) -> None:
+        self.campaigns: list[dict[str, Any]] = []
+        self.links: list[dict[str, Any]] = []
+        self.clicks: list[dict[str, Any]] = []
+
+    def _table(self, path: str) -> list[dict[str, Any]] | None:
+        prefix = results_routes._INTERNAL_PREFIX
+        return {
+            f"{prefix}/campaigns": self.campaigns,
+            f"{prefix}/links": self.links,
+            f"{prefix}/clicks": self.clicks,
+        }.get(path)
+
+    async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
+        request = httpx.Request(method, f"https://core.invalid{path}")
+        rows = self._table(path)
+        if method != "GET" or rows is None:
+            raise AssertionError(f"unexpected call {method} {path}")
+        params = kw.get("params") or {}
+        limit = params["limit"]
+        offset = params["offset"]
+        return httpx.Response(200, json=rows[offset : offset + limit], request=request)
+
+
+@pytest.fixture
+def ctx(monkeypatch: pytest.MonkeyPatch):
+    core = _FakeCore()
+    monkeypatch.setattr(admin_app, "_core", core)
+    app = admin_app.build_app()
+    app.dependency_overrides[admin_app.require_admin] = lambda: type(
+        "U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"}
+    )()
+    return TestClient(app), core
+
+
+def _campaign(campaign_id: str, name: str) -> dict[str, Any]:
+    return {"id": campaign_id, "name": name}
+
+
+def _link(link_id: str, campaign_id: str, *, is_paid: bool | None) -> dict[str, Any]:
+    return {"id": link_id, "campaign_id": campaign_id, "is_paid": is_paid}
+
+
+def _click(click_id: str, campaign_id: str, link_id: str | None) -> dict[str, Any]:
+    return {"id": click_id, "campaign_id": campaign_id, "link_id": link_id}
+
+
+def test_clicks_are_split_paid_organic_and_unknown(ctx) -> None:
+    """The one thing this endpoint can actually measure, measured correctly.
+
+    `link-unknown` carries `is_paid=None` and `link-missing` isn't in the
+    links table at all (a click whose link was later deleted) — both must
+    land in `unknown_channel_type`, never silently folded into `organic`.
+    """
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
+    core.links = [
+        _link("link-paid", _CAMPAIGN_A, is_paid=True),
+        _link("link-organic", _CAMPAIGN_A, is_paid=False),
+        _link("link-unknown", _CAMPAIGN_A, is_paid=None),
+    ]
+    core.clicks = [
+        _click("c1", _CAMPAIGN_A, "link-paid"),
+        _click("c2", _CAMPAIGN_A, "link-paid"),
+        _click("c3", _CAMPAIGN_A, "link-organic"),
+        _click("c4", _CAMPAIGN_A, "link-unknown"),
+        _click("c5", _CAMPAIGN_A, "link-missing"),
+    ]
+
+    resp = client.get("/results")
+    assert resp.status_code == 200
+    clicks = resp.json()["campaigns"][0]["clicks"]
+    assert clicks == {"total": 5, "paid": 2, "organic": 1, "unknown_channel_type": 2}
+
+
+def test_a_campaign_with_no_clicks_reports_a_real_verified_zero(ctx) -> None:
+    """Contrast case for the next test: this IS zero, because clicks are
+    actually measured — not `UnmeasuredMetric`, whose `measurable` is always
+    `False`."""
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "No traffic yet")]
+
+    resp = client.get("/results")
+    clicks = resp.json()["campaigns"][0]["clicks"]
+    assert clicks == {"total": 0, "paid": 0, "organic": 0, "unknown_channel_type": 0}
+
+
+def test_leads_conversions_and_cost_are_unmeasurable_never_zero(ctx) -> None:
+    """The milestone's actual claim: no reachable transport exists yet, so
+    these must never render as a bare `0` — that would claim "we looked and
+    nothing happened," which this plugin cannot say."""
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
+    core.links = [_link("link-1", _CAMPAIGN_A, is_paid=True)]
+    core.clicks = [_click("c1", _CAMPAIGN_A, "link-1"), _click("c2", _CAMPAIGN_A, "link-1")]
+
+    campaign = client.get("/results").json()["campaigns"][0]
+
+    assert campaign["leads"]["measurable"] is False
+    assert campaign["leads"]["denominator"] == 2, "the click count, once leads become reachable"
+    assert "issue #31" in campaign["leads"]["reason"]
+
+    assert campaign["conversions"]["measurable"] is False
+    assert campaign["conversions"]["denominator"] is None, "a lead count this plugin can't see"
+
+    assert campaign["cost"]["measurable"] is False
+    assert campaign["cost"]["denominator"] is None
+
+
+def test_pagination_gathers_every_click_not_just_the_first_page(ctx) -> None:
+    """`_list_all` must page through Core's `limit`/`offset` list route
+    rather than trusting one response — proven here with more clicks than
+    one page (`_LIST_PAGE_SIZE`), not asserted against a mock that would
+    stay green even if the pagination loop were deleted.
+    """
+    client, core = ctx
+    total_clicks = results_routes._LIST_PAGE_SIZE + 37
+    core.campaigns = [_campaign(_CAMPAIGN_A, "High traffic")]
+    core.links = [_link("link-1", _CAMPAIGN_A, is_paid=True)]
+    core.clicks = [_click(f"c{i}", _CAMPAIGN_A, "link-1") for i in range(total_clicks)]
+
+    clicks = client.get("/results").json()["campaigns"][0]["clicks"]
+    assert clicks["total"] == total_clicks
+    assert clicks["paid"] == total_clicks
+
+
+def test_clicks_for_a_deleted_campaign_are_counted_not_silently_dropped(ctx) -> None:
+    """A click naming a campaign this call can't see (deleted after the
+    click landed) must not just vanish from the numbers — it has to show up
+    somewhere, or the total the dashboard implies is quietly wrong."""
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Still live")]
+    core.clicks = [
+        _click("c1", _CAMPAIGN_A, None),
+        _click("c2", _DELETED_CAMPAIGN, None),
+        _click("c3", _DELETED_CAMPAIGN, None),
+    ]
+
+    body = client.get("/results").json()
+    assert body["unattributed_clicks"] == 2
+    assert body["campaigns"][0]["clicks"]["total"] == 1
+    assert len(body["campaigns"]) == 1, "the deleted campaign itself must not appear"
+
+
+def test_multiple_campaigns_do_not_leak_clicks_into_each_other(ctx) -> None:
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "A"), _campaign(_CAMPAIGN_B, "B")]
+    core.links = [
+        _link("link-a", _CAMPAIGN_A, is_paid=True),
+        _link("link-b", _CAMPAIGN_B, is_paid=False),
+    ]
+    core.clicks = [
+        _click("c1", _CAMPAIGN_A, "link-a"),
+        _click("c2", _CAMPAIGN_B, "link-b"),
+        _click("c3", _CAMPAIGN_B, "link-b"),
+    ]
+
+    campaigns = {c["campaign_id"]: c for c in client.get("/results").json()["campaigns"]}
+    assert campaigns[_CAMPAIGN_A]["clicks"]["total"] == 1
+    assert campaigns[_CAMPAIGN_B]["clicks"]["total"] == 2
+
+
+def test_no_campaigns_at_all_is_an_empty_list_not_an_error(ctx) -> None:
+    client, _core = ctx
+    resp = client.get("/results")
+    assert resp.status_code == 200
+    assert resp.json() == {"campaigns": [], "unattributed_clicks": 0}
+
+
+def test_results_requires_the_admin_group() -> None:
+    """The host gates on the Cognito group before this app sees a request
+    (ADR-0011); asserted here the same way every other route in this repo
+    asserts it — no dependency override, so `require_admin` runs for real
+    and rejects the missing bearer token."""
+    app = admin_app.build_app()
+    resp = TestClient(app).get("/results")
+    assert resp.status_code == 401


### PR DESCRIPTION
## What

`GET /results` on the admin app: clicks per campaign (real, paginated,
paid/organic/unknown-channel-type split) plus leads/conversions/cost as an
explicit `UnmeasuredMetric` (never a bare zero) with the reason and, where
known, the denominator a future rate would use.

## Why leads/conversions/cost aren't computed

Investigated the transport: neither `public.demo_requests` nor
`tabsii.lead_source_costs` is reachable from this plugin's internal,
SigV4-signed Core transport today (`require_admin`'s `require_auth` never
accepts the forwarded token; neither table is registered under
`/api/v1/internal/*`). Full mechanism in `results_routes.py`'s module
docstring. Filed the gap as #31 rather than build an unverified cross-domain
call I have no way to confirm reaches anything in this session.

## Boundaries respected

Did not touch `render.py`, `links.py`, `config.py`, `pipeline.py`,
`channel_plan_routes.py`, `image_routes.py`, `principal_client.py`,
`web-admin/`, or `biffo.plugin.json`. `admin_app.py` gains one include
(`StaticFiles` mount still last — asserted by the existing ordering test).

## Not verified

No live deployment to click through — this is unit/integration-tested only
(`uv run pytest`, 242 passed). The `GET /results` route itself has not been
exercised against a real Core.

Refs #7
