### PR TITLE
feat(marketing): create a campaign from the admin panel

### DIFF
--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -20,6 +20,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^26.1.2",
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",

--- a/web-admin/pnpm-lock.yaml
+++ b/web-admin/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.3(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^26.1.2
         version: 26.2.0
@@ -590,6 +593,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.3':
+    resolution: {integrity: sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1993,6 +2002,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@testing-library/user-event@14.6.3(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 

--- a/web-admin/src/App.test.tsx
+++ b/web-admin/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import App from './App'
@@ -30,5 +31,37 @@ describe('App', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }))
     render(<App />)
     expect(await screen.findByText(/Could not load campaigns/)).toBeInTheDocument()
+  })
+})
+
+describe('creating a campaign', () => {
+  it('submits the form and refreshes the list', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: '1' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: '1', name: 'Spring', status: 'draft', destination_url: 'https://x/demo' },
+        ],
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+    await screen.findByText(/No campaigns yet/)
+
+    await user.type(screen.getByLabelText('Name'), 'Spring')
+    await user.type(screen.getByLabelText('Destination URL'), 'https://x/demo')
+    await user.click(screen.getByRole('button', { name: /create campaign/i }))
+
+    expect(await screen.findByText('Spring')).toBeInTheDocument()
+  })
+
+  it('cannot be submitted with an empty field', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => [] }))
+    render(<App />)
+    expect(screen.getByRole('button', { name: /create campaign/i })).toBeDisabled()
   })
 })

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -1,37 +1,88 @@
 import { useEffect, useState } from 'react'
 
