### PR TITLE
fix(marketing): paid-pack link leak, ad-copy trim, empty-targeting gate

### DIFF
--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -17,7 +17,10 @@ this module adds is the part that is genuinely paid-only:
 2. **Targeting**, drawn straight from the approved positioning artefact's
    ``segments`` — the only audience description this pipeline has ever
    produced, and the plugin's own citation discipline (every segment carries
-   ``sources``) already makes it a defensible brief rather than a guess.
+   ``sources``) already makes it a defensible brief rather than a guess. An
+   approved positioning with zero segments 404s rather than shipping an
+   empty targeting brief silently — the same gap-must-be-visible discipline
+   this file uses for ``paid_channels``.
 3. **A budget recommendation.** This plugin calls no ad platform API and has
    no historical spend or performance data to optimise against, so this is a
    declared, fixed starting-point heuristic — not a bidding model — and says
@@ -146,7 +149,14 @@ def _fit_to_limit(text: str, limit: int) -> tuple[str, bool]:
 
     budget = limit - len(_ELLIPSIS)
     candidate = text[:budget]
-    if " " in text[: budget + 1] and " " in candidate:
+    # Only back off to the previous whole word when the cut ITSELF lands
+    # mid-word (the character immediately after `candidate` is not a space).
+    # A cut that already lands exactly on a word boundary must keep every
+    # word it already has — checking `" " in candidate` alone (the earlier
+    # version of this function) can't tell those two cases apart, so it
+    # always discarded one extra whole word even when the boundary was
+    # already clean, wasting characters the platform actually allows.
+    if text[budget] != " " and " " in candidate:
         candidate = candidate.rsplit(" ", 1)[0]
     return f"{candidate.rstrip()}{_ELLIPSIS}", True
 
@@ -236,9 +246,10 @@ async def get_paid_pack_route(
     links, and spend (reported as unmeasurable — see the module docstring).
 
     Requires an **approved** `copy` artefact carrying at least one `paid`
-    channel, and an **approved** `positioning` artefact for `targeting` — the
-    same "an unreviewed artefact must never reach an operator" discipline
-    `pack_routes.get_pack_route` already enforces for the organic pack.
+    channel, and an **approved** `positioning` artefact with at least one
+    `segment` for `targeting` — the same "an unreviewed or empty artefact
+    must never reach an operator" discipline `pack_routes.get_pack_route`
+    already enforces for the organic pack's copy gate.
     """
     campaign_id = admin_app._validated_campaign_id(campaign_id)
 
@@ -289,6 +300,11 @@ async def get_paid_pack_route(
         else (raw_positioning_body or {})
     )
     targeting = positioning_body.get("segments") or []
+    if not targeting:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The approved positioning artefact has no segments to target.",
+        )
 
     assets, missing_placements = await pack_routes._existing_assets(
         campaign_id, campaign_client=campaign_client
@@ -298,6 +314,16 @@ async def get_paid_pack_route(
     links = await pack_routes._ensure_links(
         campaign_id, paid_channels, campaign=campaign, admin_token=admin.token
     )
+    # `_ensure_links` returns every link Core holds for this campaign, not
+    # just the `paid_channels` subset passed in — see issue #48. Filtered
+    # back down here rather than at the source, since fixing it properly
+    # needs `pack_routes.py`, which several agents work in concurrently and
+    # this change does not touch. This does not fix the rarer case issue #48
+    # also describes (a paid channel sharing an organic channel's exact name
+    # would still surface that organic link instead of minting a paid one) —
+    # that half needs the source fix.
+    paid_channel_names = {c["channel"] for c in paid_channels}
+    links = [link for link in links if link.get("channel") in paid_channel_names]
 
     return {
         "campaign_id": campaign_id,

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -290,6 +290,27 @@ def test_409s_when_positioning_is_not_approved(monkeypatch: pytest.MonkeyPatch) 
     assert resp.status_code == 409
 
 
+def test_404s_when_the_approved_positioning_has_no_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An approved positioning with an empty `segments` list must not ship a
+    silently-empty targeting brief — same "the gap is visible, not silent"
+    discipline as the missing-paid-channels and missing-source-creative
+    cases above."""
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact([]),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 404
+    assert "segments" in resp.json()["detail"].lower()
+
+
 def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) -> None:
     core = _FakeCore(
         copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
@@ -373,6 +394,40 @@ def test_assembles_the_paid_pack(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["guidance"] == "Disclose #ad. Licensed music only."
 
 
+def test_does_not_leak_an_existing_organic_link_into_the_paid_pack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`pack_routes._ensure_links` (reused here) returns every link Core
+    holds for the campaign, not just the requested `channels` (issue #48) —
+    an organic link for a channel this paid pack never asked about must not
+    show up in its `links`."""
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_ORGANIC_CHANNEL, _PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    core.links.append(
+        {
+            "id": "link-organic",
+            "campaign_id": _CAMPAIGN,
+            "token": "organic-token",
+            "channel": _ORGANIC_CHANNEL["channel"],
+            "variant": None,
+            "is_paid": False,
+            "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+        }
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+
+    assert resp.status_code == 200
+    links = resp.json()["links"]
+    assert {link["channel"] for link in links} == {_PAID_CHANNEL_META["channel"]}
+    assert all(link["is_paid"] for link in links)
+
+
 def test_does_not_remint_a_paid_link_for_a_channel_that_already_has_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -422,6 +477,16 @@ def test_fit_to_limit_never_cuts_mid_word() -> None:
     words = text[:-1].split()
     source_words = "Run every one of your sites the same way".split()
     assert words == source_words[: len(words)]
+
+
+def test_fit_to_limit_keeps_the_full_word_when_the_cut_already_lands_on_a_boundary() -> None:
+    """When `budget` characters happen to land exactly on a space, the whole
+    word up to that point must be kept — backing off one further word (the
+    bug this regresses) wastes characters the platform actually allows."""
+    text, truncated = paid_pack_routes._fit_to_limit("Hello wonderful world", 16)
+    assert truncated is True
+    assert text == "Hello wonderful…"
+    assert len(text) == 16
 
 
 def test_fit_to_limit_handles_a_limit_smaller_than_the_ellipsis() -> None:


### PR DESCRIPTION
## What

Three fast-follow fixes to the paid brief pack (#47), all found by code
review and each confirmed with a failing-first test before the fix:

1. **Link leak.** `pack_routes._ensure_links` (reused by this route) returns
   every link Core holds for the campaign, not just the `paid_channels`
   subset passed in — so any pre-existing organic link surfaced in this
   route's `links` too. Filtered back down to the requested channels here.
   The root cause lives in `pack_routes.py`, filed separately as #48 (not
   fixed here — that file is worked on by other agents concurrently).
2. **`_fit_to_limit` over-trimmed.** A cut that already landed exactly on a
   word boundary was still backing off one further whole word, wasting
   characters the platform actually allows (`"Hello wonderful world"` at a
   16-char limit produced `"Hello…"` instead of `"Hello wonderful…"`).
3. **Empty targeting shipped silently.** An approved positioning artefact
   with zero segments produced a 200 with `targeting: []` instead of naming
   the gap, inconsistent with the `paid_channels`-empty case a few lines
   above it.

## Verified

Full `uv run pytest` (322 passed, 3 new regression tests), `ruff`, `pyright`,
`gitleaks` — all green, plus the repo's own pre-push `verify.sh` gate before
pushing.

## Not verified

No live-deployment check, same as #47 — unit-tested against fakes only.

Refs #8
