### PR TITLE
fix(marketing): derive the public base URL from the request, not from config

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -62,12 +62,12 @@ from typing import Any
 import httpx
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 from . import pipeline, principal_client
-from .config import public_base_url
+from .config import public_base_url_for
 from .definitions import ARTEFACT_KINDS, MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
 from .image_routes import router as image_router
 from .links import destination_with_utms, mint_token, tracked_url
@@ -163,7 +163,10 @@ class MintBody(BaseModel):
 
 @router.post("/campaigns/{campaign_id}/links", status_code=status.HTTP_201_CREATED)
 async def mint_links(
-    campaign_id: str, body: MintBody, admin: Any = Depends(require_admin)
+    campaign_id: str,
+    body: MintBody,
+    request: Request,
+    admin: Any = Depends(require_admin),
 ) -> dict[str, Any]:
     """Mint tracked links for a campaign, and return the URLs to publish.
 
@@ -179,7 +182,7 @@ async def mint_links(
     and they are an authenticated admin of this tenant. The public route's
     silence is about not confirming a *stranger's* guess.
     """
-    base_url = public_base_url()
+    base_url = public_base_url_for(request.headers.get("origin"), request.headers.get("referer"))
     if not base_url:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/marketing/config.py
+++ b/src/marketing/config.py
@@ -15,6 +15,7 @@ side of that arrangement.
 from __future__ import annotations
 
 import os
+from urllib.parse import urlsplit
 
 from aws_lambda_powertools import Logger
 
@@ -96,3 +97,37 @@ def reset_cache() -> None:
     """Forget the resolved value. For tests only."""
     global _cached
     _cached = None
+
+
+def public_base_url_for(origin: str | None, referer: str | None) -> str:
+    """This deployment's public origin, preferring what the caller actually used.
+
+    **Why the request, and not configuration.** A plugin's Terraform sets
+    environment on the plugin's OWN Lambda, but an ``admin_ingress`` app runs on
+    the SHARED PLUGIN HOST — a different function, with a different role and a
+    different environment. So `BIFFO_PUBLIC_BASE_URL_PARAMETER` and the SSM read
+    grant both landed somewhere this code never executes, and
+    ``public_base_url()`` correctly reported "not configured" forever. That gap
+    is keiranholloway/biffo-template#1456.
+
+    The origin an operator is looking at IS the public base URL, by definition —
+    they loaded this panel from it. CloudFront's `AllViewerExceptHostHeader`
+    policy drops `Host` but forwards every other viewer header, so `Origin` (and
+    `Referer` as a fallback) arrive intact.
+
+    **Safe because of what this value is used for.** It composes only the URL
+    *shown* to the operator. The link's stored ``destination_url`` is built from
+    the campaign's own destination, server-side, and is never derived from a
+    header — so a forged `Origin` can at worst show a caller a link on the
+    origin they already control, and cannot redirect anyone anywhere.
+
+    Falls back to the configured value, which is still right for any caller that
+    sends neither header.
+    """
+    for candidate in (origin, referer):
+        if not candidate:
+            continue
+        parts = urlsplit(candidate)
+        if parts.scheme in ("http", "https") and parts.netloc:
+            return f"{parts.scheme}://{parts.netloc}"
+    return public_base_url()

--- a/tests/test_marketing_config.py
+++ b/tests/test_marketing_config.py
@@ -117,3 +117,36 @@ def test_a_resolved_value_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
         assert config.public_base_url() == "https://dev.tabsii.com"
 
     assert len(calls) == 1
+
+
+def test_the_request_origin_is_preferred_over_configuration() -> None:
+    """The origin an operator is looking at IS the public base URL.
+
+    A plugin's Terraform configures the plugin's OWN Lambda, but an
+    `admin_ingress` app runs on the shared plugin host — a different function
+    with a different environment. So the configured value is absent exactly
+    where this code runs (biffo-template#1456), and the request is the only
+    reliable source.
+    """
+    assert config.public_base_url_for("https://dev.tabsii.com", None) == "https://dev.tabsii.com"
+
+
+def test_the_referer_is_the_fallback_when_there_is_no_origin() -> None:
+    """A same-origin GET may carry Referer but no Origin."""
+    assert (
+        config.public_base_url_for(None, "https://dev.tabsii.com/api/v1/plugins/marketing/admin")
+        == "https://dev.tabsii.com"
+    )
+
+
+def test_a_non_http_scheme_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only http(s) origins are usable; anything else falls through."""
+    monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL", "https://configured.example")
+    assert config.public_base_url_for("file:///etc/passwd", None) == "https://configured.example"
+
+
+def test_it_falls_back_to_configuration_when_neither_header_is_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL", "https://configured.example")
+    assert config.public_base_url_for(None, None) == "https://configured.example"

--- a/tests/test_marketing_dual_auth_wiring.py
+++ b/tests/test_marketing_dual_auth_wiring.py
@@ -99,7 +99,7 @@ def test_mint_links_forwards_the_real_admins_token_through_core(
     """`_core`'s own body — not a mock of it — signs both of `mint_links`'
     Core calls with the SAME token the request arrived with."""
     monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
-    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE_URL)
+    monkeypatch.setattr(admin_app, "public_base_url_for", lambda origin, referer: _BASE_URL)
     app = admin_app.build_app()
     app.dependency_overrides[admin_app.require_admin] = lambda: type(
         "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
@@ -125,7 +125,7 @@ def test_mint_links_calls_the_real_internal_paths_not_the_token(
     were ever transposed, the token (a JWT-shaped string, never starting
     with `/`) would arrive here as the `path`."""
     monkeypatch.setattr(admin_app, "CORE_API_URL", _CORE_API_URL)