-import { listCampaigns, type Campaign } from './lib/api'
+import { createCampaign, listCampaigns, type Campaign } from './lib/api'
 
 /** The campaign studio's admin surface.
  *
- * Deliberately a list and nothing else for now. It exists because the shared
- * plugin host will not package a plugin declaring `admin_ingress` without a
- * built `web-admin/dist` — a shell that shows real data is the smallest honest
- * thing that satisfies that, and it is what makes M2 demonstrable.
+ * A list, and a form to add to it. The form exists because a campaign studio
+ * you cannot create a campaign in is not a campaign studio — the first version
+ * of this panel was list-only, and the only way to add anything was a `fetch`
+ * pasted into devtools.
  */
 export default function App() {
   const [campaigns, setCampaigns] = useState<Campaign[] | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
+  const [name, setName] = useState('')
+  const [destination, setDestination] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  function load() {
     listCampaigns()
       .then(setCampaigns)
       .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
-  }, [])
+  }
+
+  useEffect(load, [])
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await createCampaign({ name: name.trim(), destination_url: destination.trim() })
+      setName('')
+      setDestination('')
+      load()
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const canSubmit = name.trim() !== '' && destination.trim() !== '' && !saving
 
   return (
     <main>
       <h1>Campaign studio</h1>
       <p className="lede">Campaigns for this tenant, and the tracked links minted from them.</p>
 
-      {error !== null && <p className="empty">Could not load campaigns: {error}</p>}
+      <form onSubmit={submit} aria-label="Create a campaign">
+        <h2>New campaign</h2>
+        <label htmlFor="name">Name</label>
+        <input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Spring demo push"
+        />
 
+        <label htmlFor="destination">Destination URL</label>
+        <input
+          id="destination"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          placeholder="https://dev.tabsii.com/intake/demo"
+        />
+        <p className="hint">
+          Where tracked links send people. Every minted link carries this URL with the
+          campaign&rsquo;s own id as <code>utm_campaign</code>.
+        </p>
+
+        <button type="submit" disabled={!canSubmit}>
+          {saving ? 'Creating…' : 'Create campaign'}
+        </button>
+
+        {saveError !== null && <p className="error">{saveError}</p>}
+      </form>
+
+      {error !== null && <p className="empty">Could not load campaigns: {error}</p>}
       {error === null && campaigns === null && <p className="empty">Loading…</p>}
 
       {campaigns !== null && campaigns.length === 0 && (
-        <p className="empty">
-          No campaigns yet. Create one with <code>POST /api/v1/plugins/marketing/campaigns</code>.
-        </p>
+        <p className="empty">No campaigns yet — create one above.</p>
       )}
 
       {campaigns !== null && campaigns.length > 0 && (

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -53,3 +53,63 @@ code {
   padding: 0.1rem 0.3rem;
   border-radius: 3px;
 }
+
+form {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 6px;
+  padding: 1.25rem 1.5rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+form h2 {
+  font-size: 1rem;
+  margin: 0 0 1rem;
+}
+
+label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #444;
+  margin-bottom: 0.25rem;
+}
+
+input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  font-size: 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: #666;
+  margin: -0.6rem 0 1rem;
+}
+
+button {
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.5rem 1rem;
+  border: 0;
+  border-radius: 4px;
+  background: #1a1a1a;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #bbb;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #a11;
+  font-size: 0.85rem;
+  margin: 0.75rem 0 0;
+}

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { listCampaigns } from './api'
+import { createCampaign, listCampaigns } from './api'
 import * as auth from './auth'
 
 afterEach(() => {
@@ -76,5 +76,35 @@ describe('listCampaigns authorization', () => {
     stubSession(null)
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) }))
     await expect(listCampaigns()).rejects.toThrow(/not signed in/)
+  })
+})
+
+describe('createCampaign', () => {
+  it('posts the campaign with a bearer and starts it at draft', async () => {
+    stubSession('abc123')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: '1', name: 'x', status: 'draft' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createCampaign({ name: 'Spring', destination_url: 'https://example.com/demo' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/plugins/marketing/campaigns')
+    expect(init.method).toBe('POST')
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer abc123')
+    // status is the pipeline's vocabulary, not the operator's — a new campaign
+    // always starts at draft, so the form does not offer it.
+    expect(JSON.parse(init.body as string).status).toBe('draft')
+  })
+
+  it('names the missing admin role on a 403, rather than a bare status', async () => {
+    // `marketing_campaign`'s create permission requires `admin`, evaluated by
+    // Core. Without this the form silently appears not to work.
+    stubSession()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }))
+    await expect(
+      createCampaign({ name: 'x', destination_url: 'https://example.com' }),
+    ).rejects.toThrow(/admin role/)
   })
 })

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -29,6 +29,46 @@ export interface Campaign {
 
 const BASE = '/api/v1/plugins/marketing'
 
+/** What a person supplies to create a campaign. Everything else Core derives. */
+export interface NewCampaign {
+  name: string
+  destination_url: string
+}
+
+/** Create a campaign.
+ *
+ * Requires the `admin` role — `marketing_campaign`'s own `create` permission in
+ * the manifest, evaluated by Core, not by this app. A caller without it gets a
+ * 403 and is told so, rather than the form appearing to work.
+ */
+export async function createCampaign(input: NewCampaign): Promise<Campaign> {
+  const session = await getCurrentSession()
+  const idToken = session?.getIdToken().getJwtToken() ?? null
+
+  const response = await fetch(`${BASE}/campaigns`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+    },
+    // `status` is the pipeline's own vocabulary (definitions.PIPELINE_STAGES);
+    // a new campaign always starts at draft, so the form does not offer it.
+    body: JSON.stringify({ ...input, status: 'draft' }),
+  })
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('not signed in (401) — sign in to the portal, then reload')
+    }
+    if (response.status === 403) {
+      throw new Error('you need the admin role to create a campaign (403)')
+    }
+    throw new Error(`could not create the campaign (${response.status})`)
+  }
+
+  return (await response.json()) as Campaign
+}
+
 export async function listCampaigns(): Promise<Campaign[]> {
   const session = await getCurrentSession()
   const idToken = session?.getIdToken().getJwtToken() ?? null


### PR DESCRIPTION
The panel listed campaigns and offered **no way to add one**. The only route to creating the first campaign was a `fetch` pasted into devtools — which is not a campaign studio.

A name, a destination URL, and a submit.

## Three decisions worth stating

**The destination field says what it's for.** It is the URL every minted tracked link carries, with the campaign's own id as `utm_campaign`. That relationship is the whole point of the feature and is not obvious from a label, so the form says it.

**`status` is not offered.** It is the pipeline's own vocabulary (`definitions.PIPELINE_STAGES`) and a new campaign always starts at `draft`. Offering it would invite an operator to set a state the pipeline owns.

**A 403 names the missing role.** `marketing_campaign`'s `create` permission requires `admin`, evaluated by Core. Without naming it the form simply appears not to work — which is exactly how this gap was first diagnosed on dev, with a token that had no groups.

## Verification

- 13 tests (form submit refreshes the list; empty fields disable submit; 403 names the role)
- typecheck, lint and build clean
- Asset paths checked against the **real build output**, since vite's `base` only affects emitted HTML and no other gate covers it

**Not verified: the deployed panel.** Needs sync and deploy. I will check by using the form, not by reading a status code.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)