### PR TITLE
fix(marketing): correct Surface B docs, harden pack against a malformed storage response

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -9,16 +9,32 @@ authorization is a core concern, never plugin code).
 The plugin has two surfaces in its design, and they are the same machine pointed
 at different audiences: ``admin_ingress`` is the operator marketing *the
 platform*, ``user_ingress`` is a franchise unit marketing *its own services*.
-Only the first is built. There is no platform-operator tier in Biffo — an
-instance's "platform admins" are simply its own tenant admins — which is exactly
-why one plugin can serve both Biffo-marketing-Biffo and Tabsii-marketing-Tabsii
-without a new capability.
+**Both are now built** — ``user_app.py`` is Surface B, added after this
+docstring first said "only the first is built" (now corrected: that sentence
+was stale from the moment ``user_app.py`` shipped). There is no
+platform-operator tier in Biffo — an instance's "platform admins" are simply
+its own tenant admins — which is exactly why one plugin can serve both
+Biffo-marketing-Biffo and Tabsii-marketing-Tabsii without a new capability.
 
 ## What is NOT here, and why
 
 The five tables declare their CRUD in ``biffo.plugin.json``'s ``api_routes``, so
-**Core** generates those and the host forwards them, authorised by each table's
-own admin-only permissions. The UI calls
+**Core** generates those and the host forwards them. **Not** "admin-only" any
+more, and not gated on either surface's Cognito group at all: ``biffo-
+template``'s ``plugin_host/forward.py`` places the declared-``api_routes``
+forwarder **outside** the plugin's own group gate on purpose ("gating them
+additionally on the plugin's user group... would reject the admin the route
+exists for") — reachability is governed entirely by each table's own
+``required_role`` in Core, checked against WHATEVER Cognito group the bearer
+token belongs to, not by which mount the request came in through. Four of the
+five tables (``marketing_campaign``/``artefact``/``asset``/``link``) opened
+``list``/``read`` to ``required_role: []`` so ``user_app.py`` could reach
+them — which means, as a direct consequence, ANY authenticated caller in the
+tenant can reach them via ``/api/v1/plugins/marketing/campaigns`` etc.
+directly, not only a ``founder``-group one (see ``user_app.py``'s own module
+docstring for the full reasoning and the accepted limitation this creates).
+``create``/``update``/``delete`` and every operation on ``marketing_click``
+stay admin-only. The UI calls
 ``/api/v1/plugins/marketing/campaigns`` directly — one hop.
 
 Routes live here only when they are *not* CRUD over one table: the pipeline

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -57,29 +57,36 @@ signed-and-forwarded request, because the host's group gate and Core's own
 table permission are two independent checks (``forward.py``'s own docstring:
 "Authorization for these routes is the table's own ADR-0004 permissions...
 not the plugin's user_ingress.required_group"). So ``biffo.plugin.json``
-opens ``list``/``read`` to ``required_role: []`` (any authenticated caller,
-once the host's own group gate has already run) on ``marketing_campaign``,
-``marketing_artefact``, ``marketing_asset`` and ``marketing_link``.
-``create``/``update``/``delete`` stay admin-only on every table — a unit never
-writes through this surface — and ``marketing_click`` (raw per-click
-analytics: user agent, referrer) is untouched in every operation, since no
-route here has a legitimate reason to read it. ``[]`` is the established
-idiom for "any authenticated caller", not a bespoke choice: idea-scout's own
-``idea_scout_build_types``/``idea_scout_model_catalog`` read permissions use
-it for exactly the same reason
-(``services/api/src/api/dependencies.py``: "empty ``required_role``
-authorises any authenticated caller").
+opens ``list``/``read`` to ``required_role: []`` (any authenticated caller —
+Core's ``dependencies.py``: "empty ``required_role`` authorises any
+authenticated caller") on ``marketing_campaign``, ``marketing_artefact``,
+``marketing_asset`` and ``marketing_link``. ``create``/``update``/``delete``
+stay admin-only on every table — a unit never writes through this surface —
+and ``marketing_click`` (raw per-click analytics: user agent, referrer) is
+untouched in every operation, since no route here has a legitimate reason to
+read it. ``[]`` is the established idiom for "any authenticated caller", not
+a bespoke choice: idea-scout's own ``idea_scout_build_types``/
+``idea_scout_model_catalog`` read permissions use it for exactly the same
+reason.
 
-**A real, accepted limitation this creates:** opening ``marketing_artefact``
-at the table level also makes the generic CRUD route
-(``/api/v1/plugins/marketing/artefacts``) listable by any authenticated
-caller for EVERY kind — ``research``/``positioning``/``channel_plan`` as well
-as ``copy`` — because Core's permission model is per table+operation, not per
-row or per ``kind`` value. This route only ever requests and returns the
-``copy`` kind, but a founder who called the generic CRUD path directly could
-read the internal research/positioning/channel-plan artefacts too. Building
-kind-level permission granularity into Core's permission model is out of
-scope for this change; flagged here rather than silently accepted.
+**A real, accepted limitation this creates, broader than just this
+surface.** The routes in *this file* run behind ``require_founder``, but the
+table permission itself does not know that — Core's manifest-declared
+``api_routes`` (``GET /api/v1/plugins/marketing/campaigns`` etc.) are
+forwarded by the shared host **outside any group gate at all**
+(``plugin_host/forward.py``'s own docstring: placed there deliberately so an
+admin isn't rejected by a founder-only ``user_ingress`` gate). So opening
+these four tables' ``list``/``read`` makes them reachable by **any
+authenticated tenant caller** — admin, editor, viewer or founder alike — via
+that generic CRUD path directly, not only by a ``founder``-group request
+routed through this file. For ``marketing_artefact`` specifically that also
+means every ``kind`` is reachable that way, not just the ``copy`` kind this
+file's own routes request — a caller could read the internal
+research/positioning/channel-plan artefacts too. Building either
+per-caller-group or per-``kind`` permission granularity into Core's
+permission model is out of scope for this change. Flagged here rather than
+silently accepted, and tracked for follow-up rather than only documented —
+this repo's issue #40.
 
 ## What "available" means, and what it deliberately does not check yet
 
@@ -227,8 +234,11 @@ async def list_campaigns_route(
 async def _resolve_asset_url(core_client: BiffoAPIClient, asset: dict[str, Any]) -> dict[str, Any]:
     """One asset row plus a freshly-minted GET url — minted per request, per
     `image_routes`' own docstring on why a URL is never stored. Skips (does
-    not raise for) an asset row with no `media_id` rather than failing the
-    whole pack on one malformed row."""
+    not raise for) an asset row with no `media_id`, or a storage response
+    with no `url` in it, rather than failing the whole pack on one malformed
+    row — the second case mirrors the first: a response shaped differently
+    than expected is not something retrying *this whole request* fixes any
+    more than a missing `media_id` is."""
     media_id = asset.get("media_id")
     if not media_id:
         return {**asset, "url": None}
@@ -236,7 +246,7 @@ async def _resolve_asset_url(core_client: BiffoAPIClient, asset: dict[str, Any])
         url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")
     except BiffoAPIError as exc:
         raise _core_error(exc) from exc
-    return {**asset, "url": url_resp["url"]}
+    return {**asset, "url": url_resp.get("url")}
 
 
 @router.get("/campaigns/{campaign_id}/pack")

--- a/tests/test_marketing_user_app.py
+++ b/tests/test_marketing_user_app.py
@@ -80,7 +80,7 @@ class _FakeCampaignClient:
         raise AssertionError(f"unexpected GET {path}")
 
 
-def _app(*, core_client: _FakeCoreClient, campaign_client: _FakeCampaignClient) -> FastAPI:
+def _app(*, core_client: Any, campaign_client: _FakeCampaignClient) -> FastAPI:
     app = FastAPI()
     app.include_router(user_app.router)
     app.dependency_overrides[user_app.require_founder] = _founder_user
@@ -287,6 +287,59 @@ def test_pack_assembles_copy_assets_and_links(fake_signed_client, configured_bas
             "variant": None,
             "is_paid": False,
             "url": f"{_BASE_URL}/c/tok-abc123",
+        }
+    ]
+
+
+def test_pack_survives_a_storage_response_with_no_url_key(fake_signed_client) -> None:
+    """A 200 from storage with a body shaped differently than expected (no
+    `url` key) must not 500 the whole pack — same resilience as the missing-
+    `media_id` case, not just a docstring claim about it."""
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact()]).encode(),
+            ),
+        }
+    )
+
+    class _MalformedStorageResponse:
+        async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+            return {}  # no "url" key
+
+    campaign_client = _FakeCampaignClient(
+        assets=[
+            {
+                "id": "asset-1",
+                "campaign_id": _CAMPAIGN,
+                "media_kind": "image",
+                "placement": None,
+                "media_id": "media-1",
+                "is_source": True,
+            }
+        ]
+    )
+    client = TestClient(
+        _app(core_client=_MalformedStorageResponse(), campaign_client=campaign_client)
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    assert resp.json()["assets"] == [
+        {
+            "id": "asset-1",
+            "campaign_id": _CAMPAIGN,
+            "media_kind": "image",
+            "placement": None,
+            "media_id": "media-1",
+            "is_source": True,
+            "url": None,
         }
     ]
 


### PR DESCRIPTION
Follow-up to #39, whose own code-review pass finished after that PR had
already merged (a sequencing mistake — the review should have landed before
merge, not after). Two of its findings are addressed here; two more are
filed as tracking issues rather than fixed inline, for reasons explained in
each.

## Fixed here

- **Doc correction (`admin_app.py` and `user_app.py`).** Both docstrings
  understated the real reach of opening `marketing_campaign`/`artefact`/
  `asset`/`link`'s `list`/`read`. `biffo-template`'s shared plugin host
  forwards manifest-declared `api_routes` **outside any group gate at all**
  (`plugin_host/forward.py`'s own docstring), so these four tables are
  reachable by *any authenticated tenant caller* via the generic CRUD path —
  not only by a `founder`-gated request routed through `user_app.py`, which
  is what the original docstrings implied. Corrected in both files.
  `admin_app.py` also still said "only the first [surface] is built" and
  "admin-only permissions" — both stale the moment `user_app.py` shipped.
- **`_resolve_asset_url` hardening.** A storage response with no `url` key
  (a contract change upstream, or a genuinely malformed response) previously
  raised an unhandled `KeyError` → 500 for the whole pack, contradicting the
  function's own docstring claim of degrading gracefully. Now degrades the
  same way a missing `media_id` already did (`url: null` for that one
  asset), with a regression test.

## Filed, not fixed here

- **#40** — tracks restoring tighter permissions on the four tables once
  Core's permission model can express what's actually wanted (founder-and-
  admin-only, `copy`-kind-only for `marketing_artefact`) rather than the
  blunt `required_role: []` this PR's predecessor used. Required by
  AGENTS.md §7 ("never silently disable a security gate... raise a tracking
  issue to restore it") — the original PR loosened the gate and documented
  the tradeoff but never filed the issue that section asks for.
- **#41** — a **pre-existing** class issue, not introduced by #39:
  `admin_app._latest_artefact` sorts by `created_at` with no status filter,
  so every caller that wants "the latest **approved** artefact of this
  kind" (positioning, channel plan, copy, and both pack routes) can instead
  get a newer, not-yet-approved draft and see the gate fail — even though a
  perfectly good approved artefact exists one row back. Spans five files'
  shared gating logic; needs a design decision (is "latest, period" ever
  actually wanted, or should every one of these ask for "latest approved"
  specifically?) before a fix, not a call-site patch.

## Verification

`ruff check`/`ruff format --check`/`pyright`/`pytest` (298 passed) all
green locally and via the repo's push-gate `verify` script, including
`web-admin`'s lint/typecheck/test (untouched by this PR, confirmed still
green). **Not verified against a live deployment** — same caveat as #39.

Refs #40
