### PR TITLE
feat(marketing): mint tracked links from the admin panel

### DIFF
--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
 
 /** The campaign studio's admin surface.
@@ -92,6 +93,7 @@ export default function App() {
               <th>Name</th>
               <th>Status</th>
               <th>Destination</th>
+              <th>Tracked links</th>
             </tr>
           </thead>
           <tbody>
@@ -100,6 +102,9 @@ export default function App() {
                 <td>{c.name}</td>
                 <td>{c.status}</td>
                 <td>{c.destination_url ?? '—'}</td>
+                <td>
+                  <MintLinks campaignId={c.id} />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/web-admin/src/components/MintLinks.test.tsx
+++ b/web-admin/src/components/MintLinks.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { MintLinks } from './MintLinks'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN = 'b3f1c0de-0000-4000-8000-0000000000ab'
+
+describe('MintLinks', () => {
+  it('mints a link and shows the URL to publish', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          links: [
+            {
+              id: 'l1',
+              channel: 'linkedin',
+              variant: null,
+              is_paid: false,
+              url: 'https://dev.tabsii.com/c/tok',
+            },
+          ],
+        }),
+      }),
+    )
+
+    render(<MintLinks campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Channel'), 'linkedin')
+    await user.click(screen.getByRole('button', { name: /mint link/i }))
+
+    expect(await screen.findByText('https://dev.tabsii.com/c/tok')).toBeInTheDocument()
+  })
+
+  it('posts to the admin app, not generated CRUD, and sends only the channel', async () => {
+    // The token and the destination (carrying utm_campaign) are DERIVED
+    // server-side. A caller that could supply either would put back the
+    // hand-typed utm_campaign this whole feature exists to remove.
+    stubSession()
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ links: [] }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<MintLinks campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Channel'), 'instagram')
+    await user.click(screen.getByRole('button', { name: /mint link/i }))
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(`/api/v1/plugins/marketing/admin/campaigns/${CAMPAIGN}/links`)
+    const sent = JSON.parse(init.body as string).links[0]
+    expect(sent).toEqual({ channel: 'instagram', is_paid: false })
+    expect(sent.token).toBeUndefined()
+    expect(sent.destination_url).toBeUndefined()
+  })
+
+  it('explains a 422 as the campaign having no destination', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 422 }))
+
+    render(<MintLinks campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Channel'), 'linkedin')
+    await user.click(screen.getByRole('button', { name: /mint link/i }))
+
+    expect(await screen.findByText(/no destination URL/i)).toBeInTheDocument()
+  })
+
+  it('cannot be submitted without a channel', () => {
+    render(<MintLinks campaignId={CAMPAIGN} />)
+    expect(screen.getByRole('button', { name: /mint link/i })).toBeDisabled()
+  })
+})

--- a/web-admin/src/components/MintLinks.tsx
+++ b/web-admin/src/components/MintLinks.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+
+import { mintLinks, type MintedLink } from '../lib/api'
+
+/** Mint tracked links for one campaign, and show the URLs to publish.
+ *
+ * The operator supplies a channel and, optionally, a variant and whether the
+ * link is paid. Everything that makes the link *trackable* — the token, and the
+ * destination carrying `utm_campaign` — is derived server-side and deliberately
+ * not offered here: a hand-typed `utm_campaign` is precisely what this feature
+ * exists to remove.
+ */
+export function MintLinks({ campaignId }: { campaignId: string }) {
+  const [channel, setChannel] = useState('')
+  const [variant, setVariant] = useState('')
+  const [isPaid, setIsPaid] = useState(false)
+  const [minting, setMinting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [minted, setMinted] = useState<MintedLink[]>([])
+  const [copied, setCopied] = useState<string | null>(null)
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setMinting(true)
+    setError(null)
+    try {
+      const links = await mintLinks(campaignId, [
+        {
+          channel: channel.trim(),
+          ...(variant.trim() !== '' ? { variant: variant.trim() } : {}),
+          is_paid: isPaid,
+        },
+      ])
+      setMinted((prev) => [...prev, ...links])
+      setChannel('')
+      setVariant('')
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setMinting(false)
+    }
+  }
+
+  async function copy(url: string) {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(url)
+    } catch {
+      // A clipboard write can be refused (permissions, or Safari outside a
+      // user gesture). Say so rather than showing a success that did not
+      // happen — the URL is on screen and selectable either way.
+      setCopied(null)
+      setError('could not copy — select the URL and copy it manually')
+    }
+  }
+
+  return (
+    <div className="mint">
+      <form onSubmit={submit} aria-label={`Mint a tracked link for ${campaignId}`}>
+        <label htmlFor={`channel-${campaignId}`}>Channel</label>
+        <input
+          id={`channel-${campaignId}`}
+          value={channel}
+          onChange={(e) => setChannel(e.target.value)}
+          placeholder="linkedin"
+        />
+
+        <label htmlFor={`variant-${campaignId}`}>Variant (optional)</label>
+        <input
+          id={`variant-${campaignId}`}
+          value={variant}
+          onChange={(e) => setVariant(e.target.value)}
+          placeholder="a"
+        />
+
+        <label className="checkbox">
+          <input type="checkbox" checked={isPaid} onChange={(e) => setIsPaid(e.target.checked)} />
+          Paid placement
+        </label>
+
+        <button type="submit" disabled={channel.trim() === '' || minting}>
+          {minting ? 'Minting…' : 'Mint link'}
+        </button>
+      </form>
+
+      {error !== null && <p className="error">{error}</p>}
+
+      {minted.length > 0 && (
+        <ul className="minted">
+          {minted.map((link) => (
+            <li key={link.id}>
+              <span className="chan">
+                {link.channel}
+                {link.variant ? ` · ${link.variant}` : ''}
+                {link.is_paid ? ' · paid' : ''}
+              </span>
+              <code>{link.url}</code>
+              <button type="button" onClick={() => copy(link.url)}>
+                {copied === link.url ? 'Copied' : 'Copy'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -113,3 +113,63 @@ button:disabled {
   font-size: 0.85rem;
   margin: 0.75rem 0 0;
 }
+
+.mint form {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+}
+
+.mint label {
+  font-size: 0.75rem;
+  margin-bottom: 0.15rem;
+}
+
+.mint input[type='text'],
+.mint input:not([type]) {
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.mint .checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 400;
+  margin-bottom: 0.6rem;
+}
+
+.mint .checkbox input {
+  width: auto;
+  margin: 0;
+}
+
+.mint button {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.7rem;
+}
+
+.minted {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+}
+
+.minted li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid #eee;
+}
+
+.minted .chan {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.minted code {
+  word-break: break-all;
+  font-size: 0.75rem;
+}

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -29,6 +29,11 @@ export interface Campaign {
 
 const BASE = '/api/v1/plugins/marketing'
 
+//: Minting is NOT generated CRUD — it reads one row and writes several, and the
+//: values it writes are derived (the token, and the destination with its UTMs).
+//: So it lives on the plugin's own admin app, one path segment deeper.
+const ADMIN_BASE = '/api/v1/plugins/marketing/admin'
+
 /** What a person supplies to create a campaign. Everything else Core derives. */
 export interface NewCampaign {
   name: string
@@ -91,4 +96,58 @@ export async function listCampaigns(): Promise<Campaign[]> {
 
   const body: unknown = await response.json()
   return Array.isArray(body) ? (body as Campaign[]) : []
+}
+
+
+/** One tracked link, as minted. */
+export interface MintedLink {
+  id: string
+  channel: string
+  variant: string | null
+  is_paid: boolean
+  /** The URL to publish. `c/<token>` on this instance's own origin. */
+  url: string
+}
+
+/** Mint tracked links for a campaign.
+ *
+ * The caller supplies only a channel (and optionally a variant, and whether it
+ * is paid). The token and the destination — including `utm_campaign`, which is
+ * the campaign's own id — are derived server-side and cannot be supplied. That
+ * is the point of the whole milestone, so the form does not offer them.
+ */
+export async function mintLinks(
+  campaignId: string,
+  links: { channel: string; variant?: string; is_paid?: boolean }[],
+): Promise<MintedLink[]> {
+  const session = await getCurrentSession()
+  const idToken = session?.getIdToken().getJwtToken() ?? null
+
+  const response = await fetch(`${ADMIN_BASE}/campaigns/${campaignId}/links`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+    },
+    body: JSON.stringify({ links }),
+  })
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('not signed in (401) — sign in to the portal, then reload')
+    }
+    if (response.status === 403) {
+      throw new Error('you need the admin role to mint links (403)')
+    }
+    if (response.status === 422) {
+      throw new Error('this campaign has no destination URL, so its links would lead nowhere')
+    }
+    if (response.status === 503) {
+      throw new Error('this deployment has no public base URL configured, so links cannot be minted')
+    }
+    throw new Error(`could not mint links (${response.status})`)
+  }
+
+  const body = (await response.json()) as { links?: MintedLink[] }
+  return body.links ?? []
 }


### PR DESCRIPTION
Creating a campaign worked; minting a link for it did not. `POST /campaigns/{id}/links` was API-only, so the attribution spine had a UI for the first half and devtools for the second.

Per campaign: a channel, an optional variant, a paid checkbox, and the **publishable URL with a copy button**.

## What the form deliberately does not offer

The **token** and the **destination**. Both are derived server-side, and a caller who could supply either would put back the hand-typed `utm_campaign` this entire feature exists to remove. A test asserts the request body carries only the channel.

Minting posts to the plugin's **own admin app**, not generated CRUD, because it reads one row and writes several. A test pins that path too — the two are one segment apart and easy to confuse.

## Errors that say what to do

- **422** → "this campaign has no destination URL, so its links would lead nowhere"
- **503** → "no public base URL configured"
- **403** → names the admin role
- A **failed clipboard write** says so rather than showing a false "Copied" — it can be refused outside a user gesture, and the URL is on screen and selectable regardless. (The day-0 design flags silent clipboard failure on mobile Safari; this does not fix that, it just stops lying about it.)

## Verification

17 tests; typecheck, lint and build clean.

**Not verified: the deployed panel.** Next step is sync, deploy, and driving it in a real browser.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)