### PR TITLE
feat(marketing): paid brief pack export (M9)

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -712,6 +712,16 @@ def build_app() -> FastAPI:
 
     app.include_router(pack_router)
 
+    # The paid brief pack (M9, issue #8) — the paid-specific additions on top
+    # of the same pack shape `pack_router` above assembles: ad copy at
+    # platform character limits, targeting from the approved positioning, a
+    # budget recommendation, and spend reported as explicitly unmeasurable
+    # (issue #31) rather than a silent zero. Same lazy-import reasoning as
+    # every other route module included above.
+    from .paid_pack_routes import router as paid_pack_router
+
+    app.include_router(paid_pack_router)
+
     # LAST. See the module docstring: a StaticFiles mount at "/" swallows
     # everything registered after it, so anything below this line is unreachable.
     static = _static_dir()

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -1,0 +1,312 @@
+"""The paid brief pack (M9, issue #8) — everything a paid channel needs that
+the organic pack (``pack_routes.py``, M5) does not already carry.
+
+**This is the organic pack's shape, with paid-specific additions, not a
+second assembler.** The two things a distribution pack always needs —
+whatever ``marketing_asset`` rows already exist, resolved to a fresh GET url,
+and tracked links minted through the same three pure functions
+(``links.mint_token`` / ``destination_with_utms`` / ``tracked_url``) —
+are reused directly from ``pack_routes`` (``_existing_assets``,
+``_asset_with_url``, ``_ensure_links``) rather than re-implemented here. What
+this module adds is the part that is genuinely paid-only:
+
+1. **Ad copy at real platform character limits.** The approved copy
+   artefact's channels already exist (``copy_routes.py``, M5); this module
+   filters to the ``paid`` ones and trims headline/body/cta to the limit its
+   guessed platform actually enforces, never mid-word.
+2. **Targeting**, drawn straight from the approved positioning artefact's
+   ``segments`` — the only audience description this pipeline has ever
+   produced, and the plugin's own citation discipline (every segment carries
+   ``sources``) already makes it a defensible brief rather than a guess.
+3. **A budget recommendation.** This plugin calls no ad platform API and has
+   no historical spend or performance data to optimise against, so this is a
+   declared, fixed starting-point heuristic — not a bidding model — and says
+   so in its own ``basis`` field.
+4. **Spend, reported as explicitly unmeasurable.** ``lead_source_costs``
+   (``tabsii.lead_source_costs``, DDL module 049) is not reachable from this
+   plugin today — no ``/api/v1/internal/*`` route is registered for it, and
+   it sits behind tabsii-CRM RBAC codes unrelated to this plugin's own admin
+   identity (issue #31, the exact gap ``results_routes.py`` already reports
+   leads/conversions/cost against). This module does not invent a call to a
+   route that does not exist; it reuses ``results_routes.UnmeasuredMetric``
+   verbatim so "no data" reads the same way here as it does on the results
+   dashboard, rather than a bespoke ``0``.
+
+## What this module deliberately does NOT do
+
+No platform API call, no app registration, no credential vault, anywhere in
+this file — the entire Meta/TikTok gauntlet stays out of the critical path by
+design (issue #8). The pack is executed by hand in Ads Manager or Google Ads;
+nothing here submits anything anywhere. It also never re-fetches or re-crops
+creative bytes — see ``pack_routes.py``'s own module docstring for exactly
+why that shape is a CodeQL ``py/full-ssrf`` sink (issue #36 owns the real
+fix, at generation time); this module inherits the same constraint by
+calling the same two functions, not by re-deriving the reasoning.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from biffo_plugin_sdk import BiffoAPIClient, create_core_client
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from . import admin_app, pack_routes, pipeline, principal_client
+from .results_routes import UnmeasuredMetric
+
+require_admin = admin_app.require_admin
+
+router = APIRouter(dependencies=[Depends(require_admin)])
+
+#: Duplicated local constant, not a cross-module reference — see
+#: `channel_plan_routes._INTERNAL_PREFIX` for exactly why:
+#: `tests/test_marketing_core_paths_guard.py` resolves a module-level string
+#: constant only within the SAME file's own AST, and its own disagreement
+#: test asserts every copy (this one included) still agrees with the rest.
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
+
+
+def get_core_client() -> BiffoAPIClient:
+    """SigV4-signed by default (ADR-0009), matching
+    `pack_routes.get_core_client` exactly — the internal storage routes are
+    IAM-only, never Cognito."""
+    return create_core_client()
+
+
+def get_campaign_client(
+    admin: Any = Depends(require_admin),
+) -> principal_client.PrincipalCoreClient:
+    """A dual-auth client for this plugin's own generated-CRUD tables
+    (`marketing_asset`), matching `pack_routes.get_campaign_client` exactly."""
+    return principal_client.PrincipalCoreClient(admin.token)
+
+
+# ── Ad copy at real platform character limits ───────────────────────────────
+
+#: Character limits by guessed platform, per field. Deliberately conservative,
+#: published numbers (Meta/Google/TikTok/LinkedIn ad-copy guidance), not
+#: fetched from anywhere — this milestone calls no platform API, so these are
+#: static data, the same way `definitions.PLACEMENTS`'s aspect ratios are.
+#: `"generic"` is the fallback for a channel this table does not recognise,
+#: sized to the narrowest of the known platforms so a guess never overstates
+#: how much room the operator actually has.
+_PLATFORM_LIMITS: dict[str, dict[str, int]] = {
+    "meta": {"headline": 40, "body": 125, "cta": 20},
+    "google_search": {"headline": 30, "body": 90, "cta": 30},
+    "tiktok": {"headline": 100, "body": 100, "cta": 20},
+    "linkedin": {"headline": 70, "body": 150, "cta": 20},
+    "generic": {"headline": 30, "body": 90, "cta": 20},
+}
+
+#: Ordered so a more specific keyword (e.g. "google") is checked before a
+#: channel name that happens to also mention a competitor in passing —
+#: not currently ambiguous with real channel names, but order is still
+#: significant and worth being explicit about.
+_PLATFORM_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("meta", ("facebook", "instagram", "meta")),
+    ("google_search", ("google",)),
+    ("tiktok", ("tiktok",)),
+    ("linkedin", ("linkedin",)),
+)
+
+_ELLIPSIS = "…"
+
+
+def _platform_for_channel(channel: str) -> str:
+    """The best-guess ad platform for a free-text channel name (e.g.
+    "Instagram Reels", "Google Search ads") — there is no channel enum
+    anywhere in this pipeline (`ChannelRecommendation.channel` is free text
+    the channel-plan agent names itself), so this is a keyword guess, not a
+    lookup. Falls back to `"generic"`'s narrower limits rather than raising:
+    an unrecognised channel still deserves a pack, just a more conservative
+    one."""
+    lowered = channel.lower()
+    for platform, keywords in _PLATFORM_KEYWORDS:
+        if any(keyword in lowered for keyword in keywords):
+            return platform
+    return "generic"
+
+
+def _fit_to_limit(text: str, limit: int) -> tuple[str, bool]:
+    """`text` trimmed to at most `limit` characters, breaking on the last
+    whole word that fits and returning whether it had to be trimmed at all.
+
+    Never truncates mid-word: this text is meant to be copied straight into
+    an Ads Manager form by a person, and a word sheared in half reads as
+    broken, not merely short. Returns `(text, False)` unchanged when it
+    already fits — matching `render.render`'s own "already correct" no-op
+    discipline for the same reason: an unnecessary rewrite is a chance to
+    introduce a difference nobody asked for.
+    """
+    if len(text) <= limit:
+        return text, False
+    if limit <= len(_ELLIPSIS):
+        return _ELLIPSIS[:limit], True
+
+    budget = limit - len(_ELLIPSIS)
+    candidate = text[:budget]
+    if " " in text[: budget + 1] and " " in candidate:
+        candidate = candidate.rsplit(" ", 1)[0]
+    return f"{candidate.rstrip()}{_ELLIPSIS}", True
+
+
+def _ad_copy_variant(channel_copy: dict[str, Any]) -> dict[str, Any]:
+    """One paid channel's copy, trimmed to its guessed platform's limits.
+
+    The original headline/body/cta are never returned alongside the trimmed
+    ones — this pack is meant to be pasted straight into Ads Manager, and a
+    second, longer copy sitting next to the one that actually fits is an
+    invitation to paste the wrong one. Each field's own `_limit` and
+    `_truncated` flag says what happened, so the trim is never silent.
+    """
+    channel = channel_copy.get("channel") or ""
+    platform = _platform_for_channel(channel)
+    limits = _PLATFORM_LIMITS[platform]
+
+    headline, headline_truncated = _fit_to_limit(
+        channel_copy.get("headline") or "", limits["headline"]
+    )
+    body, body_truncated = _fit_to_limit(channel_copy.get("body") or "", limits["body"])
+    cta, cta_truncated = _fit_to_limit(channel_copy.get("cta") or "", limits["cta"])
+
+    return {
+        "channel": channel,
+        "platform": platform,
+        "headline": headline,
+        "headline_limit": limits["headline"],
+        "headline_truncated": headline_truncated,
+        "body": body,
+        "body_limit": limits["body"],
+        "body_truncated": body_truncated,
+        "cta": cta,
+        "cta_limit": limits["cta"],
+        "cta_truncated": cta_truncated,
+    }
+
+
+# ── Budget recommendation ────────────────────────────────────────────────────
+
+#: A fixed starting-point figure, not a bid-optimisation output — see the
+#: module docstring's point 3. Changing this is a product decision, not a
+#: bugfix, which is why it is named rather than inlined.
+_DEFAULT_DAILY_TEST_BUDGET_USD = 20.0
+_DEFAULT_TEST_WINDOW_DAYS = 7
+
+
+def _budget_recommendation(paid_channel_count: int) -> dict[str, Any]:
+    """A flat per-channel daily test budget for `paid_channel_count` paid
+    channels, over `_DEFAULT_TEST_WINDOW_DAYS` days.
+
+    Deliberately not a function of anything this plugin cannot see —
+    audience size, expected CPM, historical performance — because it cannot
+    see any of them: no platform API is called, and no spend history is
+    reachable yet (issue #31). `basis` states that limitation in the
+    response itself, not only in this docstring, so a caller reading only
+    the JSON still gets the real reasoning.
+    """
+    per_channel_daily = _DEFAULT_DAILY_TEST_BUDGET_USD
+    total_daily = per_channel_daily * paid_channel_count
+    return {
+        "currency": "USD",
+        "channel_count": paid_channel_count,
+        "per_channel_daily": per_channel_daily,
+        "total_daily": total_daily,
+        "test_window_days": _DEFAULT_TEST_WINDOW_DAYS,
+        "total_test_budget": total_daily * _DEFAULT_TEST_WINDOW_DAYS,
+        "basis": (
+            f"A fixed starting-point heuristic (${per_channel_daily:.0f}/day per paid "
+            f"channel for a {_DEFAULT_TEST_WINDOW_DAYS}-day test window) — not a "
+            "bid-optimisation model. This plugin calls no ad platform API and holds no "
+            "historical spend or performance data to optimise against; reassess once "
+            "real spend and conversion data exist (see `spend` below)."
+        ),
+    }
+
+
+@router.get("/campaigns/{campaign_id}/paid-pack")
+async def get_paid_pack_route(
+    campaign_id: str,
+    core_client: BiffoAPIClient = Depends(get_core_client),
+    campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
+    admin: Any = Depends(require_admin),
+) -> dict[str, Any]:
+    """Assemble this campaign's paid brief pack: ad copy at platform
+    character limits, creative, targeting, a budget recommendation, tracked
+    links, and spend (reported as unmeasurable — see the module docstring).
+
+    Requires an **approved** `copy` artefact carrying at least one `paid`
+    channel, and an **approved** `positioning` artefact for `targeting` — the
+    same "an unreviewed artefact must never reach an operator" discipline
+    `pack_routes.get_pack_route` already enforces for the organic pack.
+    """
+    campaign_id = admin_app._validated_campaign_id(campaign_id)
+
+    campaign_resp = await admin_app._core(
+        "GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", admin.token
+    )
+    if campaign_resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+    campaign_resp.raise_for_status()
+    campaign = campaign_resp.json() or {}
+
+    copy_artefact = await admin_app._latest_artefact(campaign_id, "copy", admin.token)
+    if copy_artefact is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No copy artefact for this campaign yet."
+        )
+    try:
+        pipeline.require_approved(copy_artefact.get("status") or "", what="The copy artefact")
+    except pipeline.ArtefactNotApprovedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    raw_copy_body = copy_artefact.get("body")
+    copy_body = (
+        json.loads(raw_copy_body) if isinstance(raw_copy_body, str) else (raw_copy_body or {})
+    )
+    paid_channels = [c for c in (copy_body.get("channels") or []) if c.get("motion") == "paid"]
+    if not paid_channels:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This campaign's approved copy has no paid channels.",
+        )
+
+    positioning = await admin_app._latest_artefact(campaign_id, "positioning", admin.token)
+    if positioning is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No positioning artefact for this campaign yet.",
+        )
+    try:
+        pipeline.require_approved(positioning.get("status") or "", what="The positioning artefact")
+    except pipeline.ArtefactNotApprovedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    raw_positioning_body = positioning.get("body")
+    positioning_body = (
+        json.loads(raw_positioning_body)
+        if isinstance(raw_positioning_body, str)
+        else (raw_positioning_body or {})
+    )
+    targeting = positioning_body.get("segments") or []
+
+    assets, missing_placements = await pack_routes._existing_assets(
+        campaign_id, campaign_client=campaign_client
+    )
+    assets_with_urls = [await pack_routes._asset_with_url(core_client, a) for a in assets]
+
+    links = await pack_routes._ensure_links(
+        campaign_id, paid_channels, campaign=campaign, admin_token=admin.token
+    )
+
+    return {
+        "campaign_id": campaign_id,
+        "ad_copy": [_ad_copy_variant(c) for c in paid_channels],
+        "assets": assets_with_urls,
+        "missing_placements": missing_placements,
+        "targeting": targeting,
+        "budget": _budget_recommendation(len(paid_channels)),
+        "links": links,
+        "guidance": campaign.get("guidance") or "",
+        "spend": UnmeasuredMetric(),
+    }

--- a/tests/test_marketing_core_paths_guard.py
+++ b/tests/test_marketing_core_paths_guard.py
@@ -222,8 +222,8 @@ def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
     `_INTERNAL_PREFIX` copies this file's own docstring explains
     (`admin_app.py`, `channel_plan_routes.py`, `image_routes.py`,
     `results_routes.py`, `copy_routes.py`, `pack_routes.py`, `user_app.py`,
-    each forced local because the AST walk resolves a named constant only
-    within the file that defines it) actually agree with each other or with
+    `paid_pack_routes.py`, each forced local because the AST walk resolves a
+    named constant only within the file that defines it) actually agree with
     the real mounted path. Verified empirically before this test was written: a
     single-character typo in one copy (`marketting` for `marketing`) sends
     every call in that file to an unmounted path while the rest of this
@@ -242,6 +242,7 @@ def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
         copy_routes,
         image_routes,
         pack_routes,
+        paid_pack_routes,
         results_routes,
         user_app,
     )
@@ -254,3 +255,4 @@ def test_the_internal_prefix_constant_agrees_across_every_copy() -> None:
     assert results_routes._INTERNAL_PREFIX == canonical
     assert copy_routes._INTERNAL_PREFIX == canonical
     assert pack_routes._INTERNAL_PREFIX == canonical
+    assert paid_pack_routes._INTERNAL_PREFIX == canonical

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -1,0 +1,457 @@
+"""The paid brief pack (M9, issue #8), over the same fakes
+`test_marketing_pack_routes.py` uses for the organic pack — the internal
+(SigV4) storage client, the dual-auth asset client, and `admin_app._core` —
+plus one addition: the fake `_core` also has to answer a `positioning`
+artefact lookup, since `targeting` is drawn from it.
+
+Fixture UUIDs deliberately do not end in twelve digits (gitleaks'
+`biffo-aws-account-id` rule matches any bare run of twelve).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, pack_routes, paid_pack_routes
+from marketing.definitions import PLACEMENTS
+
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ab"
+_SOURCE_MEDIA_ID = "media-source"
+_BASE_URL = "https://dev.example.invalid"
+
+_ORGANIC_CHANNEL = {
+    "channel": "Instagram Reels",
+    "motion": "organic",
+    "headline": "Run every site the same way, finally.",
+    "body": "One dashboard, every location.",
+    "cta": "See how it works",
+    "sources": [{"url": "https://example.com/y", "note": "n"}],
+}
+
+_PAID_CHANNEL_META = {
+    "channel": "Facebook feed ads",
+    "motion": "paid",
+    "headline": ("Run every one of your sites exactly the same way, finally, at last, for good"),
+    "body": (
+        "One dashboard controls every location's marketing, so nothing drifts between "
+        "sites and nobody has to remember to do the same thing five times over."
+    ),
+    "cta": "Book a demo today",
+    "sources": [{"url": "https://example.com/z", "note": "n"}],
+}
+
+_PAID_CHANNEL_GOOGLE = {
+    "channel": "Google Search ads",
+    "motion": "paid",
+    "headline": "Short headline",
+    "body": "Short body",
+    "cta": "Go",
+    "sources": [{"url": "https://example.com/w", "note": "n"}],
+}
+
+_SEGMENTS = [
+    {
+        "name": "Multi-site operators",
+        "description": "Operators running more than one location.",
+        "sources": [{"url": "https://example.com/seg", "note": "n"}],
+    }
+]
+
+
+def _source_asset() -> dict[str, Any]:
+    return {
+        "id": "asset-source",
+        "campaign_id": _CAMPAIGN,
+        "media_kind": "image",
+        "placement": None,
+        "media_id": _SOURCE_MEDIA_ID,
+        "is_source": True,
+    }
+
+
+def _copy_artefact(channels: list[dict[str, Any]], *, status: str = "approved") -> dict[str, Any]:
+    return {
+        "id": "artefact-copy-1",
+        "campaign_id": _CAMPAIGN,
+        "kind": "copy",
+        "status": status,
+        "body": json.dumps({"channels": channels}),
+        "created_at": "2026-08-10T00:00:01Z",
+    }
+
+
+def _positioning_artefact(
+    segments: list[dict[str, Any]], *, status: str = "approved"
+) -> dict[str, Any]:
+    return {
+        "id": "artefact-positioning-1",
+        "campaign_id": _CAMPAIGN,
+        "kind": "positioning",
+        "status": status,
+        "body": json.dumps({"segments": segments, "pillars": [], "ctas": []}),
+        "created_at": "2026-08-10T00:00:00Z",
+    }
+
+
+_DEFAULT_CAMPAIGN = object()
+
+
+class _FakeCore:
+    """Stands in for `admin_app._core`: campaigns, artefacts (copy AND
+    positioning — the paid pack needs both) and links."""
+
+    def __init__(
+        self,
+        *,
+        campaign: dict[str, Any] | None | object = _DEFAULT_CAMPAIGN,
+        copy_artefact: dict[str, Any] | None = None,
+        positioning_artefact: dict[str, Any] | None = None,
+    ) -> None:
+        self.campaign = (
+            {
+                "id": _CAMPAIGN,
+                "destination_url": "https://example.com/landing",
+                "guidance": "Disclose #ad. Licensed music only.",
+            }
+            if campaign is _DEFAULT_CAMPAIGN
+            else campaign
+        )
+        self.copy_artefact = copy_artefact
+        self.positioning_artefact = positioning_artefact
+        self.links: list[dict[str, Any]] = []
+        self._next_link_id = 0
+
+    async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
+        request = httpx.Request(method, f"https://core.invalid{path}")
+        prefix = admin_app._INTERNAL_PREFIX
+        if method == "GET" and path == f"{prefix}/campaigns/{_CAMPAIGN}":
+            if self.campaign is None:
+                return httpx.Response(404, json={"detail": "not found"}, request=request)
+            return httpx.Response(200, json=self.campaign, request=request)
+        if method == "GET" and path == f"{prefix}/artefacts":
+            params = kw.get("params") or {}
+            kind = params.get("kind")
+            if kind == "copy":
+                rows = [self.copy_artefact] if self.copy_artefact else []
+            elif kind == "positioning":
+                rows = [self.positioning_artefact] if self.positioning_artefact else []
+            else:
+                rows = []
+            return httpx.Response(200, json=rows, request=request)
+        if method == "GET" and path == f"{prefix}/links":
+            return httpx.Response(200, json=self.links, request=request)
+        if method == "POST" and path == f"{prefix}/links":
+            self._next_link_id += 1
+            row = {"id": f"link-{self._next_link_id}", **kw["json"]}
+            self.links.append(row)
+            return httpx.Response(201, json=row, request=request)
+        raise AssertionError(f"unexpected call {method} {path}")
+
+
+class _FakeCampaignClient:
+    def __init__(self, *, assets: list[dict[str, Any]] | None = None) -> None:
+        self.assets: list[dict[str, Any]] = list(assets or [])
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        if path == f"{paid_pack_routes._INTERNAL_PREFIX}/assets":
+            campaign_id = (params or {}).get("campaign_id")
+            return [a for a in self.assets if a.get("campaign_id") == campaign_id]
+        raise AssertionError(f"unexpected GET {path}")
+
+
+class _FakeStorageClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        self.calls.append(("GET", path, params))
+        # The literal storage path `pack_routes._asset_with_url` (reused by
+        # this route) resolves URLs through — matching
+        # `test_marketing_pack_routes._FakeStorageClient` exactly.
+        prefix = f"{pack_routes._STORAGE_PATH}/"
+        if path.startswith(prefix) and path.endswith("/url"):
+            media_id = path[len(prefix) : -len("/url")]
+            return {
+                "url": f"https://bucket.s3.eu-west-1.amazonaws.com/signed-get-{media_id}",
+                "expires_in": 300,
+            }
+        raise AssertionError(f"unexpected GET {path}")
+
+
+def _admin_user() -> Any:
+    return type("U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"})()
+
+
+def _app(*, core_client: _FakeStorageClient, campaign_client: _FakeCampaignClient) -> FastAPI:
+    app = FastAPI()
+    app.include_router(paid_pack_routes.router)
+    app.dependency_overrides[paid_pack_routes.require_admin] = _admin_user
+    app.dependency_overrides[paid_pack_routes.get_core_client] = lambda: core_client
+    app.dependency_overrides[paid_pack_routes.get_campaign_client] = lambda: campaign_client
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _base_url(monkeypatch: pytest.MonkeyPatch):
+    # `_ensure_links` (reused from `pack_routes`) reads `public_base_url`
+    # through that module's own imported name — patched there, matching
+    # `test_marketing_pack_routes.py`'s own fixture exactly.
+    monkeypatch.setattr(pack_routes, "public_base_url", lambda: _BASE_URL)
+
+
+# ── failure paths ────────────────────────────────────────────────────────────
+
+
+def test_404s_an_unknown_campaign(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(campaign=None)
+    monkeypatch.setattr(admin_app, "_core", core)
+    client = TestClient(
+        _app(core_client=_FakeStorageClient(), campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+
+
+def test_404s_when_no_copy_artefact_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(copy_artefact=None)
+    monkeypatch.setattr(admin_app, "_core", core)
+    client = TestClient(
+        _app(core_client=_FakeStorageClient(), campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+    assert "copy" in resp.json()["detail"].lower()
+
+
+def test_409s_when_copy_is_not_approved(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(copy_artefact=_copy_artefact([_PAID_CHANNEL_META], status="proposed"))
+    monkeypatch.setattr(admin_app, "_core", core)
+    client = TestClient(
+        _app(core_client=_FakeStorageClient(), campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 409
+
+
+def test_404s_when_the_approved_copy_has_no_paid_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Organic-only copy must not produce a paid pack — there is nothing paid
+    to brief."""
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_ORGANIC_CHANNEL]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+    assert "paid" in resp.json()["detail"].lower()
+
+
+def test_404s_when_no_positioning_artefact_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(copy_artefact=_copy_artefact([_PAID_CHANNEL_META]), positioning_artefact=None)
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+    assert "positioning" in resp.json()["detail"].lower()
+
+
+def test_409s_when_positioning_is_not_approved(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS, status="proposed"),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 409
+
+
+def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    client = TestClient(
+        _app(core_client=_FakeStorageClient(), campaign_client=_FakeCampaignClient(assets=[]))
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+    assert "source creative" in resp.json()["detail"].lower()
+
+
+# ── the happy path ───────────────────────────────────────────────────────────
+
+
+def test_assembles_the_paid_pack(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_ORGANIC_CHANNEL, _PAID_CHANNEL_META, _PAID_CHANNEL_GOOGLE]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    storage = _FakeStorageClient()
+    client = TestClient(_app(core_client=storage, campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # 1. Ad copy: only the PAID channels, never the organic one, each fit to
+    # its guessed platform's limits.
+    assert {c["channel"] for c in body["ad_copy"]} == {
+        "Facebook feed ads",
+        "Google Search ads",
+    }
+    meta_copy = next(c for c in body["ad_copy"] if c["channel"] == "Facebook feed ads")
+    assert meta_copy["platform"] == "meta"
+    assert len(meta_copy["headline"]) <= meta_copy["headline_limit"] == 40
+    assert len(meta_copy["body"]) <= meta_copy["body_limit"] == 125
+    assert meta_copy["headline_truncated"] is True
+    assert meta_copy["headline"].endswith("…")
+    assert " " not in meta_copy["headline"][-2:]  # never cut mid-word
+
+    google_copy = next(c for c in body["ad_copy"] if c["channel"] == "Google Search ads")
+    assert google_copy["platform"] == "google_search"
+    # Short enough already: untouched, not truncated.
+    assert google_copy["headline"] == "Short headline"
+    assert google_copy["headline_truncated"] is False
+
+    # 2. Creative: same shape as the organic pack — whatever assets already
+    # exist, with the gap named rather than silently absent.
+    assert len(body["assets"]) == 1
+    assert body["assets"][0]["is_source"] is True
+    assert set(body["missing_placements"]) == set(PLACEMENTS)
+
+    # 3. Targeting: the approved positioning's segments, verbatim.
+    assert body["targeting"] == _SEGMENTS
+
+    # 4. Budget: a stated, non-fabricated heuristic over the paid channel
+    # count (2 here), not a bid-optimisation number.
+    assert body["budget"]["channel_count"] == 2
+    assert body["budget"]["per_channel_daily"] == 20.0
+    assert body["budget"]["total_daily"] == 40.0
+    assert "heuristic" in body["budget"]["basis"].lower()
+
+    # 5. Links: one per PAID channel, both `is_paid`.
+    assert len(body["links"]) == 2
+    assert all(link["is_paid"] for link in body["links"])
+    assert all("utm_medium=paid" in core.links[i]["destination_url"] for i in range(2))
+
+    # 6. Spend: explicitly unmeasurable, never a fabricated zero.
+    assert body["spend"]["measurable"] is False
+    assert "issue #31" in body["spend"]["reason"] or "31" in body["spend"]["reason"]
+
+    # 7. Guidance carried through unchanged, same as the organic pack.
+    assert body["guidance"] == "Disclose #ad. Licensed music only."
+
+
+def test_does_not_remint_a_paid_link_for_a_channel_that_already_has_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    core.links.append(
+        {
+            "id": "link-existing",
+            "campaign_id": _CAMPAIGN,
+            "token": "existing-token",
+            "channel": "Facebook feed ads",
+            "variant": None,
+            "is_paid": True,
+            "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+        }
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["links"]) == 1
+    assert resp.json()["links"][0]["url"] == f"{_BASE_URL}/c/existing-token"
+    assert core.links == [core.links[0]]
+
+
+# ── pure-function unit tests ─────────────────────────────────────────────────
+
+
+def test_fit_to_limit_leaves_short_text_untouched() -> None:
+    text, truncated = paid_pack_routes._fit_to_limit("Book a demo", 40)
+    assert text == "Book a demo"
+    assert truncated is False
+
+
+def test_fit_to_limit_never_cuts_mid_word() -> None:
+    text, truncated = paid_pack_routes._fit_to_limit("Run every one of your sites the same way", 20)
+    assert truncated is True
+    assert len(text) <= 20
+    assert text.endswith("…")
+    assert not text[:-1].endswith(" ")  # no trailing space before the ellipsis
+    # Every word in the trimmed text is a whole word from the source.
+    words = text[:-1].split()
+    source_words = "Run every one of your sites the same way".split()
+    assert words == source_words[: len(words)]
+
+
+def test_fit_to_limit_handles_a_limit_smaller_than_the_ellipsis() -> None:
+    text, truncated = paid_pack_routes._fit_to_limit("Hello world", 1)
+    assert truncated is True
+    assert len(text) == 1
+
+
+@pytest.mark.parametrize(
+    ("channel", "expected"),
+    [
+        ("Facebook feed ads", "meta"),
+        ("Instagram Stories ads", "meta"),
+        ("Meta Advantage+", "meta"),
+        ("Google Search ads", "google_search"),
+        ("Google Performance Max", "google_search"),
+        ("TikTok Spark ads", "tiktok"),
+        ("LinkedIn Sponsored Content", "linkedin"),
+        ("Pinterest ads", "generic"),
+    ],
+)
+def test_platform_for_channel(channel: str, expected: str) -> None:
+    assert paid_pack_routes._platform_for_channel(channel) == expected
+
+
+def test_budget_recommendation_scales_with_channel_count() -> None:
+    one = paid_pack_routes._budget_recommendation(1)
+    three = paid_pack_routes._budget_recommendation(3)
+    assert one["total_daily"] == paid_pack_routes._DEFAULT_DAILY_TEST_BUDGET_USD
+    assert three["total_daily"] == paid_pack_routes._DEFAULT_DAILY_TEST_BUDGET_USD * 3
+    assert three["total_test_budget"] == (
+        three["total_daily"] * paid_pack_routes._DEFAULT_TEST_WINDOW_DAYS
+    )


### PR DESCRIPTION
## What

`GET /campaigns/{id}/paid-pack` — the paid brief pack (M9). Same shape as the
organic pack (`pack_routes.py`, M5): whatever `marketing_asset` rows already
exist (reused via `pack_routes._existing_assets`/`_asset_with_url`, not
re-fetched or re-cropped), and tracked links (reused via
`pack_routes._ensure_links`, filtered to `paid`-motion channels only).

New in this module, in `src/marketing/paid_pack_routes.py`:

- **Ad copy at platform character limits** — each paid channel's copy trimmed
  to a guessed platform's headline/body/cta limits (Meta/Google/TikTok/
  LinkedIn published numbers), breaking on a whole word, never mid-string.
  `*_truncated` flags say when a trim happened.
- **Targeting** — the approved positioning artefact's `segments`, verbatim.
- **Budget** — a stated, fixed starting-point heuristic ($20/day per paid
  channel, 7-day test window), not a bid-optimisation model — the response's
  own `basis` field says why.
- **Spend** — reported via `results_routes.UnmeasuredMetric` (reused, not
  reinvented): `lead_source_costs` has no reachable `/api/v1/internal/*`
  route from this plugin (#31), so this never emits a fabricated zero.

No platform API call anywhere in this route, no app registration, no
credential vault — the entire Meta/TikTok gauntlet stays out of the critical
path by design.

`admin_app.py` gains one `include_router` line. The core-paths guard's
disagreement test (`test_the_internal_prefix_constant_agrees_across_every_copy`)
is extended to cover the new module's `_INTERNAL_PREFIX` copy.

## Not verified

No live deployment check — this is unit-tested against fakes only (mirroring
`test_marketing_pack_routes.py`'s own convention), same as every other route
module in this plugin.

Refs #8
