### PR TITLE
test(marketing): stop fixture UUIDs tripping the instance's secret scan

### DIFF
--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -28,7 +28,7 @@ from fastapi.testclient import TestClient
 from marketing import image_routes
 from marketing.image_provider import GeneratedImage, ImageProviderError
 
-_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000006"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ef"
 _MEDIA_ID = "media-1"
 _LEDGER_ID = "ledger-1"
 _PRESIGN_URL = "https://s3.example.invalid/upload"

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 from marketing import admin_app, pipeline
 from marketing.definitions import RESEARCH_SYNTHESIS_AGENT_NAME
 
-_CAMPAIGN = "b3f1c0de-0000-4000-8000-000000000002"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000cd"
 
 
 class _FakeCore:


### PR DESCRIPTION
Third occurrence of the same trap. `.gitleaks.toml`'s `biffo-aws-account-id` rule matches **any bare 12-digit number**, and a UUID's final group is twelve hex digits — so a fixture id ending in decimal digits reads as an AWS account id.

```
test_marketing_pipeline_routes.py  ...000000000002
test_marketing_image_routes.py     ...000000000006
```

This repo's own gate does **not** carry that rule, so it passes here and fails in `tabsii-platform` when the tests are vendored in with the plugin — one repo and one CI cycle downstream of where it is written, every time. That config gap is #19.

#21 fixed the first of these and **was never merged**, which is how the same constant came back. Closed as superseded by this.

286 passed.

Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)