### PR TITLE
feat(marketing): M7 as deterministic video assembly, not generative video

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+      # video_assembly.py's determinism tests (tests/test_marketing_video_assembly.py)
+      # skip — not fail — when no `ffmpeg` binary is on PATH, so a runner
+      # image without one would make this job report green having actually
+      # run zero of them. ubuntu-latest ships ffmpeg preinstalled, so this is
+      # a no-op there; it only does real work the day RUNNER_LABEL routes this
+      # repo to a self-hosted image that doesn't (see AGENTS.md #9 — that
+      # switch happens outside this repo's control).
+      - run: command -v ffmpeg >/dev/null || (sudo apt-get update && sudo apt-get install -y ffmpeg)
       - run: uv sync --all-groups
       - run: uv run pytest --cov --cov-report=xml
       - uses: codecov/codecov-action@v5

--- a/src/marketing/video_assembly.py
+++ b/src/marketing/video_assembly.py
@@ -98,6 +98,17 @@ This module shells out to whatever ``ffmpeg`` resolves to on ``PATH``
 in. That is infrastructure this milestone did not add — flagged here
 deliberately rather than discovered at deploy time.
 
+**Needs ffmpeg >= 5.1** — the ``-fps_mode`` option this module passes was
+added in that release (it replaces the older, deprecated ``-vsync``). Several
+widely-used community Lambda ffmpeg layers bundle older static builds that
+predate it; whichever layer gets attached must be checked against this
+before relying on it, or `assemble()` fails every call in production with a
+`VideoAssemblyError` despite passing every test here against a newer local
+binary. Not version-checked at runtime — a fast, loud failure on the very
+first real call is an acceptable way to discover a wrong layer, and probing
+`ffmpeg -version` output on every call would cost real latency for a
+condition that, once the right layer is attached, never recurs.
+
 ## Frame preparation, not just cropping
 
 ``render.py`` is reused for the crop — this module never recomputes an
@@ -142,6 +153,16 @@ _DEFAULT_SECONDS_PER_FRAME = 3.0
 #: epoch is arbitrary — only fixedness matters.
 _FIXED_CREATION_TIME = "1970-01-01T00:00:00.000000Z"
 
+#: A stuck ffmpeg process (pathological input, a wedged bundled binary) must
+#: not block `assemble()` forever — without this, the failure mode is the
+#: Lambda's own function timeout killing the process, which surfaces as an
+#: opaque infra-level timeout instead of the diagnosable `VideoAssemblyError`
+#: this module otherwise guarantees. Generous relative to any clip this
+#: milestone produces (a handful of stills, single-digit seconds each,
+#: single-threaded medium-preset libx264) so a slow-but-healthy encode is
+#: never mistaken for a hang.
+_FFMPEG_TIMEOUT_S = 120
+
 _CAPTION_FONT_SIZE = 28
 _CAPTION_MARGIN = 16
 _CAPTION_TEXT_COLOR = (255, 255, 255, 255)
@@ -155,8 +176,20 @@ class FfmpegNotFoundError(RuntimeError):
 
 
 class VideoAssemblyError(RuntimeError):
-    """ffmpeg ran and exited non-zero. Carries its stderr tail so the actual
+    """ffmpeg ran and either exited non-zero or ran past `_FFMPEG_TIMEOUT_S`
+    and was killed. Carries its stderr tail (or "timed out") so the actual
     encoder failure is visible, not just "ffmpeg failed"."""
+
+
+class InvalidCreativeError(ValueError):
+    """One of `creative_bytes` is not decodable as an image at all (a
+    truncated upload, a wrong content-type). Deliberately a `ValueError`
+    subclass — `assemble`'s documented contract already includes `ValueError`
+    for bad input (an empty list), and undecodable bytes is the same kind of
+    caller mistake, not a new category. Raised instead of letting Pillow's
+    own `UnidentifiedImageError`/`OSError` escape unwrapped, which would be
+    an exception type nothing in this module's documented contract mentions.
+    """
 
 
 def _ffmpeg_path() -> str:
@@ -197,6 +230,30 @@ def _draw_caption(image: Image.Image, text: str) -> None:
     )
 
 
+def _to_opaque_rgb(source: Image.Image) -> Image.Image:
+    """`source` as opaque RGB, compositing any alpha channel over black
+    rather than dropping it.
+
+    mp4/H.264 has no alpha channel, so an RGB frame is required either way —
+    but `Image.convert("RGB")` on an image with transparency (`RGBA`, `LA`,
+    or a palette image with an alpha info entry) does a raw channel copy: it
+    keeps whatever RGB values were stored under the transparent pixels, which
+    for most encoders/tools is undefined content, not "the colour that should
+    show through". A source with real transparency would then render as
+    visibly wrong output — silently, since nothing about a raw channel copy
+    raises. Compositing over a fixed black background (matching the black
+    used for even-dimension padding just below) makes the "what shows where
+    the source was transparent" choice explicit and deterministic instead of
+    inheriting whatever bytes happened to be there.
+    """
+    if source.mode in ("RGBA", "LA") or (source.mode == "P" and "transparency" in source.info):
+        rgba = source.convert("RGBA")
+        background = Image.new("RGB", rgba.size, (0, 0, 0))
+        background.paste(rgba, mask=rgba.getchannel("A"))
+        return background
+    return source.convert("RGB")
+
+
 def _prepare_frame(creative_bytes: bytes, placement: str, *, text: str | None) -> bytes:
     """One placement-cropped, even-dimensioned, optionally captioned PNG
     frame, ready for ffmpeg's ``image2``/concat input.
