### PR TITLE
fix(marketing): authenticate the admin panel with the portal's Cognito session

### DIFF
--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "amazon-cognito-identity-js": "^6.3.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/web-admin/pnpm-lock.yaml
+++ b/web-admin/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      amazon-cognito-identity-js:
+        specifier: ^6.3.12
+        version: 6.3.20
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -65,6 +68,19 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@aws-crypto/sha256-js@1.2.2':
+    resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
+
+  '@aws-crypto/util@1.2.2':
+    resolution: {integrity: sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -545,6 +561,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -720,6 +740,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  amazon-cognito-identity-js@6.3.20:
+    resolution: {integrity: sha512-akaaLpDqz4i0m2XG4+x+XcHAlboRt3rydVrSiEFCKvaGZSmZdvnYW4SXqm2OGeVdZK0R1nIXjp8yEpID3rHC5Q==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -753,6 +776,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.11.13:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
     engines: {node: '>=6.0.0'}
@@ -769,6 +795,9 @@ packages:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -929,6 +958,9 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  fast-base64-decode@1.0.0:
+    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -999,6 +1031,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1030,8 +1065,17 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1122,6 +1166,15 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -1310,6 +1363,9 @@ packages:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -1319,6 +1375,12 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1338,6 +1400,9 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
 
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
@@ -1425,6 +1490,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -1441,6 +1509,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1493,6 +1564,27 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@aws-crypto/sha256-js@1.2.2':
+    dependencies:
+      '@aws-crypto/util': 1.2.2
+      '@aws-sdk/types': 3.974.2
+      tslib: 1.14.1
+
+  '@aws-crypto/util@1.2.2':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -1867,6 +1959,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -2104,6 +2200,16 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  amazon-cognito-identity-js@6.3.20:
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0
+      js-cookie: 3.0.8
+    transitivePeerDependencies:
+      - encoding
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -2126,6 +2232,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.11.13: {}
 
   brace-expansion@1.1.18:
@@ -2144,6 +2252,12 @@ snapshots:
       electron-to-chromium: 1.5.403
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   cac@6.7.14: {}
 
@@ -2325,6 +2439,8 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  fast-base64-decode@1.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -2386,6 +2502,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -2407,7 +2525,18 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
+
+  isomorphic-unfetch@3.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -2498,6 +2627,10 @@ snapshots:
   nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.53: {}
 
@@ -2675,6 +2808,8 @@ snapshots:
     dependencies:
       tldts: 6.1.86
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -2682,6 +2817,10 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@1.14.1: {}
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -2701,6 +2840,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@8.3.0: {}
+
+  unfetch@4.2.0: {}
 
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
@@ -2791,6 +2932,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -2803,6 +2946,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -1,11 +1,26 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { listCampaigns } from './api'
+import * as auth from './auth'
 
-afterEach(() => vi.unstubAllGlobals())
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/** The admin panel runs behind the portal's shared Cognito session; these tests
+ * stub it rather than standing up a real pool. */
+function stubSession(jwt: string | null = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue(
+    jwt === null
+      ? null
+      : ({ getIdToken: () => ({ getJwtToken: () => jwt }) } as never),
+  )
+}
 
 describe('listCampaigns', () => {
   it('calls the plugin API relative to the origin, not an absolute host', async () => {
+    stubSession()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -20,6 +35,7 @@ describe('listCampaigns', () => {
     // A body can be an HTML error page or an authorization message. Rendering
     // it is how another plugin showed `{"detail":"Administrator access
     // required"}` where its content belonged.
+    stubSession()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -34,7 +50,31 @@ describe('listCampaigns', () => {
   })
 
   it('returns an empty list when the body is not an array', async () => {
+    stubSession()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }))
     await expect(listCampaigns()).resolves.toEqual([])
+  })
+})
+
+describe('listCampaigns authorization', () => {
+  it('sends the Cognito id token as a bearer, not cookies', async () => {
+    // The first version used `credentials: 'include'`. API Gateway's
+    // /api/v1/plugins/* route is JWT-authorized, so every call 401'd and the
+    // panel rendered "Could not load campaigns: request failed (401)".
+    stubSession('abc123')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await listCampaigns()
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer abc123')
+    expect(init.credentials).toBeUndefined()
+  })
+
+  it('says plainly that the caller is not signed in on a 401', async () => {
+    stubSession(null)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }))
+    await expect(listCampaigns()).rejects.toThrow(/not signed in/)
   })
 })

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -2,10 +2,23 @@
  *
  * Same-origin and relative: this app is served from
  * `/api/v1/plugins/marketing/admin/`, so the API sits one level up at