-    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE_URL)
+    monkeypatch.setattr(admin_app, "public_base_url_for", lambda origin, referer: _BASE_URL)
     app = admin_app.build_app()
     app.dependency_overrides[admin_app.require_admin] = lambda: type(
         "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}

--- a/tests/test_marketing_mint_route.py
+++ b/tests/test_marketing_mint_route.py
@@ -54,7 +54,7 @@ class _FakeCore:
 def ctx(monkeypatch: pytest.MonkeyPatch):
     core = _FakeCore()
     monkeypatch.setattr(admin_app, "_core", core)
-    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE)
+    monkeypatch.setattr(admin_app, "public_base_url_for", lambda origin, referer: _BASE)
 
     app = admin_app.build_app()
     # The host gates on the Cognito group before this app sees a request
@@ -135,7 +135,7 @@ def test_a_campaign_with_no_destination_is_refused(monkeypatch: pytest.MonkeyPat
     """
     core = _FakeCore(destination=None)
     monkeypatch.setattr(admin_app, "_core", core)
-    monkeypatch.setattr(admin_app, "public_base_url", lambda: _BASE)
+    monkeypatch.setattr(admin_app, "public_base_url_for", lambda origin, referer: _BASE)
     app = admin_app.build_app()
     app.dependency_overrides[admin_app.require_admin] = lambda: type(
         "U", (), {"sub": "a", "groups": ["admin"], "token": "t"}
@@ -154,7 +154,7 @@ def test_an_unconfigured_deployment_says_so_rather_than_minting_a_broken_url(
 ) -> None:
     """Without a base URL the minted link would be published as `/c/<token>`."""
     monkeypatch.setattr(admin_app, "_core", _FakeCore())
-    monkeypatch.setattr(admin_app, "public_base_url", lambda: "")
+    monkeypatch.setattr(admin_app, "public_base_url_for", lambda origin, referer: "")
     app = admin_app.build_app()
     app.dependency_overrides[admin_app.require_admin] = lambda: type(
         "U", (), {"sub": "a", "groups": ["admin"], "token": "t"}


### PR DESCRIPTION
Minting failed on the deployed panel with **"this deployment has no public base URL configured"** — my own 503, firing correctly, against configuration that could never have been present.

## The cause

A plugin's Terraform sets environment on the **plugin's own Lambda**. An `admin_ingress` app runs on the **shared plugin host** — a different function, with a different role and a different environment. Confirmed on dev:

```
plugin lambda: BIFFO_PUBLIC_BASE_URL_PARAMETER  present
plugin host:   absent
```

So both the env var and the `ssm:GetParameter` grant landed on a Lambda this code never executes in. **Setting the SSM parameter could not have fixed it** — the host's role cannot read it either. This is keiranholloway/biffo-template#1456 in its sharpest form.

## The fix

The origin an operator is looking at **is** the public base URL — they loaded the panel from it. CloudFront's `AllViewerExceptHostHeader` policy drops `Host` but forwards every other viewer header, so `Origin` (and `Referer` as fallback) arrive intact. Configuration remains the fallback for callers that send neither.

**Safe because of what the value does.** It composes only the URL *shown* to the operator. The link's stored `destination_url` is built server-side from the campaign's own destination and never from a header — so a forged `Origin` can at worst show a caller a link on an origin they already control, and cannot redirect anyone anywhere. Non-http(s) schemes are rejected.

## Verification

326 passed; ruff and pyright clean.

**Not verified: the deployed mint.** That is the next step — I will mint a link in the browser and click it.

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)