### PR TITLE
feat(marketing): declare user_ingress — Surface B, franchise-unit read surface

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -59,11 +59,11 @@
       "permissions": {
         "list": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "read": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "create": {
           "allowed": true,
@@ -130,11 +130,11 @@
       "permissions": {
         "list": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "read": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "create": {
           "allowed": true,
@@ -188,11 +188,11 @@
       "permissions": {
         "list": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "read": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "create": {
           "allowed": true,
@@ -253,11 +253,11 @@
       "permissions": {
         "list": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "read": {
           "allowed": true,
-          "required_role": ["admin"]
+          "required_role": []
         },
         "create": {
           "allowed": true,
@@ -475,6 +475,10 @@
     "agent-run-request": "^1",
     "owner-scoped-tables": "^1",
     "object-storage": "^1"
+  },
+  "user_ingress": {
+    "required_group": "founder",
+    "app": "marketing.user_app:app"
   },
   "admin_ingress": {
     "required_group": "admin",

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -1,0 +1,324 @@
+"""The campaign studio's franchise-unit-facing ASGI app (ADR-0021 ``user_ingress``).
+
+Mounted by the shared plugin host at ``/api/v1/plugins/marketing``, gated on the
+``founder`` Cognito group before this app sees a request (ADR-0011 —
+authorization is a core concern, never plugin code). ``founder`` is the
+estate's existing name for "an approved, ordinary product user" — both
+``idea-scout`` and ``ideation`` gate their own ``user_ingress`` on it, and
+``modules/cloud/aws/auth/main.tf`` describes the group itself as "Approved
+product user (e.g. an invited founder). Access to user-facing modules." This
+plugin reuses that convention rather than inventing a Tabsii-specific group
+name for a capability the plugin contract already generalises over — see
+``admin_app.py``'s own module docstring for why one manifest can serve both
+Biffo-marketing-Biffo and Tabsii-marketing-Tabsii through the SAME two ingress
+keys.
+
+## Surface A vs. Surface B
+
+``admin_app.py``'s docstring lays out the split: ``admin_ingress`` is the
+operator marketing *the platform*; ``user_ingress`` — this file — is a
+franchise unit marketing *its own services*. This change is deliberately the
+smallest honest slice of the second surface: a unit can see which campaigns
+are published and pull the material to actually promote one. Per-unit
+localisation, unit-scoped visibility, and the full download-and-copy polish
+the day-0 design describes are iteration 2
+(``docs/design/marketing-plugin/campaign-studio.md`` §2, in
+``tabsii-platform``) and are **not** built here.
+
+## No built UI in this surface
+
+Unlike ``admin_ingress``, the shared plugin host does not bake a
+``StaticFiles`` mount into a ``user_ingress`` app at all — read
+``services/_plugin-host/src/plugin_host/mount.py::build_host`` in
+``biffo-template`` directly: only the ``/<name>/admin`` mount gets the
+``_is_public_admin_asset`` exemption, and it is ``admin_app.py`` itself
+(not the host) that mounts ``StaticFiles`` inside that app. A user-facing UI
+is a separate manifest concept (``user_frontend``, hosted per ADR-0018) that
+``idea-scout`` and ``ideation`` both declare and this plugin deliberately does
+not yet: building and deploying a real SPA plus its own CloudFront
+distribution is a materially bigger commitment than "declare the surface and
+make it real", and biffo-template issue #558 (open) tracks consolidating that
+whole mechanism into ADR-0021 rather than multiplying copies of it mid-
+migration. So this surface is **JSON only** — a unit reaches it directly (or a
+future UI calls it, the way ``web-admin/src/lib/api.ts`` calls
+``admin_app.py``).
+
+## Read-only, and why two tables' permissions had to change
+
+Every route here reads ``marketing_campaign``, ``marketing_artefact`` (the
+``copy`` kind only — see ``get_pack_route``) and ``marketing_asset``/
+``marketing_link`` through the same dual-auth mount ``admin_app._core`` and
+``principal_client.PrincipalCoreClient`` use (``principal_client``'s module
+docstring has the full mechanism) — Core's own per-table ``required_role``
+governs who can pass, regardless of which plugin surface forwarded the call.
+Those tables' ``list``/``read`` permissions were ``["admin"]`` only; a
+``founder``-group caller would 403 there even with a perfectly-formed
+signed-and-forwarded request, because the host's group gate and Core's own
+table permission are two independent checks (``forward.py``'s own docstring:
+"Authorization for these routes is the table's own ADR-0004 permissions...
+not the plugin's user_ingress.required_group"). So ``biffo.plugin.json``
+opens ``list``/``read`` to ``required_role: []`` (any authenticated caller,
+once the host's own group gate has already run) on ``marketing_campaign``,
+``marketing_artefact``, ``marketing_asset`` and ``marketing_link``.
+``create``/``update``/``delete`` stay admin-only on every table — a unit never
+writes through this surface — and ``marketing_click`` (raw per-click
+analytics: user agent, referrer) is untouched in every operation, since no
+route here has a legitimate reason to read it. ``[]`` is the established
+idiom for "any authenticated caller", not a bespoke choice: idea-scout's own
+``idea_scout_build_types``/``idea_scout_model_catalog`` read permissions use
+it for exactly the same reason
+(``services/api/src/api/dependencies.py``: "empty ``required_role``
+authorises any authenticated caller").
+
+**A real, accepted limitation this creates:** opening ``marketing_artefact``
+at the table level also makes the generic CRUD route
+(``/api/v1/plugins/marketing/artefacts``) listable by any authenticated
+caller for EVERY kind — ``research``/``positioning``/``channel_plan`` as well
+as ``copy`` — because Core's permission model is per table+operation, not per
+row or per ``kind`` value. This route only ever requests and returns the
+``copy`` kind, but a founder who called the generic CRUD path directly could
+read the internal research/positioning/channel-plan artefacts too. Building
+kind-level permission granularity into Core's permission model is out of
+scope for this change; flagged here rather than silently accepted.
+
+## What "available" means, and what it deliberately does not check yet
+
+A campaign is available to a unit once its ``status`` is ``ready`` or
+``live``. The generic list route has no server-side filter for "one of a set
+of values" (mirrors ``results_routes.py``'s own full-pagination-then-filter
+precedent), so this fetches every campaign a founder can see and filters in
+memory. There is no per-unit or per-locality scoping — every founder-group
+caller sees every published campaign in the tenant, which matches ADR-0001's
+current single-tenant reality and campaign-studio.md §2's own "Actors: one"
+->"many, each with their own locality" line marking that as iteration 2's
+job, not this one's.
+
+## What the pack does NOT do, deliberately
+
+Unlike the admin surface's ``pack_routes.py`` (a concurrent change in this
+repo, deliberately not imported from or edited here to keep this change
+independent of it), this route does not mint missing tracked links, does not
+require a source creative to exist, and does not report
+``missing_placements``. It only
+assembles whatever already exists: existing assets resolved to fresh URLs,
+existing links resolved to their tracked URL, and the latest **approved**
+``copy`` artefact. A campaign whose admin has approved copy but not yet
+generated any stills, or not yet minted every channel's link, produces a pack
+with an empty ``assets`` or ``links`` list rather than a 404 or a write this
+surface has no permission to make. That is an honest, minimal reading of "the
+distribution pack material for one campaign" — not the richer, mutating
+version the admin surface builds.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
+from biffo_plugin_sdk.user_serving import require_group
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
+
+from . import admin_app, principal_client
+from .config import public_base_url
+from .links import tracked_url
+
+require_founder = require_group("founder")
+
+#: Every `_core`-shaped call site below must carry this literal prefix — see
+#: `tests/test_marketing_core_paths_guard.py`'s module docstring for why it
+#: is a local constant rather than an import (the guard resolves a named
+#: constant only within the file that defines it), and that file's own
+#: disagreement test for why every copy across the plugin is asserted equal.
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
+
+#: Matches `image_routes._STORAGE_PATH` — duplicated for the same reason,
+#: not imported (see `admin_app._validated_campaign_id`'s docstring on why a
+#: stateful/path-bearing helper is duplicated per file rather than shared).
+_STORAGE_PATH = "/api/v1/internal/plugins/me/storage"
+
+#: Core's generic list route pages at up to 200 rows
+#: (`routing/crud_handlers.py`, tabsii-platform) — mirrored as a literal here
+#: rather than imported, matching `results_routes._LIST_PAGE_SIZE`'s own
+#: reasoning: this plugin has no dependency on Core's own package.
+_LIST_PAGE_SIZE = 200
+
+#: The only statuses that make a campaign "available" to a unit — see the
+#: module docstring. Not `definitions.PIPELINE_STAGES` wholesale: a unit must
+#: never see `draft`/`researching`/`planned`/`generating` work in progress.
+_AVAILABLE_STATUSES = frozenset({"ready", "live"})
+
+router = APIRouter(dependencies=[Depends(require_founder)])
+
+
+def get_core_client() -> BiffoAPIClient:
+    """SigV4-signed, plugin-identity-only client for Core's `me` storage
+    route — never table-permission-gated, so it needs no forwarded token.
+    Matches `image_routes.get_core_client`/`pack_routes.get_core_client`,
+    the same mechanism used there for the same route."""
+    return create_core_client()
+
+
+def get_campaign_client(
+    founder: Any = Depends(require_founder),
+) -> principal_client.PrincipalCoreClient:
+    """Dual-auth client for this plugin's own generated-CRUD tables, carrying
+    THIS founder's own forwarded token — same mechanism as `admin_app._core`
+    and `image_routes.get_campaign_client` (issue #27's fix), just built from
+    the founder gate instead of the admin one."""
+    return principal_client.PrincipalCoreClient(founder.token)
+
+
+def _core_error(exc: BiffoAPIError) -> HTTPException:
+    """Matches `image_routes`/`pack_routes`'s own mapping: storage's 503
+    ("not configured here") passes through as-is; everything else is 502,
+    since Core answered and what it said is not something retrying *this*
+    request fixes."""
+    if exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+        return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=exc.detail)
+    return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=exc.detail)
+
+
+async def _list_all(
+    client: principal_client.PrincipalCoreClient, path: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Every row Core holds for `path`/`params`, paged in full — mirrors
+    `results_routes._list_all` exactly. Duplicated rather than imported:
+    that module is admin-only (`router = APIRouter(dependencies=
+    [Depends(admin_app.require_admin)])`) and this file must not gain an
+    admin dependency by way of a shared helper."""
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page_params = {**params, "limit": _LIST_PAGE_SIZE, "offset": offset}
+        batch = await client.get(path, params=page_params)
+        batch = batch or []
+        rows.extend(batch)
+        if len(batch) < _LIST_PAGE_SIZE:
+            return rows
+        offset += _LIST_PAGE_SIZE
+
+
+def _campaign_summary(row: dict[str, Any]) -> dict[str, Any]:
+    """The fields a unit needs to decide whether to open a campaign — not a
+    passthrough of the whole row. Deliberately narrow so a future column
+    added to `marketing_campaign` for admin/pipeline use does not reach a
+    unit's browser by default."""
+    return {
+        "id": row["id"],
+        "name": row.get("name") or "",
+        "status": row.get("status") or "",
+        "starts_at": row.get("starts_at"),
+        "ends_at": row.get("ends_at"),
+    }
+
+
+@router.get("/campaigns")
+async def list_campaigns_route(
+    client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
+) -> list[dict[str, Any]]:
+    """Every campaign this founder can promote right now — `ready` or `live`
+    only. See the module docstring for why draft/in-flight work never
+    appears here."""
+    rows = await _list_all(client, f"{_INTERNAL_PREFIX}/campaigns", {})
+    return [_campaign_summary(r) for r in rows if (r.get("status") or "") in _AVAILABLE_STATUSES]
+
+
+async def _resolve_asset_url(core_client: BiffoAPIClient, asset: dict[str, Any]) -> dict[str, Any]:
+    """One asset row plus a freshly-minted GET url — minted per request, per
+    `image_routes`' own docstring on why a URL is never stored. Skips (does
+    not raise for) an asset row with no `media_id` rather than failing the
+    whole pack on one malformed row."""
+    media_id = asset.get("media_id")
+    if not media_id:
+        return {**asset, "url": None}
+    try:
+        url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")
+    except BiffoAPIError as exc:
+        raise _core_error(exc) from exc
+    return {**asset, "url": url_resp["url"]}
+
+
+@router.get("/campaigns/{campaign_id}/pack")
+async def get_pack_route(
+    campaign_id: str,
+    core_client: BiffoAPIClient = Depends(get_core_client),
+    campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
+    founder: Any = Depends(require_founder),
+) -> dict[str, Any]:
+    """The material a unit needs to actually publish this campaign: its
+    guidance text, the latest **approved** copy, every existing asset
+    resolved to a real URL, and every already-minted tracked link. Nothing
+    here is generated or minted — that stays an admin action
+    (`admin_app.mint_links`, `image_routes.generate_still_route`); this route
+    only assembles what already exists. See the module docstring's "What the
+    pack does NOT do" section for how this differs from the admin surface's
+    own pack.
+    """
+    campaign_id = admin_app._validated_campaign_id(campaign_id)
+
+    campaign_resp = await admin_app._core(
+        "GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", founder.token
+    )
+    if campaign_resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+    campaign_resp.raise_for_status()
+    campaign = campaign_resp.json() or {}
+
+    if (campaign.get("status") or "") not in _AVAILABLE_STATUSES:
+        # Same 404 as "does not exist" — a unit has no legitimate way to
+        # learn a draft/in-flight campaign exists at all.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+
+    copy_artefact = await admin_app._latest_artefact(campaign_id, "copy", founder.token)
+    if copy_artefact is None or copy_artefact.get("status") != "approved":
+        # Collapsed to one outcome rather than admin_app's 409-for-proposed:
+        # a founder cannot approve anything, so "exists but not approved yet"
+        # and "does not exist yet" carry the same actionable information —
+        # none — and 409 would surface internal pipeline state for nothing.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No approved copy for this campaign yet.",
+        )
+    raw_body = copy_artefact.get("body")
+    copy_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+    channels = copy_body.get("channels") or []
+
+    asset_rows = await _list_all(
+        campaign_client, f"{_INTERNAL_PREFIX}/assets", {"campaign_id": campaign_id}
+    )
+    assets = [await _resolve_asset_url(core_client, a) for a in asset_rows]
+
+    link_rows = await _list_all(
+        campaign_client, f"{_INTERNAL_PREFIX}/links", {"campaign_id": campaign_id}
+    )
+    base_url = public_base_url()
+    links = [
+        {
+            "channel": link.get("channel") or "",
+            "variant": link.get("variant"),
+            "is_paid": bool(link.get("is_paid")),
+            "url": tracked_url(base_url, link["token"]) if base_url and link.get("token") else None,
+        }
+        for link in link_rows
+    ]
+
+    return {
+        "campaign_id": campaign_id,
+        "campaign_name": campaign.get("name") or "",
+        "guidance": campaign.get("guidance") or "",
+        "copy": channels,
+        "assets": assets,
+        "links": links,
+    }
+
+
+def build_app() -> FastAPI:
+    """The user (founder) ASGI app — JSON only, no static mount. See the
+    module docstring's "No built UI in this surface" section for why."""
+    app = FastAPI(title="Marketing — campaign studio (unit)")
+    app.include_router(router)
+    return app
+
+
+app = build_app()

--- a/tests/test_marketing_core_paths_guard.py
+++ b/tests/test_marketing_core_paths_guard.py
@@ -221,10 +221,10 @@ def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
     starts with `/api/v1/` — it never checks that the independent
     `_INTERNAL_PREFIX` copies this file's own docstring explains
     (`admin_app.py`, `channel_plan_routes.py`, `image_routes.py`,
-    `results_routes.py`, `copy_routes.py`, `pack_routes.py`, each forced
-    local because the AST walk resolves a named constant only within the
-    file that defines it) actually agree with each other or with the real
-    mounted path. Verified empirically before this test was written: a
+    `results_routes.py`, `copy_routes.py`, `pack_routes.py`, `user_app.py`,
+    each forced local because the AST walk resolves a named constant only
+    within the file that defines it) actually agree with each other or with
+    the real mounted path. Verified empirically before this test was written: a
     single-character typo in one copy (`marketting` for `marketing`) sends
     every call in that file to an unmounted path while the rest of this
     suite — including
@@ -243,11 +243,13 @@ def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
         image_routes,
         pack_routes,
         results_routes,
+        user_app,
     )
 
     canonical = "/api/v1/internal/plugins/marketing"
     assert admin_app._INTERNAL_PREFIX == canonical
     assert channel_plan_routes._INTERNAL_PREFIX == canonical
+    assert user_app._INTERNAL_PREFIX == canonical
     assert image_routes._INTERNAL_PREFIX == canonical
     assert results_routes._INTERNAL_PREFIX == canonical
     assert copy_routes._INTERNAL_PREFIX == canonical

--- a/tests/test_marketing_manifest.py
+++ b/tests/test_marketing_manifest.py
@@ -57,14 +57,43 @@ def test_the_admin_surface_is_declared_and_points_at_a_real_app() -> None:
     assert ingress["app"] == "marketing.admin_app:app"
 
 
-def test_no_user_ingress_yet() -> None:
-    """Iteration 1 is the admin surface only.
+def test_the_user_surface_is_declared_and_points_at_a_real_app() -> None:
+    """Surface B (franchise units) — mirrors
+    `test_the_admin_surface_is_declared_and_points_at_a_real_app` exactly.
 
-    Asserted rather than assumed: declaring `user_ingress` would mount a
-    franchise-unit surface that does not exist, and the failure would be a 500
-    for whoever found it first.
+    `required_group` is `founder`, not a bespoke name: both `idea-scout` and
+    `ideation` gate their own `user_ingress` on the same group, and
+    `modules/cloud/aws/auth/main.tf` describes it as "Approved product user"
+    generically, not as anything Idea-Scout-specific.
     """
-    assert "user_ingress" not in _raw(), "user_ingress is iteration 2, not this one"
+    ingress = _raw().get("user_ingress")
+    assert ingress, "user_ingress is absent — the unit surface would never mount"
+    assert ingress["required_group"] == "founder"
+    assert ingress["app"] == "marketing.user_app:app"
+
+
+def test_founder_readable_tables_stay_read_only_for_founders() -> None:
+    """`marketing_campaign`/`marketing_artefact`/`marketing_asset`/
+    `marketing_link` open `list`/`read` to any authenticated caller (`[]`) so
+    `user_app.py` can read them — but `create`/`update`/`delete` must stay
+    `admin`-only on every one of them, and `marketing_click` must stay
+    admin-only on every operation (see `user_app.py`'s module docstring for
+    why). A regression here would let a `founder`-group caller write through
+    the generic CRUD path directly, which no route in `user_app.py` needs or
+    should have."""
+    tables = {t["name"]: t for t in _raw()["tables"]}
+    for name in ("marketing_campaign", "marketing_artefact", "marketing_asset", "marketing_link"):
+        perms = tables[name]["permissions"]
+        assert perms["list"]["required_role"] == [], f"{name}.list should be open"
+        assert perms["read"]["required_role"] == [], f"{name}.read should be open"
+        for op in ("create", "update", "delete"):
+            assert perms[op]["required_role"] == ["admin"], f"{name}.{op} must stay admin-only"
+
+    click_perms = tables["marketing_click"]["permissions"]
+    for op in ("list", "read", "create", "update", "delete"):
+        assert click_perms[op]["required_role"] == ["admin"], (
+            f"marketing_click.{op} must stay admin-only"
+        )
 
 
 @pytest.mark.parametrize("table", _raw()["tables"], ids=lambda t: t["name"])

--- a/tests/test_marketing_user_app.py
+++ b/tests/test_marketing_user_app.py
@@ -1,0 +1,426 @@
+"""The unit (franchise) surface (ADR-0021 `user_ingress`, `user_app.py`).
+
+Fakes rather than mocks, matching this repo's convention
+(`test_marketing_image_routes.py`, `test_marketing_mint_route.py`): what is
+worth asserting is what got requested and what came back, and a fake that
+records both says that directly.
+
+Two fakes stand in for the two client shapes `user_app.py` depends on,
+matching `test_marketing_image_routes.py`'s own split:
+
+- `_FakeCoreClient` — the SigV4-only, plugin-identity client
+  (`get_core_client`) used for the `me` storage `/url` route.
+- `_FakeCampaignClient` — the dual-auth client (`get_campaign_client`) over
+  this plugin's own generated-CRUD tables, carrying the founder's own
+  forwarded token.
+
+`admin_app._core`/`admin_app._latest_artefact` are exercised for real (not
+faked) via `monkeypatch.setattr(admin_app, "CORE_API_URL", ...)` plus a faked
+`principal_client.SignedCoreClient` — mirrors
+`test_marketing_dual_auth_wiring.py`'s own approach for the same reason: this
+file reuses those two helpers directly (see `user_app.py`'s module docstring
+for why that reuse is safe and established), so a fake at THAT seam is what
+proves the real function bodies ran, not a mock of them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, principal_client, user_app
+
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000a1"
+_CORE_API_URL = "https://core.invalid"
+_BASE_URL = "https://dev.tabsii.com"
+
+
+def _founder_user() -> Any:
+    return type("U", (), {"sub": "unit-1", "groups": ["founder"], "token": "founder-jwt"})()
+
+
+class _FakeCoreClient:
+    """Stands in for `get_core_client()` — the SigV4-only storage-URL client."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append((path, params))
+        if path.endswith("/url"):
+            media_id = path.split("/")[-2]
+            return {"url": f"https://s3.example.invalid/{media_id}"}
+        raise AssertionError(f"unexpected GET {path}")
+
+
+class _FakeCampaignClient:
+    """Stands in for `get_campaign_client()` — the dual-auth
+    `PrincipalCoreClient` over this plugin's own generated-CRUD tables."""
+
+    def __init__(
+        self,
+        *,
+        assets: list[dict[str, Any]] | None = None,
+        links: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.assets = assets or []
+        self.links = links or []
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append((path, params))
+        if path == f"{user_app._INTERNAL_PREFIX}/assets":
+            return self.assets
+        if path == f"{user_app._INTERNAL_PREFIX}/links":
+            return self.links
+        raise AssertionError(f"unexpected GET {path}")
+
+
+def _app(*, core_client: _FakeCoreClient, campaign_client: _FakeCampaignClient) -> FastAPI:
+    app = FastAPI()
+    app.include_router(user_app.router)
+    app.dependency_overrides[user_app.require_founder] = _founder_user
+    app.dependency_overrides[user_app.get_core_client] = lambda: core_client
+    app.dependency_overrides[user_app.get_campaign_client] = lambda: campaign_client
+    return app
+
+
+class _FakeSignedCoreClient:
+    """The lowest seam `admin_app._core` reaches Core through — see
+    `test_marketing_dual_auth_wiring.py`'s own docstring for why this is
+    faked at `principal_client.SignedCoreClient` rather than mocking
+    `admin_app._core` itself: it proves `_core`'s and `_latest_artefact`'s
+    real bodies ran with the founder's own token, not a stand-in for them."""
+
+    def __init__(self, responses: dict[str, tuple[int, bytes]]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        content: bytes | None = None,
+        extra_signed_headers: dict[str, str] | None = None,
+    ) -> tuple[int, bytes, str]:
+        self.calls.append(
+            {"method": method, "path": path, "extra_signed_headers": extra_signed_headers}
+        )
+        for prefix, (status_code, body) in self._responses.items():
+            if path.startswith(prefix):
+                return status_code, body, "application/json"
+        raise AssertionError(f"unexpected {method} {path}")
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _campaign_row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "id": _CAMPAIGN,
+        "name": "Summer offers",
+        "status": "ready",
+        "guidance": "Disclose the promotional partnership.",
+        "starts_at": None,
+        "ends_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _approved_copy_artefact(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "id": "artefact-1",
+        "campaign_id": _CAMPAIGN,
+        "kind": "copy",
+        "status": "approved",
+        "body": json.dumps({"channels": [{"channel": "instagram", "text": "Great offer!"}]}),
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture
+def fake_signed_client(monkeypatch: pytest.MonkeyPatch):
+    def _install(responses: dict[str, tuple[int, bytes]]) -> _FakeSignedCoreClient:
+        client = _FakeSignedCoreClient(responses)
+        monkeypatch.setattr(principal_client, "SignedCoreClient", lambda **kw: client)
+        monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
+        return client
+
+    return _install
+
+
+@pytest.fixture
+def configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Matches `test_marketing_dual_auth_wiring.py`'s own approach exactly
+    (`monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE_URL)`):
+    `user_app.py` imports `public_base_url` by name from `config`, so
+    patching `user_app`'s own reference to it is isolated from `config`'s
+    process-lifetime cache — no other test's cached value can leak in, and
+    this test cannot leak one out either."""
+    monkeypatch.setattr(user_app, "public_base_url", lambda: _BASE_URL)
+
+
+# ── /campaigns ────────────────────────────────────────────────────────────
+
+
+def test_lists_only_ready_and_live_campaigns() -> None:
+    campaign_client = _FakeCampaignClient()
+    campaign_client.get = _paged_campaigns(  # type: ignore[method-assign]
+        [
+            _campaign_row(id="c-draft", status="draft"),
+            _campaign_row(id="c-ready", status="ready"),
+            _campaign_row(id="c-live", status="live"),
+            _campaign_row(id="c-archived", status="archived"),
+        ]
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=campaign_client))
+
+    resp = client.get("/campaigns")
+
+    assert resp.status_code == 200
+    ids = {c["id"] for c in resp.json()}
+    assert ids == {"c-ready", "c-live"}
+
+
+def _paged_campaigns(rows: list[dict[str, Any]]):
+    """A `.get` replacement that answers the `/campaigns` list path with
+    `rows` and 404s anything else — the minimal shape `_list_all`'s single
+    page needs (fewer than `_LIST_PAGE_SIZE` rows, so it returns after one
+    call)."""
+
+    async def get(path: str, params: dict[str, Any] | None = None) -> Any:
+        if path == f"{user_app._INTERNAL_PREFIX}/campaigns":
+            return rows if (params or {}).get("offset", 0) == 0 else []
+        raise AssertionError(f"unexpected GET {path}")
+
+    return get
+
+
+def test_campaign_summary_omits_internal_fields() -> None:
+    """Only id/name/status/starts_at/ends_at travel to a unit — not `brief`
+    or `destination_url`, which are internal working fields."""
+    internal_row = _campaign_row(
+        brief="what the research agent should look for",
+        destination_url="https://tabsii.com/apply",
+    )
+    campaign_client = _FakeCampaignClient()
+    campaign_client.get = _paged_campaigns([internal_row])  # type: ignore[method-assign]
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=campaign_client))
+
+    resp = client.get("/campaigns")
+
+    assert resp.status_code == 200
+    body = resp.json()[0]
+    assert set(body) == {"id", "name", "status", "starts_at", "ends_at"}
+
+
+# ── /campaigns/{id}/pack ─────────────────────────────────────────────────
+
+
+def test_pack_assembles_copy_assets_and_links(fake_signed_client, configured_base_url) -> None:
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact()]).encode(),
+            ),
+        }
+    )
+    core_client = _FakeCoreClient()
+    campaign_client = _FakeCampaignClient(
+        assets=[
+            {
+                "id": "asset-1",
+                "campaign_id": _CAMPAIGN,
+                "media_kind": "image",
+                "placement": None,
+                "media_id": "media-1",
+                "is_source": True,
+            }
+        ],
+        links=[
+            {
+                "id": "link-1",
+                "campaign_id": _CAMPAIGN,
+                "channel": "instagram",
+                "variant": None,
+                "is_paid": False,
+                "token": "tok-abc123",
+            }
+        ],
+    )
+    client = TestClient(_app(core_client=core_client, campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["campaign_id"] == _CAMPAIGN
+    assert body["campaign_name"] == "Summer offers"
+    assert body["guidance"] == "Disclose the promotional partnership."
+    assert body["copy"] == [{"channel": "instagram", "text": "Great offer!"}]
+    assert body["assets"] == [
+        {
+            "id": "asset-1",
+            "campaign_id": _CAMPAIGN,
+            "media_kind": "image",
+            "placement": None,
+            "media_id": "media-1",
+            "is_source": True,
+            "url": "https://s3.example.invalid/media-1",
+        }
+    ]
+    assert body["links"] == [
+        {
+            "channel": "instagram",
+            "variant": None,
+            "is_paid": False,
+            "url": f"{_BASE_URL}/c/tok-abc123",
+        }
+    ]
+
+
+def test_pack_404s_a_campaign_that_is_not_ready_or_live(fake_signed_client) -> None:
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row(status="draft")).encode(),
+            ),
+        }
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 404
+
+
+def test_pack_404s_an_unknown_campaign(fake_signed_client) -> None:
+    fake_signed_client(
+        {f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (404, b'{"detail":"not found"}')}
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 404
+
+
+def test_pack_404s_a_malformed_campaign_id() -> None:
+    """The SSRF guard (`admin_app._validated_campaign_id`, reused here): not
+    a UUID must 404 before any Core call is attempted."""
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()))
+
+    resp = client.get("/campaigns/not-a-uuid-at-all/pack")
+
+    assert resp.status_code == 404
+
+
+def test_pack_404s_when_copy_is_not_yet_approved(fake_signed_client) -> None:
+    """A `proposed` copy artefact must not reach a unit — collapsed to the
+    same 404 as "no copy yet", never a 409 (see `get_pack_route`'s own
+    docstring for why: a founder cannot act on that distinction)."""
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact(status="proposed")]).encode(),
+            ),
+        }
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 404
+
+
+def test_pack_forwards_the_founders_own_token(fake_signed_client) -> None:
+    """`admin_app._core`/`_latest_artefact`, reused here, must carry THIS
+    founder's token — not a hardcoded or admin one — through to Core."""
+    fake = fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact()]).encode(),
+            ),
+        }
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=_FakeCampaignClient()))
+
+    client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert fake.calls, "no Core calls were made"
+    for call in fake.calls:
+        assert call["extra_signed_headers"] == {
+            principal_client.FORWARDED_USER_HEADER: "founder-jwt"
+        }
+
+
+def test_pack_omits_link_urls_when_no_public_base_url_is_configured(
+    fake_signed_client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A link with no base URL configured still appears — with `url: null` —
+    rather than the whole pack failing, since assets/copy may still be
+    useful with no base URL wired up yet."""
+    monkeypatch.setattr(user_app, "public_base_url", lambda: "")
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact()]).encode(),
+            ),
+        }
+    )
+    campaign_client = _FakeCampaignClient(
+        links=[
+            {
+                "id": "link-1",
+                "campaign_id": _CAMPAIGN,
+                "channel": "instagram",
+                "variant": None,
+                "is_paid": False,
+                "token": "tok-abc123",
+            }
+        ]
+    )
+    client = TestClient(_app(core_client=_FakeCoreClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    assert resp.json()["links"] == [
+        {"channel": "instagram", "variant": None, "is_paid": False, "url": None}
+    ]
+
+
+def test_the_manifest_app_path_resolves() -> None:
+    """`user_ingress.app` is "marketing.user_app:app" — assert that resolves,
+    same discipline as `test_marketing_admin_app.test_the_manifest_app_path_resolves`."""
+    module_name, _, attr = "marketing.user_app:app".partition(":")
+    module = __import__(module_name, fromlist=[attr])
+    assert getattr(module, attr) is not None


### PR DESCRIPTION
## Why

The plugin declared only `admin_ingress`. `discover.py`/`mount.py` in
`biffo-template`'s shared plugin host only build a public, ungated
`/api/v1/plugins/marketing/*` mount when a `user_ingress` app is present —
without one, `web-admin`'s own direct calls to that path (the generic-CRUD
routes the admin UI's `api.ts` hits for `/campaigns` etc.) are unreachable.
Declaring `user_ingress` fixes that for Surface A too, not just adding
Surface B.

## What

- `src/marketing/user_app.py` — a new, read-only JSON API gated on the
  `founder` Cognito group (the convention both `idea-scout` and `ideation`
  already use for `user_ingress`, per their manifests and
  `modules/cloud/aws/auth/main.tf`'s own description of the group). Two
  routes: `GET /campaigns` (ready/live campaigns only) and
  `GET /campaigns/{id}/pack` (approved copy, existing assets resolved to
  signed URLs, existing tracked links, guidance).
- `biffo.plugin.json` — declares `user_ingress`; opens `list`/`read` on
  `marketing_campaign`/`marketing_artefact`/`marketing_asset`/
  `marketing_link` to any authenticated caller (`required_role: []`, the
  same idiom idea-scout's own read-only tables use) so a founder-gated
  request can pass Core's per-table permission check.
  `create`/`update`/`delete` stay admin-only everywhere; `marketing_click`
  is untouched on every operation.
- Tests for the new routes/manifest shape, plus the core-paths guard's
  disagreement check extended to cover `user_app.py`'s own
  `_INTERNAL_PREFIX` copy.

## Deliberately not in this PR

- **No built UI.** The shared plugin host does not bake a `StaticFiles`
  mount into a `user_ingress` app (only `admin_ingress` gets that); a real
  UI is the separate `user_frontend`/ADR-0018 mechanism idea-scout/ideation
  use, and building + deploying one is a materially bigger, separate piece
  of work (`user_app.py`'s module docstring has the detail).
- **No link minting, no `missing_placements` reporting.** Unlike the admin
  surface's `pack_routes.py`, this route only assembles what already
  exists — it has no write permission and doesn't need one.
- **No per-unit/locality scoping.** Every founder-group caller sees every
  published campaign in the tenant — iteration 2's job per
  `campaign-studio.md` §2, not this one's.

## A real, accepted limitation

Opening `marketing_artefact`'s table permission also makes the generic CRUD
`/artefacts` route listable by any authenticated caller for every `kind` —
`research`/`positioning`/`channel_plan` as well as `copy` — since Core's
permission model is per table+operation, not per row/kind. `user_app.py`
only ever requests and returns the `copy` kind, but a founder calling the
generic route directly could read the others. Documented in `user_app.py`'s
own module docstring rather than silently accepted; kind-level permission
granularity is out of scope here.

## Verification

`uv run ruff check .`, `ruff format --check .`, `pyright`, `pytest` (297
passed) all green locally, plus the repo's own push-gate `verify` script.
**Not verified against a live deployment** — no session to check a real
`founder`-group request actually reaches this surface end to end. See the
final report for what that would take.