- * `/api/v1/plugins/marketing/`. Hard-coding an absolute origin here would
- * break the moment the instance's domain differs, which is every instance
- * other than the one it was written on.
+ * `/api/v1/plugins/marketing/`. Hard-coding an absolute origin would break on
+ * every instance but the one it was written on.
+ *
+ * ## Why the Authorization header, and not cookies
+ *
+ * The first version of this file used `credentials: 'include'`, which sends
+ * cookies. API Gateway's `/api/v1/plugins/*` route is JWT-authorized, so a
+ * cookie is not a credential it recognises: every call came back 401 and the
+ * panel rendered "Could not load campaigns: request failed (401)".
+ *
+ * The estate authenticates with a Cognito ID token in `Authorization: Bearer`,
+ * resolved from the portal's shared session — `auth.ts`/`identity.ts` here are
+ * idea-scout's, copied rather than rewritten, because this is exactly the part
+ * that should not be reinvented per plugin.
  */
+
+import { getCurrentSession } from './auth'
 
 export interface Campaign {
   id: string
@@ -17,12 +30,22 @@ export interface Campaign {
 const BASE = '/api/v1/plugins/marketing'
 
 export async function listCampaigns(): Promise<Campaign[]> {
-  const response = await fetch(`${BASE}/campaigns`, { credentials: 'include' })
+  const session = await getCurrentSession()
+  const idToken = session?.getIdToken().getJwtToken() ?? null
+
+  const response = await fetch(`${BASE}/campaigns`, {
+    headers: {
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+    },
+  })
 
   if (!response.ok) {
-    // The status, not the body. A body can be an HTML error page — rendering
-    // it into the message is how another plugin ended up showing
-    // `{"detail":"Administrator access required"}` where its content belonged.
+    // The status, not the body. A body can be an HTML error page — rendering it
+    // is how another plugin displayed `{"detail":"Administrator access
+    // required"}` where its content belonged.
+    if (response.status === 401) {
+      throw new Error('not signed in (401) — sign in to the portal, then reload')
+    }
     throw new Error(`request failed (${response.status})`)
   }
 

--- a/web-admin/src/lib/auth.ts
+++ b/web-admin/src/lib/auth.ts
@@ -1,0 +1,61 @@
+import {
+  CognitoUserPool,
+  type CognitoUserSession,
+  type ICognitoUserPoolData,
+} from 'amazon-cognito-identity-js'
+
+import { pruneForeignCognitoCredentials } from './cognito-hygiene'
+import { resolveCoreIdentity } from './identity'
+
+// SHARED-SESSION INVARIANT (ADR-0007), mirroring the sibling skeleton's auth.ts.
+//
+// This app NEVER signs anyone in — the core portal owns authentication. It only
+// READS the session the portal already established, which works because it points
+// at the SAME Cognito User Pool / App Client as the portal (resolved at runtime
+// from identity.ts). Same origin + one App Client means amazon-cognito-identity-js's
+// localStorage keys (keyed by Client ID, not path) carry the portal's session over
+// here for free. Do NOT point at a different pool/client (breaks SSO), and do NOT
+// add signIn/signOut here (a second login path bypasses the portal).
+//
+// The pool is built lazily and memoised: a missing identity resolves to null →
+// "signed out", never a hard crash.
+
+let userPool: CognitoUserPool | null = null
+
+async function getUserPool(): Promise<CognitoUserPool | null> {
+  if (userPool) return userPool
+  const identity = await resolveCoreIdentity()
+  if (!identity) return null
+  // Once per page load, and only with a resolved client id: drop credentials
+  // left behind by pools this deployment no longer uses (biffo-template#834).
+  // The portal and the sibling skeleton do the same; this origin is shared, so
+  // whichever app loads first does the cleaning.
+  pruneForeignCognitoCredentials(identity.clientId)
+  const poolData: ICognitoUserPoolData = {
+    UserPoolId: identity.userPoolId,
+    ClientId: identity.clientId,
+  }
+  userPool = new CognitoUserPool(poolData)
+  return userPool
+}
+
+/** The shared portal session, or null if there isn't a valid one (→ redirect to login). */
+export async function getCurrentSession(): Promise<CognitoUserSession | null> {
+  const pool = await getUserPool()
+  if (!pool) return null
+  return new Promise((resolve) => {
+    const user = pool.getCurrentUser()
+    if (!user) {
+      resolve(null)
+      return
+    }
+    user.getSession((err: Error | null, session: CognitoUserSession | null) => {
+      resolve(err ?? !session?.isValid() ? null : session)
+    })
+  })
+}
+
+/** Test-only: reset the memoised pool. */
+export function __resetUserPoolForTests(): void {
+  userPool = null
+}

--- a/web-admin/src/lib/cognito-hygiene.ts
+++ b/web-admin/src/lib/cognito-hygiene.ts
@@ -1,0 +1,60 @@
+// Removing Cognito credentials belonging to pools this deployment no longer uses.
+//
+// `amazon-cognito-identity-js` stores tokens under keys shaped
+// `CognitoIdentityServiceProvider.<ClientId>.<username>.<tokenType>` and reads
+// them back scoped by Client ID. Replacing a user pool therefore does not clear
+// the old one's keys: they are simply never read again, and they accumulate for
+// as long as the browser profile lives. `dev.biffo.io` was measured carrying
+// four pools' credentials — three of them dead — where AWS has one pool and one
+// client (biffo-template#834).
+//
+// What this is NOT: a fix for a wrong-identity read. Because every consumer
+// resolves its pool from the runtime identity document (#403) and lets
+// amazon-cognito-identity-js scope the lookup by Client ID, a stale pool's
+// tokens are never enumerated and never selected. That claim was made and
+// withdrawn on #834.
+//
+// What it IS: dead bearer tokens for real identities should not sit in browser
+// storage forever, and any future code that enumerates
+// `CognitoIdentityServiceProvider.*` — a debug helper, a sign-out-everywhere
+// action, a migration — should not inherit a growing minefield.
+
+/** `CognitoIdentityServiceProvider.<clientId>.<rest…>` — capture the client id. */
+const COGNITO_KEY = /^CognitoIdentityServiceProvider\.([^.]+)\./
+
+/**
+ * Delete every Cognito credential key whose Client ID is not `clientId`.
+ *
+ * Returns the keys removed, so a caller can log or assert on them. A no-op when
+ * `clientId` is falsy — an unresolved identity must never be treated as "no
+ * client matches", which would delete the live session along with the residue.
+ *
+ * Storage is injected for tests and to stay safe where there is none: this
+ * module is imported during `next build`'s prerender in Node, where
+ * `localStorage` does not exist.
+ */
+export function pruneForeignCognitoCredentials(
+  clientId: string | null | undefined,
+  storage: Storage | undefined = typeof localStorage === 'undefined' ? undefined : localStorage,
+): string[] {
+  if (!clientId || !storage) return []
+
+  // Snapshot the keys first, via the Storage API rather than Object.keys:
+  // removeItem() mutates the live key set, so index-based iteration would skip
+  // entries as it shrinks and leave half the residue behind.
+  const keys: string[] = []
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i)
+    if (key !== null) keys.push(key)
+  }
+
+  const removed: string[] = []
+  for (const key of keys) {
+    const match = COGNITO_KEY.exec(key)
+    if (match && match[1] !== clientId) {
+      storage.removeItem(key)
+      removed.push(key)
+    }
+  }
+  return removed
+}

--- a/web-admin/src/lib/identity.ts
+++ b/web-admin/src/lib/identity.ts
@@ -1,0 +1,73 @@
+// Runtime core identity — same mechanism as the founder-facing web/'s own
+// identity.ts (ADR-0007). This used to fetch admin_app's own /identity route
+// instead, on the theory that this app (served by the plugin host at
+// /api/v1/plugins/idea-scout/admin/*) is a different origin from the portal and
+// so can't reach /.well-known/biffo-identity.json directly. That theory was
+// wrong: both are served from the same dev.biffo.io origin. The self-served
+// /identity route also turned out to be a dead end even for same-origin
+// callers — the API Gateway's own JWT authorizer and the plugin host's
+// group_gate both sit in front of it, so it can never be reached before a
+// session exists to prove admin-group membership with (confirmed live: a
+// direct fetch 401'd). /.well-known/biffo-identity.json has no such problem:
+// it's public, unauthenticated static content on the portal's own bucket, and
+// was already reachable the whole time.
+//
+// Core publishes its Cognito coordinates there. We resolve it at RUNTIME so
+// this app never bakes the core's pool/client id into its bundle — when core
+// replaces its pool, we always see the current one. Same-origin makes a
+// relative fetch valid with no CORS. Memoised: at most one request per page
+// load. Unreachable → null → the caller treats the visitor as signed out (a
+// clean redirect beats trusting a stale local pool id).
+
+export interface CoreIdentity {
+  userPoolId: string
+  clientId: string
+  region?: string
+  apiUrl?: string
+  portalUrl?: string
+}
+
+const IDENTITY_DOCUMENT_PATH = '/.well-known/biffo-identity.json'
+
+let cached: Promise<CoreIdentity | null> | null = null
+
+function identityFromDocument(data: unknown): CoreIdentity | null {
+  if (typeof data !== 'object' || data === null) return null
+  const doc = data as Record<string, unknown>
+  const userPoolId = typeof doc['userPoolId'] === 'string' ? doc['userPoolId'] : ''
+  const clientId = typeof doc['clientId'] === 'string' ? doc['clientId'] : ''
+  if (!userPoolId || !clientId) return null
+  const identity: CoreIdentity = { userPoolId, clientId }
+  if (typeof doc['region'] === 'string') identity.region = doc['region']
+  if (typeof doc['apiUrl'] === 'string') identity.apiUrl = doc['apiUrl']
+  if (typeof doc['portalUrl'] === 'string') identity.portalUrl = doc['portalUrl']
+  return identity
+}
+
+async function fetchCoreIdentity(): Promise<CoreIdentity | null> {
+  try {
+    const res = await fetch(IDENTITY_DOCUMENT_PATH, { cache: 'no-store' })
+    if (res.ok) {
+      const identity = identityFromDocument(await res.json())
+      if (identity) return identity
+    }
+  } catch {
+    // Network error or fetch unavailable — fall through to null.
+  }
+  console.warn(
+    `[biffo] could not resolve the core identity document at ${IDENTITY_DOCUMENT_PATH}; ` +
+      'treating the visitor as signed out.',
+  )
+  return null
+}
+
+/** Resolve core's Cognito identity at runtime. Memoised; null when unreachable. */
+export function resolveCoreIdentity(): Promise<CoreIdentity | null> {
+  cached ??= fetchCoreIdentity()
+  return cached
+}
+
+/** Test-only: clear the memoised resolution. */
+export function __resetCoreIdentityForTests(): void {
+  cached = null
+}


### PR DESCRIPTION
The panel loads on dev and then renders **"Could not load campaigns: request failed (401)"**.

`api.ts` used `credentials: 'include'` — cookies. API Gateway's `/api/v1/plugins/*` route is **JWT-authorized**, so a cookie is not a credential it recognises, and every call 401'd.

## The real mistake is upstream of that line

idea-scout already ships working auth for exactly this surface:

- `identity.ts` — resolves the pool from `/.well-known/biffo-identity.json`
- `cognito-hygiene.ts` — prunes foreign Cognito credentials
- `auth.ts` — reads the portal's shared session

I wrote a new `api.ts` instead of copying it. So this PR copies those three modules verbatim and sends `Authorization: Bearer <id token>`, which is what idea-scout's own client does.

## Tests

A test asserts the bearer **is** sent and that `credentials` is **not** — the regression is one word, and nothing else would catch it. A 401 now says *"not signed in — sign in to the portal, then reload"* rather than a bare status, because that is the one failure a reader can act on.

9 tests; typecheck, lint and build clean.

**Not verified: the deployed result.** This needs to reach the instance and redeploy before the panel actually lists campaigns. I will check the browser-visible behaviour, not the status code — a 200 serving the wrong thing is how this looked fine twice today.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)