@@ -205,10 +262,41 @@ def _prepare_frame(creative_bytes: bytes, placement: str, *, text: str | None) -
     byte-identical no-op path — ffmpeg's input needs even dimensions (see the
     module docstring), which `render.py` does not promise, so this cannot
     skip the round-trip the way `render.render` itself does.
+
+    Raises `InvalidCreativeError` if `creative_bytes` (after `render_placement`
+    has cropped or passed it through) is not decodable as an image at all —
+    Pillow's own `UnidentifiedImageError`/`OSError` on a truncated or
+    non-image input is deliberately not left to escape unwrapped (see that
+    error's own docstring).
+
+    Not handled, deliberately out of scope for this milestone, same posture
+    `render.py` takes for EXIF orientation: Adobe-inverted CMYK JPEGs. A CMYK
+    source that already matches `placement`'s ratio takes `render.render`'s
+    no-op path unchanged, and this function's `.convert()` then uses
+    Pillow's non-Adobe-aware CMYK interpretation — visibly wrong colours, not
+    a crash, and not new: `render.py`'s own no-op path already hands back
+    such bytes unmodified for any other consumer to interpret.
     """
-    cropped = render_placement(creative_bytes, placement)
-    with Image.open(io.BytesIO(cropped)) as source:
-        frame = source.convert("RGB")
+    try:
+        # `render_placement` (render.render) is where the FIRST decode
+        # happens — it opens `creative_bytes` itself to read width/height —
+        # so an undecodable creative fails there, not in the `Image.open`
+        # below. Both calls are covered by the same try/except: Pillow
+        # raises `UnidentifiedImageError` (an `OSError` subclass) for
+        # unrecognised bytes, and a plain `OSError` for a truncated file it
+        # partially recognised — both are "this isn't a usable image", not a
+        # bug in this module or in `render.py`.
+        cropped = render_placement(creative_bytes, placement)
+        with Image.open(io.BytesIO(cropped)) as source:
+            frame = _to_opaque_rgb(source)
+    except OSError as exc:
+        # Deliberately just `OSError`, not `ValueError` too:
+        # `UnknownPlacementError` (raised by `render_placement` for a bad
+        # `placement`) is a `ValueError` subclass with nothing to do with
+        # decoding, and must propagate unwrapped for `assemble`'s documented
+        # contract to hold. `PIL.UnidentifiedImageError` — the actual
+        # bad-bytes case this except exists for — is an `OSError` subclass.
+        raise InvalidCreativeError(f"Could not decode a creative as an image: {exc}") from exc
 
     width, height = frame.size
     even_width, even_height = _even(width), _even(height)
@@ -253,15 +341,24 @@ def assemble(
     Deterministic: the same arguments produce byte-identical mp4 bytes, every
     time (see the module docstring's Determinism section).
 
-    Raises `ValueError` for an empty `creative_bytes`,
-    `marketing.render.UnknownPlacementError` for a `placement` outside
-    `definitions.PLACEMENTS` (raised by the first call to `render_placement`
+    Raises `ValueError` for an empty `creative_bytes` or a non-positive
+    `seconds_per_frame`, `InvalidCreativeError` (a `ValueError` subclass) for
+    a creative that is not decodable as an image, `marketing.render.
+    UnknownPlacementError` for a `placement` outside `definitions.PLACEMENTS`
+    (raised by the first call to `render_placement` inside `_prepare_frame`
     below — not re-checked here, so there is exactly one place that decides
     what a valid placement is), `FfmpegNotFoundError` if no ffmpeg binary is
-    available, and `VideoAssemblyError` if ffmpeg runs and fails.
+    available, and `VideoAssemblyError` if ffmpeg runs and fails or runs
+    past `_FFMPEG_TIMEOUT_S`.
     """
     if not creative_bytes:
         raise ValueError("assemble() needs at least one still to compose.")
+    if seconds_per_frame <= 0:
+        # Silently clamped to one frame by `_concat_file_text`'s `max(1,
+        # round(...))` otherwise — a near-zero or negative value is far more
+        # likely a caller's sign error than an intentional flash-frame, and
+        # `creative_bytes` already gets this same fail-fast treatment above.
+        raise ValueError(f"seconds_per_frame must be positive, got {seconds_per_frame!r}.")
 
     ffmpeg = _ffmpeg_path()
 
@@ -322,9 +419,23 @@ def assemble(
         # function created itself under `tmp_path` — nothing here comes from
         # the caller unescaped (placement/text only ever reach Pillow, never
         # the shell), and shell=True is never used.
-        result = subprocess.run(  # noqa: S603
-            command, cwd=tmp_path, capture_output=True, check=False
-        )
+        try:
+            result = subprocess.run(  # noqa: S603
+                command,
+                cwd=tmp_path,
+                capture_output=True,
+                check=False,
+                timeout=_FFMPEG_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # Without this, a wedged ffmpeg blocks assemble() until whatever
+            # calls it times out first — a Lambda's own function timeout,
+            # opaquely, instead of this module's own named error. See
+            # `_FFMPEG_TIMEOUT_S`'s comment for why this bound is generous.
+            raise VideoAssemblyError(
+                f"ffmpeg did not finish within {_FFMPEG_TIMEOUT_S}s and was killed."
+            ) from exc
+
         if result.returncode != 0:
             stderr_tail = result.stderr.decode("utf-8", errors="replace")[-4000:]
             raise VideoAssemblyError(f"ffmpeg exited {result.returncode}: {stderr_tail}")

--- a/src/marketing/video_assembly.py
+++ b/src/marketing/video_assembly.py
@@ -1,0 +1,332 @@
+"""Deterministic video assembly (M7) — the decision this milestone made.
+
+Issue #6 gated M7 on a spike: pick a generative-video provider, produce real
+assets, agree a quality bar and a cost ceiling before writing any code. That
+spike was not run. Instead the owner decided — and this module is the
+record — to build **deterministic assembly** instead of generative video, for
+reasons the issue itself anticipated and ``render.py``'s module docstring
+already argues in miniature for still images:
+
+1. **The renderer this needs already exists and is proven.** ``render.py``
+   (M5) centre-crops one approved creative into every placement's exact
+   ratio with integer arithmetic and byte-identical, no-op-when-possible
+   output. This module reuses it rather than re-solving cropping.
+2. **Cheaper, more controllable, and usually indistinguishable at social
+   sizes** — the issue's own words for what assembly buys over generation.
+3. **Generative video is the least predictable cost in the roadmap**, and
+   would need a provider port, a queue, pre-generation cost estimation and a
+   new failure class — all to produce output whose quality this milestone
+   was never able to agree a bar for, because the spike that would have set
+   one never ran.
+
+So: **no model call anywhere in this module.** It takes the bytes of one or
+more already-approved stills (the same creatives ``render.py`` crops for
+placements) plus optional caption text, and produces a short H.264 mp4 for
+one of ``definitions.PLACEMENTS`` — composed, not generated.
+
+## Mechanism: ffmpeg via subprocess, not a pure-Python encoder
+
+A pure-Python MP4/H.264 encoder is real work with no upside here: ffmpeg is a
+single, well-understood dependency that already does exactly this, correctly,
+and its determinism can be pinned with documented flags (below) rather than
+built from scratch and re-proven. The cost is a **system binary this module
+does not control**: see "Deployment" below.
+
+## Determinism
+
+The same property `render.py` rests on, extended to video: the same input
+stills, the same placement, the same caption text and the same per-frame
+duration must produce **byte-identical** mp4 output, every time — proven
+directly in ``tests/test_marketing_video_assembly.py`` by assembling twice
+and comparing bytes, the same pattern ``test_marketing_render.py`` uses for
+the still-image case. ffmpeg is not deterministic by default; every flag
+below exists to close one specific source of run-to-run drift, found by
+assembling the same input twice and diffing the output until nothing
+differed:
+
+- **No wall-clock metadata.** mp4's ``mvhd``/``tkhd``/``mdhd`` atoms carry a
+  creation/modification timestamp that defaults to "now" — ``-metadata
+  creation_time=...`` pins it to a fixed value (not merely tagging metadata;
+  the mov muxer reads this same value into those atoms). ``-map_metadata -1``
+  strips anything else ffmpeg would otherwise copy from the input.
+- **No run-varying encoder identification.** ``-fflags +bitexact -flags:v
+  +bitexact`` stop libx264 and the mp4 muxer writing a version-carrying
+  encoder tag; without it the output still differs byte-for-byte between
+  ffmpeg builds (never observed to differ between two calls in the *same*
+  process, but bitexact is what makes that a guarantee rather than an
+  accident of this one ffmpeg build).
+- **No thread-count-dependent encoding.** libx264's frame-parallel encoding
+  can make its output depend on how many threads it ran with, which varies
+  with the host's core count — a source of drift that would be invisible on
+  one machine and real across two. ``-threads 1 -x264opts threads=1`` pins
+  single-threaded encoding so the *host's* core count cannot leak into the
+  output.
+- **No per-run frame-count ambiguity.** Rather than lean on the concat
+  demuxer's own ``duration`` directive (which has a well-known quirk: it is
+  silently ignored for the last entry, and stacks unpredictably with output
+  trimming), each still's concat-file entry is the same source frame
+  **repeated** ``round(seconds_per_frame * fps)`` times, with ``-r`` set as
+  an **input** rate. The total duration and frame count are then exact by
+  construction — no directive whose edge behaviour has to be trusted.
+  Confirmed empirically: two runs of an otherwise-identical two-still,
+  six-second assembly produced exactly 144 frames and a 6.000000s duration,
+  byte-identical, whether run from the same temp directory or two different
+  ones a second apart.
+- **No system-font dependency.** Caption text is drawn with Pillow's own
+  embedded bitmap font (``ImageFont.load_default``), never a system font —
+  system font availability and hinting vary by platform, which would make a
+  captioned frame the one thing here that is not reproducible across
+  machines. Confirmed: two independently-drawn captions on identical canvases
+  produce byte-identical PNGs.
+
+Not proven, and not claimed: byte-identical output **across different ffmpeg
+builds/versions**. The bitexact flags close the known sources of
+cross-version drift, but the only thing this module (and its tests) actually
+demonstrates is repeat-call determinism on one ffmpeg binary — which is the
+property "the same input always produces the same output" needs, and the one
+a deployed Lambda actually holds fixed (one bundled binary, not a moving
+target).
+
+## Deployment: this needs a real ffmpeg binary — a Lambda layer, concretely
+
+This module shells out to whatever ``ffmpeg`` resolves to on ``PATH``
+(``shutil.which``) and raises ``FfmpegNotFoundError`` — loudly, at call time
+— if there isn't one. **No Lambda layer for it exists yet in this repo's
+``terraform/``.** A production deployment needs one bundling a static
+``ffmpeg`` binary (several public layers exist, e.g. the
+``ffmpeg-lambda-layer`` project) attached to the Lambda this admin app runs
+in. That is infrastructure this milestone did not add — flagged here
+deliberately rather than discovered at deploy time.
+
+## Frame preparation, not just cropping
+
+``render.py`` is reused for the crop — this module never recomputes an
+aspect ratio or a crop box. But a frame ffmpeg can encode needs two more
+things `render.py` does not promise:
+
+- **Even width and height.** H.264's ``yuv420p`` pixel format cannot
+  represent an odd dimension at all (ffmpeg fails outright, confirmed:
+  ``Invalid argument`` from libx264 on a 401x401 frame with no padding).
+  ``render.py``'s crop can legitimately produce an odd dimension — it has no
+  reason to avoid one, since nothing about a still image requires an even
+  size. This module pads to the nearest even size (black, bottom/right)
+  after the crop, before ffmpeg ever sees the frame.
+- **A caption, optionally**, composited in Pillow rather than ffmpeg's
+  ``drawtext`` filter — see "No system-font dependency" above.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from marketing.render import render as render_placement
+
+#: Fixed so the concat file's frame-repeat count is exact and so the same
+#: value is used everywhere duration math happens. Not configurable per call:
+#: varying it would vary the encoded stream's frame count/timing, which is a
+#: legitimate reason for two assemblies to differ — but nothing in this
+#: milestone needs that yet, and a hardcoded value keeps the determinism
+#: claim about *what this module does today*, not what it could be asked to.
+_FPS = 24
+
+#: How long a single still is shown, absent an explicit ``seconds_per_frame``.
+_DEFAULT_SECONDS_PER_FRAME = 3.0
+
+#: Pinned into the mp4's mvhd/tkhd/mdhd atoms (see module docstring). The
+#: epoch is arbitrary — only fixedness matters.
+_FIXED_CREATION_TIME = "1970-01-01T00:00:00.000000Z"
+
+_CAPTION_FONT_SIZE = 28
+_CAPTION_MARGIN = 16
+_CAPTION_TEXT_COLOR = (255, 255, 255, 255)
+_CAPTION_BAND_COLOR = (0, 0, 0, 170)
+
+
+class FfmpegNotFoundError(RuntimeError):
+    """No ``ffmpeg`` binary on ``PATH``. See the module docstring's
+    "Deployment" section — this is a packaging gap to fix, not a bug in this
+    module."""
+
+
+class VideoAssemblyError(RuntimeError):
+    """ffmpeg ran and exited non-zero. Carries its stderr tail so the actual
+    encoder failure is visible, not just "ffmpeg failed"."""
+
+
+def _ffmpeg_path() -> str:
+    resolved = shutil.which("ffmpeg")
+    if resolved is None:
+        raise FfmpegNotFoundError(
+            "ffmpeg is not on PATH. This module shells out to a system ffmpeg "
+            "binary for deterministic mp4 encoding (see video_assembly.py's "
+            "module docstring) — the Lambda package deploying this plugin "
+            "must bundle one (e.g. a Lambda layer); nothing in this repo "
+            "does that yet."
+        )
+    return resolved
+
+
+def _even(value: int) -> int:
+    """`value`, rounded up to the nearest even number."""
+    return value + (value % 2)
+
+
+def _draw_caption(image: Image.Image, text: str) -> None:
+    """Composite `text` onto `image` in place, bottom-anchored on a
+    translucent band. Pillow's embedded bitmap font only — see the module
+    docstring's "No system-font dependency" for why.
+    """
+    draw = ImageDraw.Draw(image, "RGBA")
+    font = ImageFont.load_default(size=_CAPTION_FONT_SIZE)
+    width, height = image.size
+    _left, top, _right, bottom = draw.textbbox((0, 0), text, font=font)
+    text_height = bottom - top
+    band_top = max(0, height - text_height - 2 * _CAPTION_MARGIN)
+    draw.rectangle([(0, band_top), (width, height)], fill=_CAPTION_BAND_COLOR)
+    draw.text(
+        (_CAPTION_MARGIN, band_top + _CAPTION_MARGIN),
+        text,
+        font=font,
+        fill=_CAPTION_TEXT_COLOR,
+    )
+
+
+def _prepare_frame(creative_bytes: bytes, placement: str, *, text: str | None) -> bytes:
+    """One placement-cropped, even-dimensioned, optionally captioned PNG
+    frame, ready for ffmpeg's ``image2``/concat input.
+
+    Always decodes and re-saves through Pillow, even on `render_placement`'s
+    byte-identical no-op path — ffmpeg's input needs even dimensions (see the
+    module docstring), which `render.py` does not promise, so this cannot
+    skip the round-trip the way `render.render` itself does.
+    """
+    cropped = render_placement(creative_bytes, placement)
+    with Image.open(io.BytesIO(cropped)) as source:
+        frame = source.convert("RGB")
+
+    width, height = frame.size
+    even_width, even_height = _even(width), _even(height)
+    if (even_width, even_height) != (width, height):
+        padded = Image.new("RGB", (even_width, even_height), (0, 0, 0))
+        padded.paste(frame, (0, 0))
+        frame = padded
+
+    if text:
+        _draw_caption(frame, text)
+
+    buffer = io.BytesIO()
+    # Same fixed encoder parameters as render.py, for the same reason: no
+    # optimize pass and a fixed compress_level keep the PNG encode itself
+    # from being a source of drift, independent of ffmpeg entirely.
+    frame.save(buffer, format="PNG", optimize=False, compress_level=6)
+    return buffer.getvalue()
+
+
+def _concat_file_text(frame_names: list[str], seconds_per_frame: float) -> str:
+    """The ffmpeg concat demuxer script: each frame's filename repeated
+    ``round(seconds_per_frame * _FPS)`` times, no ``duration`` directive.
+    See the module docstring's "No per-run frame-count ambiguity" for why
+    repetition is used instead of ``duration``.
+    """
+    repeats = max(1, round(seconds_per_frame * _FPS))
+    lines = [f"file '{name}'" for name in frame_names for _ in range(repeats)]
+    return "\n".join(lines) + "\n"
+
+
+def assemble(
+    creative_bytes: list[bytes],
+    placement: str,
+    *,
+    text: str | None = None,
+    seconds_per_frame: float = _DEFAULT_SECONDS_PER_FRAME,
+) -> bytes:
+    """An mp4 for `placement`, composed from one or more already-approved
+    stills in `creative_bytes` (shown in order, each for `seconds_per_frame`
+    seconds) with `text` optionally burned in as a caption on every frame.
+
+    Deterministic: the same arguments produce byte-identical mp4 bytes, every
+    time (see the module docstring's Determinism section).
+
+    Raises `ValueError` for an empty `creative_bytes`,
+    `marketing.render.UnknownPlacementError` for a `placement` outside
+    `definitions.PLACEMENTS` (raised by the first call to `render_placement`
+    below — not re-checked here, so there is exactly one place that decides
+    what a valid placement is), `FfmpegNotFoundError` if no ffmpeg binary is
+    available, and `VideoAssemblyError` if ffmpeg runs and fails.
+    """
+    if not creative_bytes:
+        raise ValueError("assemble() needs at least one still to compose.")
+
+    ffmpeg = _ffmpeg_path()
+
+    frames = [_prepare_frame(b, placement, text=text) for b in creative_bytes]
+
+    with tempfile.TemporaryDirectory(prefix="marketing-video-assembly-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        frame_names: list[str] = []
+        for index, frame in enumerate(frames):
+            name = f"frame_{index:04d}.png"
+            (tmp_path / name).write_bytes(frame)
+            frame_names.append(name)
+
+        concat_path = tmp_path / "concat.txt"
+        concat_path.write_text(_concat_file_text(frame_names, seconds_per_frame))
+
+        output_path = tmp_path / "output.mp4"
+        command = [
+            ffmpeg,
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-r",
+            str(_FPS),
+            "-i",
+            str(concat_path),
+            "-fps_mode",
+            "cfr",
+            "-pix_fmt",
+            "yuv420p",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-threads",
+            "1",
+            "-x264opts",
+            "threads=1",
+            "-movflags",
+            "+faststart",
+            "-map_metadata",
+            "-1",
+            "-fflags",
+            "+bitexact",
+            "-flags:v",
+            "+bitexact",
+            "-metadata",
+            f"creation_time={_FIXED_CREATION_TIME}",
+            str(output_path),
+        ]
+        # Every element of `command` is either a literal flag or a path this
+        # function created itself under `tmp_path` — nothing here comes from
+        # the caller unescaped (placement/text only ever reach Pillow, never
+        # the shell), and shell=True is never used.
+        result = subprocess.run(  # noqa: S603
+            command, cwd=tmp_path, capture_output=True, check=False
+        )
+        if result.returncode != 0:
+            stderr_tail = result.stderr.decode("utf-8", errors="replace")[-4000:]
+            raise VideoAssemblyError(f"ffmpeg exited {result.returncode}: {stderr_tail}")
+
+        return output_path.read_bytes()

--- a/tests/test_marketing_video_assembly.py
+++ b/tests/test_marketing_video_assembly.py
@@ -1,0 +1,255 @@
+"""Deterministic video assembly (video_assembly.py) — the core of M7.
+
+The property the whole module rests on is stated in its own docstring:
+**assembled, never generated**, and — extending `render.py`'s own headline
+claim — the same inputs produce byte-identical mp4 output every time.
+`test_assembling_twice_is_byte_identical` and its siblings below are the
+whole point of this file; everything else checks that the composed video is
+actually what was asked for (right placement ratio, right number of stills,
+caption present/absent, failure on bad input).
+
+Skipped, not failed, when no `ffmpeg` binary is on `PATH` — this module
+shells out to a system binary this repo does not control (see
+`video_assembly.py`'s "Deployment" docstring section), and a CI runner or a
+contributor's machine without it should not read as this module being
+broken.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+
+import pytest
+from PIL import Image
+
+from marketing.definitions import PLACEMENTS
+from marketing.render import UnknownPlacementError, _center_crop_box
+from marketing.video_assembly import (
+    FfmpegNotFoundError,
+    VideoAssemblyError,
+    _concat_file_text,
+    _even,
+    assemble,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None,
+    reason="ffmpeg is not on PATH — see video_assembly.py's Deployment section.",
+)
+
+
+def _png_bytes(width: int, height: int, color: tuple[int, int, int]) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _probe(mp4_bytes: bytes) -> dict[str, str]:
+    """A handful of ffprobe fields, parsed from `-of default=nk=1`, keyed by
+    the order requested. Used instead of a full JSON parse because every
+    call site here wants exactly one or two scalar fields.
+    """
+    import subprocess
+    import tempfile
+    from pathlib import Path
+
+    ffprobe = shutil.which("ffprobe")
+    assert ffprobe is not None, "ffprobe must be on PATH alongside ffmpeg for this test to run"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "probe.mp4"
+        path.write_bytes(mp4_bytes)
+        result = subprocess.run(  # noqa: S603
+            [
+                ffprobe,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,nb_frames:format=duration",
+                "-of",
+                "default=noprint_wrappers=1",
+                str(path),
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    fields: dict[str, str] = {}
+    for line in result.stdout.strip().splitlines():
+        key, _, value = line.partition("=")
+        fields[key] = value
+    return fields
+
+
+# --- Determinism: the property the whole module rests on -------------------
+
+
+def test_assembling_twice_is_byte_identical() -> None:
+    """The headline claim, extended from render.py's still-image case to a
+    real encode: two stills, a caption, composed twice, must match exactly —
+    not merely play back the same, but be the same bytes."""
+    stills = [_png_bytes(320, 320, (200, 40, 40)), _png_bytes(320, 320, (40, 200, 40))]
+
+    first = assemble(stills, "feed_1x1", text="Byte for byte.", seconds_per_frame=0.5)
+    second = assemble(stills, "feed_1x1", text="Byte for byte.", seconds_per_frame=0.5)
+
+    assert first == second
+
+
+def test_assembling_is_deterministic_across_every_placement() -> None:
+    stills = [_png_bytes(500, 300, (10, 10, 200))]
+    for placement in PLACEMENTS:
+        assert assemble(stills, placement, seconds_per_frame=0.5) == assemble(
+            stills, placement, seconds_per_frame=0.5
+        )
+
+
+def test_a_single_still_with_no_caption_is_deterministic() -> None:
+    """The simplest possible call — one frame, no text — is still pinned:
+    proves determinism does not depend on the multi-frame or caption paths."""
+    stills = [_png_bytes(400, 400, (5, 5, 5))]
+
+    first = assemble(stills, "feed_1x1", seconds_per_frame=0.25)
+    second = assemble(stills, "feed_1x1", seconds_per_frame=0.25)
+
+    assert first == second
+
+
+def test_odd_dimensioned_source_still_assembles_deterministically() -> None:
+    """render.py's crop can legitimately hand back an odd width/height (it
+    has no reason to avoid one) — this is the case the even-padding step
+    exists for, and it must not reintroduce nondeterminism of its own."""
+    stills = [_png_bytes(401, 401, (90, 90, 90))]
+
+    first = assemble(stills, "feed_1x1", seconds_per_frame=0.25)
+    second = assemble(stills, "feed_1x1", seconds_per_frame=0.25)
+
+    assert first == second
+
+
+# --- The composed video is actually what was asked for ---------------------
+
+
+def test_output_is_cropped_to_the_placements_exact_ratio() -> None:
+    """Reuses render.py for the crop — this proves the crop's exact pixel
+    dimensions survive into the encoded stream, at each placement, up to the
+    even-dimension padding `_even` applies afterward (H.264's yuv420p cannot
+    represent an odd size at all — see the module docstring). Expected
+    dimensions are computed the same way `render.py`'s own crop-box tests do
+    (`_center_crop_box` directly), then padded, rather than asserting the
+    ratio survives exactly — it provably cannot when the crop box itself is
+    odd-sized, which `_center_crop_box` legitimately produces."""
+    source_w, source_h = 900, 500
+    stills = [_png_bytes(source_w, source_h, (0, 0, 0))]
+
+    for placement, (ratio_w, ratio_h) in {
+        "feed_1x1": (1, 1),
+        "portrait_4x5": (4, 5),
+        "story_9x16": (9, 16),
+    }.items():
+        left, top, right, bottom = _center_crop_box(source_w, source_h, ratio_w, ratio_h)
+        expected_w = _even(right - left)
+        expected_h = _even(bottom - top)
+
+        out = assemble(stills, placement, seconds_per_frame=0.25)
+        probe = _probe(out)
+        width, height = int(probe["width"]), int(probe["height"])
+
+        assert (width, height) == (expected_w, expected_h), (
+            f"{placement}: got {width}x{height}, expected {expected_w}x{expected_h}"
+        )
+
+
+def test_multiple_stills_extend_the_total_duration() -> None:
+    stills_one = [_png_bytes(300, 300, (1, 1, 1))]
+    stills_three = [
+        _png_bytes(300, 300, (1, 1, 1)),
+        _png_bytes(300, 300, (2, 2, 2)),
+        _png_bytes(300, 300, (3, 3, 3)),
+    ]
+
+    one = _probe(assemble(stills_one, "feed_1x1", seconds_per_frame=1.0))
+    three = _probe(assemble(stills_three, "feed_1x1", seconds_per_frame=1.0))
+
+    assert float(three["duration"]) == pytest.approx(3 * float(one["duration"]), rel=0.05)
+
+
+def test_seconds_per_frame_is_honoured_in_the_encoded_duration() -> None:
+    stills = [_png_bytes(300, 300, (7, 7, 7))]
+
+    out = assemble(stills, "feed_1x1", seconds_per_frame=2.0)
+    probe = _probe(out)
+
+    assert float(probe["duration"]) == pytest.approx(2.0, abs=0.1)
+
+
+# --- Bad input ---------------------------------------------------------
+
+
+def test_an_unknown_placement_raises_the_same_error_render_does() -> None:
+    """Delegated to render.py's own error, deliberately not re-implemented —
+    see the module docstring."""
+    stills = [_png_bytes(100, 100, (0, 0, 0))]
+    with pytest.raises(UnknownPlacementError):
+        assemble(stills, "billboard_21x9")
+
+
+def test_an_empty_creative_list_raises_rather_than_producing_nothing() -> None:
+    with pytest.raises(ValueError, match="at least one still"):
+        assemble([], "feed_1x1")
+
+
+# --- Failure modes this module names explicitly -----------------------
+
+
+def test_missing_ffmpeg_raises_a_named_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `video_assembly` does `import shutil` and calls `shutil.which(...)`, so
+    # patching the `shutil` module's own attribute (the same module object
+    # both files import) is enough — no need to reach into the other module.
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    stills = [_png_bytes(100, 100, (0, 0, 0))]
+    with pytest.raises(FfmpegNotFoundError):
+        assemble(stills, "feed_1x1")
+
+
+def test_ffmpeg_failure_surfaces_as_video_assembly_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-zero ffmpeg exit must not be swallowed — simulated by pointing
+    `_ffmpeg_path` at a binary that always fails (`false`), proving the
+    return-code check actually fires rather than only being reachable in
+    theory."""
+    import marketing.video_assembly as video_assembly_module
+
+    false_binary = shutil.which("false")
+    assert false_binary is not None, "the `false` binary must exist for this test to mean anything"
+    monkeypatch.setattr(video_assembly_module, "_ffmpeg_path", lambda: false_binary)
+
+    stills = [_png_bytes(100, 100, (0, 0, 0))]
+    with pytest.raises(VideoAssemblyError):
+        assemble(stills, "feed_1x1")
+
+
+# --- Frame-count arithmetic directly: exact, no drift from timing edge cases
+
+
+def test_even_rounds_up_only_when_needed() -> None:
+    assert _even(400) == 400
+    assert _even(401) == 402
+    assert _even(0) == 0
+
+
+def test_concat_file_text_repeats_each_frame_the_exact_computed_count() -> None:
+    """No `duration` directive — see the module docstring's "No per-run
+    frame-count ambiguity". Each name must appear exactly
+    `round(seconds_per_frame * _FPS)` times, in order."""
+    text = _concat_file_text(["a.png", "b.png"], seconds_per_frame=0.5)
+    lines = text.strip().splitlines()
+
+    # _FPS is 24; 0.5s * 24fps = 12 repeats per frame.
+    assert lines.count("file 'a.png'") == 12
+    assert lines.count("file 'b.png'") == 12
+    assert lines[:12] == ["file 'a.png'"] * 12
+    assert lines[12:] == ["file 'b.png'"] * 12

--- a/tests/test_marketing_video_assembly.py
+++ b/tests/test_marketing_video_assembly.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import shutil
+from typing import cast
 
 import pytest
 from PIL import Image
@@ -27,6 +28,7 @@ from marketing.definitions import PLACEMENTS
 from marketing.render import UnknownPlacementError, _center_crop_box
 from marketing.video_assembly import (
     FfmpegNotFoundError,
+    InvalidCreativeError,
     VideoAssemblyError,
     _concat_file_text,
     _even,
@@ -82,6 +84,40 @@ def _probe(mp4_bytes: bytes) -> dict[str, str]:
         key, _, value = line.partition("=")
         fields[key] = value
     return fields
+
+
+def _first_frame_colors(mp4_bytes: bytes) -> set[tuple[int, int, int]]:
+    """The distinct RGB colours present in the encoded video's first frame,
+    extracted via ffmpeg back to a PNG and read with Pillow — for asserting
+    what the encoder actually wrote, not just what was asked for."""
+    import subprocess
+    import tempfile
+    from pathlib import Path
+
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg is not None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        video_path = Path(tmp) / "in.mp4"
+        video_path.write_bytes(mp4_bytes)
+        frame_path = Path(tmp) / "frame.png"
+        subprocess.run(  # noqa: S603
+            [
+                ffmpeg,
+                "-y",
+                "-loglevel",
+                "error",
+                "-i",
+                str(video_path),
+                "-frames:v",
+                "1",
+                str(frame_path),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        with Image.open(frame_path) as img:
+            return {cast("tuple[int, int, int]", pixel) for pixel in img.convert("RGB").getdata()}
 
 
 # --- Determinism: the property the whole module rests on -------------------
@@ -202,6 +238,39 @@ def test_an_empty_creative_list_raises_rather_than_producing_nothing() -> None:
         assemble([], "feed_1x1")
 
 
+def test_undecodable_creative_bytes_raise_invalid_creative_error() -> None:
+    """Not a PIL.UnidentifiedImageError/OSError escaping unwrapped — wrapped
+    into this module's own documented error type."""
+    with pytest.raises(InvalidCreativeError):
+        assemble([b"this is not an image"], "feed_1x1")
+
+
+@pytest.mark.parametrize("seconds_per_frame", [0.0, -1.0, -0.001])
+def test_non_positive_seconds_per_frame_raises(seconds_per_frame: float) -> None:
+    stills = [_png_bytes(100, 100, (0, 0, 0))]
+    with pytest.raises(ValueError, match="seconds_per_frame must be positive"):
+        assemble(stills, "feed_1x1", seconds_per_frame=seconds_per_frame)
+
+
+def test_transparent_source_is_composited_over_black_not_channel_dropped() -> None:
+    """A raw `.convert('RGB')` on an RGBA image keeps whatever RGB values sit
+    under the transparent pixels — for a freshly-created `Image.new('RGBA',
+    ..., (0, 0, 0, 0))` that happens to be black anyway, so this test uses a
+    transparent pixel whose RGB channels are deliberately something else
+    (white) to prove the encoded frame shows the composited background
+    (black, matching the even-padding colour) and not the stored-but-hidden
+    white."""
+    transparent_white = Image.new("RGBA", (300, 300), (255, 255, 255, 0))
+    buffer = io.BytesIO()
+    transparent_white.save(buffer, format="PNG")
+
+    out = assemble([buffer.getvalue()], "feed_1x1", seconds_per_frame=0.25)
+    probe_colors = _first_frame_colors(out)
+
+    assert (255, 255, 255) not in probe_colors, "transparent white must not leak through"
+    assert (0, 0, 0) in probe_colors, "transparent pixels must composite onto the black background"
+
+
 # --- Failure modes this module names explicitly -----------------------
 
 
@@ -229,6 +298,29 @@ def test_ffmpeg_failure_surfaces_as_video_assembly_error(monkeypatch: pytest.Mon
 
     stills = [_png_bytes(100, 100, (0, 0, 0))]
     with pytest.raises(VideoAssemblyError):
+        assemble(stills, "feed_1x1")
+
+
+def test_ffmpeg_timeout_surfaces_as_video_assembly_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged ffmpeg must not block assemble() forever — simulated by
+    making `subprocess.run` itself raise `TimeoutExpired`, proving the
+    `except` around it actually fires rather than only being reachable in
+    theory. Not exercised by actually waiting `_FFMPEG_TIMEOUT_S` seconds:
+    that would make this the slowest test in the suite for no extra
+    coverage."""
+    import subprocess
+
+    import marketing.video_assembly as video_assembly_module
+
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["ffmpeg"], timeout=video_assembly_module._FFMPEG_TIMEOUT_S
+        )
+
+    monkeypatch.setattr(video_assembly_module.subprocess, "run", _raise_timeout)
+
+    stills = [_png_bytes(100, 100, (0, 0, 0))]
+    with pytest.raises(VideoAssemblyError, match="did not finish"):
         assemble(stills, "feed_1x1")
 
 


### PR DESCRIPTION
Remaining scope of M5 (#4) beyond the already-merged deterministic form-factor renderer (#15, "the renderer is finished and merged — do not rebuild it").

## Copy generation (fourth pipeline stage)
A `copy` artefact kind, wired through the exact `pending -> proposed -> approved | rejected` gate and zero-citation guard M3/M4 already established — no second pipeline shape. `start_copy_route` (`copy_routes.py`) requires both the positioning and channel-plan artefacts approved, and the copy agent writes one `ChannelCopy` per channel in the approved channel plan, grounded in and citing the positioning's pillars/CTAs. Generic `get_artefact_route`/`approve_artefact_route`/`reject_artefact_route` in `admin_app.py` pick it up once it's a known kind (`_PIPELINE_ARTEFACT_KINDS`, `_SINGLE_RUN_ADVANCERS`).

Design call worth flagging: "per selected channel" is read here as "per-channel" (each channel in the channel plan gets its own tailored copy), matching M3/M4's shape of always processing the full approved upstream artefact rather than a caller-chosen subset. An operator-selectable subset is a request-body addition a future milestone could make without changing the pipeline shape.

## The distribution pack (`pack_routes.py`, `GET /campaigns/{id}/pack`)
- **Assets** — the approved source creative plus a render of every `PLACEMENTS` entry, via `render.render` (untouched). Renders/uploads a placement at most once per campaign; every later pack request reuses the stored `marketing_asset` row.
- **Copy** — the latest **approved** `copy` artefact's channels, verbatim.
- **Tracked links** — one per copy channel, minted with `links.mint_token`/`destination_with_utms`/`tracked_url` (untouched) and reused on later requests rather than re-minted.
- **`guidance`** — `marketing_campaign.guidance`, verbatim.

## What I did not build or verify
- No frontend. `web-admin/` is untouched, per the boundary — this is the API a frontend would consume.
- The day-0 design's two device warnings (clipboard write silently failing on mobile Safari; iOS `<a download>` on video opening a preview instead of saving) are **unverified** — there is no device in this loop and no download/copy UI in this change to even exercise them. Issue #4's own "done when" requires a real-phone check, which is why this stays `Refs`, not `Closes`.

259 passed (`uv run pytest`), plus `ruff check`/`ruff format --check`/`pyright`/`sh scripts/biffo.sh verify` all clean.

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
