### PR TITLE
feat(marketing): admin UI for the pipeline, images, packs and results

### DIFF
--- a/web-admin/src/App.test.tsx
+++ b/web-admin/src/App.test.tsx
@@ -65,3 +65,26 @@ describe('creating a campaign', () => {
     expect(screen.getByRole('button', { name: /create campaign/i })).toBeDisabled()
   })
 })
+
+describe('opening a campaign studio', () => {
+  it('switches to the campaign detail view, and back again', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { id: '1', name: 'Spring demo push', status: 'draft', destination_url: null, brief: null },
+      ],
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const user = userEvent.setup()
+    render(<App />)
+    await screen.findByText('Spring demo push')
+
+    await user.click(screen.getByRole('button', { name: /^open$/i }))
+    expect(screen.getByRole('heading', { name: 'Spring demo push' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Pipeline' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /back to campaigns/i }))
+    expect(screen.getByRole('heading', { name: 'Campaign studio' })).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -1,18 +1,22 @@
 import { useEffect, useState } from 'react'
 
+import { CampaignDetail } from './components/CampaignDetail'
 import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
 
 /** The campaign studio's admin surface.
  *
- * A list, and a form to add to it. The form exists because a campaign studio
- * you cannot create a campaign in is not a campaign studio — the first version
- * of this panel was list-only, and the only way to add anything was a `fetch`
- * pasted into devtools.
+ * A list, and a form to add to it, and — once a campaign exists — the whole
+ * studio behind it: the brief, the pipeline gates (M3–M5), image generation
+ * (M6), both distribution packs (M5/M9), and results (M8). The first version
+ * of this panel was list-only, and the only way to add anything was a
+ * `fetch` pasted into devtools; this is the second gap of the same shape —
+ * seven milestones of API with no way to reach them from a browser.
  */
 export default function App() {
   const [campaigns, setCampaigns] = useState<Campaign[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<Campaign | null>(null)
 
   const [name, setName] = useState('')
   const [destination, setDestination] = useState('')
@@ -26,6 +30,23 @@ export default function App() {
   }
 
   useEffect(load, [])
+
+  function handleCampaignUpdated(updated: Campaign) {
+    setSelected(updated)
+    setCampaigns((prev) => prev?.map((c) => (c.id === updated.id ? updated : c)) ?? prev)
+  }
+
+  if (selected !== null) {
+    return (
+      <main>
+        <CampaignDetail
+          campaign={selected}
+          onBack={() => setSelected(null)}
+          onCampaignUpdated={handleCampaignUpdated}
+        />
+      </main>
+    )
+  }
 
   async function submit(event: React.FormEvent) {
     event.preventDefault()
@@ -94,6 +115,7 @@ export default function App() {
               <th>Status</th>
               <th>Destination</th>
               <th>Tracked links</th>
+              <th>Studio</th>
             </tr>
           </thead>
           <tbody>
@@ -104,6 +126,11 @@ export default function App() {
                 <td>{c.destination_url ?? '—'}</td>
                 <td>
                   <MintLinks campaignId={c.id} />
+                </td>
+                <td>
+                  <button type="button" onClick={() => setSelected(c)}>
+                    Open
+                  </button>
                 </td>
               </tr>
             ))}

--- a/web-admin/src/components/ArtefactBody.tsx
+++ b/web-admin/src/components/ArtefactBody.tsx
@@ -1,0 +1,158 @@
+import type { ReactNode } from 'react'
+
+import type {
+  ChannelPlanBody as ChannelPlanBodyT,
+  CopySetBody,
+  PositioningBody as PositioningBodyT,
+  ResearchSynthesisBody,
+  Source,
+} from '../lib/api'
+
+/** Every artefact kind's body is grounded in citations, and the citations are
+ * the whole reason a human approval gate exists here at all — see
+ * `pipeline.py`'s module docstring on the zero-citation guard. Shown next to
+ * every claim, never collapsed into a count. */
+export function SourceList({ sources }: { sources: Source[] }) {
+  if (sources.length === 0) {
+    return <p className="no-sources">No sources cited.</p>
+  }
+  return (
+    <ul className="sources">
+      {sources.map((s) => (
+        <li key={s.url}>
+          <a href={s.url} target="_blank" rel="noreferrer">
+            {s.url}
+          </a>
+          <span className="note">{s.note}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+interface FindingItem {
+  key: string
+  /** The item's own heading, as a full element — callers vary the tag
+   * (`<h4>`/`<h5>`/`<p className="pillar">`) and content (plain text, or
+   * text plus a motion badge), so this is a rendered node, not a string. */
+  heading: ReactNode
+  body: ReactNode
+  sources: Source[]
+}
+
+/** One list of cited items — a research finding, a positioning segment,
+ * pillar or CTA, a channel-plan recommendation, or one channel's copy. Every
+ * artefact kind's body is a list of exactly this shape (a heading, some
+ * prose, and its sources), so the four renderers below share this one loop
+ * rather than repeating `.map(...) => <div className="finding">…` four
+ * times with nothing to keep them in step. */
+function FindingGroup({ items }: { items: FindingItem[] }) {
+  return (
+    <>
+      {items.map((item) => (
+        <div className="finding" key={item.key}>
+          {item.heading}
+          {item.body}
+          <SourceList sources={item.sources} />
+        </div>
+      ))}
+    </>
+  )
+}
+
+export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
+  return (
+    <div className="artefact-body">
+      <p className="summary">{body.summary}</p>
+      <FindingGroup
+        items={body.findings.map((f, i) => ({
+          key: `${f.signal}-${i}`,
+          heading: <h4>{f.signal}</h4>,
+          body: <p>{f.why_it_matters}</p>,
+          sources: f.sources,
+        }))}
+      />
+    </div>
+  )
+}
+
+export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
+  return (
+    <div className="artefact-body">
+      <h4>Segments</h4>
+      <FindingGroup
+        items={body.segments.map((s, i) => ({
+          key: `${s.name}-${i}`,
+          heading: <h5>{s.name}</h5>,
+          body: <p>{s.description}</p>,
+          sources: s.sources,
+        }))}
+      />
+
+      <h4>Message pillars</h4>
+      <FindingGroup
+        items={body.pillars.map((p, i) => ({
+          key: `${p.pillar}-${i}`,
+          heading: <p className="pillar">{p.pillar}</p>,
+          body: <p>{p.rationale}</p>,
+          sources: p.sources,
+        }))}
+      />
+
+      <h4>Calls to action</h4>
+      <FindingGroup
+        items={body.ctas.map((c, i) => ({
+          key: `${c.text}-${i}`,
+          heading: <p className="pillar">{c.text}</p>,
+          body: <p>{c.rationale}</p>,
+          sources: c.sources,
+        }))}
+      />
+    </div>
+  )
+}
+
+export function ChannelPlanArtefact({ body }: { body: ChannelPlanBodyT }) {
+  const byRank = [...body.channels].sort((a, b) => a.rank - b.rank)
+  return (
+    <div className="artefact-body">
+      <FindingGroup
+        items={byRank.map((c, i) => ({
+          key: `${c.channel}-${i}`,
+          heading: (
+            <h4>
+              #{c.rank} {c.channel} <span className={`motion motion-${c.motion}`}>{c.motion}</span>
+            </h4>
+          ),
+          body: <p>{c.rationale}</p>,
+          sources: c.sources,
+        }))}
+      />
+    </div>
+  )
+}
+
+export function CopyArtefact({ body }: { body: CopySetBody }) {
+  return (
+    <div className="artefact-body">
+      <FindingGroup
+        items={body.channels.map((c, i) => ({
+          key: `${c.channel}-${i}`,
+          heading: (
+            <h4>
+              {c.channel} <span className={`motion motion-${c.motion}`}>{c.motion}</span>
+            </h4>
+          ),
+          body: (
+            <>
+              <p className="headline">{c.headline}</p>
+              <p>{c.body}</p>
+              <p className="cta">{c.cta}</p>
+            </>
+          ),
+          sources: c.sources,
+        }))}
+      />
+    </div>
+  )
+}

--- a/web-admin/src/components/CampaignDetail.test.tsx
+++ b/web-admin/src/components/CampaignDetail.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import type { Campaign } from '../lib/api'
+import { CampaignDetail } from './CampaignDetail'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN: Campaign = {
+  id: 'c1',
+  name: 'Spring demo push',
+  status: 'draft',
+  destination_url: 'https://example.com/demo',
+  brief: null,
+  guidance: null,
+}
+
+describe('CampaignDetail', () => {
+  it('renders the campaign name and every section, and calls back on "Back"', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }))
+
+    const onBack = vi.fn()
+    const user = userEvent.setup()
+    render(<CampaignDetail campaign={CAMPAIGN} onBack={onBack} onCampaignUpdated={() => {}} />)
+
+    expect(screen.getByRole('heading', { name: 'Spring demo push' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Pipeline' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Images' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Distribution pack' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Paid brief pack' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Results' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /back to campaigns/i }))
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it('blocks research with no brief, and saving one unlocks it', async () => {
+    stubSession()
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.endsWith('/campaigns/c1') && init?.method === 'PATCH') {
+        return Promise.resolve({ ok: true, json: async () => ({ ...CAMPAIGN, brief: 'Who this is for.' }) })
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const onCampaignUpdated = vi.fn()
+    const user = userEvent.setup()
+    render(<CampaignDetail campaign={CAMPAIGN} onBack={() => {}} onCampaignUpdated={onCampaignUpdated} />)
+
+    const research = await screen.findByTestId('stage-research')
+    expect(within(research).getByRole('button', { name: /start research/i })).toBeDisabled()
+
+    await user.type(screen.getByLabelText('Brief'), 'Who this is for.')
+    await user.click(screen.getByRole('button', { name: /save brief/i }))
+
+    expect(onCampaignUpdated).toHaveBeenCalledWith(expect.objectContaining({ brief: 'Who this is for.' }))
+  })
+})

--- a/web-admin/src/components/CampaignDetail.tsx
+++ b/web-admin/src/components/CampaignDetail.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+
+import { updateCampaign, type Campaign } from '../lib/api'
+import { DistributionPack } from './DistributionPack'
+import { ImageGenerator } from './ImageGenerator'
+import { PaidPack } from './PaidPack'
+import { Pipeline } from './Pipeline'
+import { Results } from './Results'
+
+/** One campaign's whole studio: the brief, the pipeline gates, image
+ * generation, both distribution packs, and results — everything M3–M9 built
+ * an API for but that, before this component, had no browser surface at all.
+ */
+export function CampaignDetail({
+  campaign,
+  onBack,
+  onCampaignUpdated,
+}: {
+  campaign: Campaign
+  onBack: () => void
+  onCampaignUpdated: (campaign: Campaign) => void
+}) {
+  const [brief, setBrief] = useState(campaign.brief ?? '')
+  const [savingBrief, setSavingBrief] = useState(false)
+  const [briefError, setBriefError] = useState<string | null>(null)
+
+  async function saveBrief(event: React.FormEvent) {
+    event.preventDefault()
+    setSavingBrief(true)
+    setBriefError(null)
+    try {
+      const updated = await updateCampaign(campaign.id, { brief: brief.trim() })
+      onCampaignUpdated(updated)
+    } catch (e: unknown) {
+      setBriefError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSavingBrief(false)
+    }
+  }
+
+  const campaignBrief = (campaign.brief ?? '').trim()
+  const hasBrief = campaignBrief !== ''
+
+  return (
+    <div className="campaign-detail">
+      <button type="button" className="back" onClick={onBack}>
+        &larr; Back to campaigns
+      </button>
+      <h2>{campaign.name}</h2>
+      <p className="lede">{campaign.destination_url ?? 'No destination URL set'}</p>
+
+      <section className="brief" aria-label="Campaign brief">
+        <h3>Brief</h3>
+        <p className="hint">
+          What research and positioning are grounded in. Required before research can start —
+          nothing else in the pipeline can run before it does.
+        </p>
+        <form onSubmit={saveBrief}>
+          <label htmlFor="brief">Brief</label>
+          <textarea
+            id="brief"
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+            placeholder="Who this campaign is for, what it's promoting, and why now."
+          />
+          <button type="submit" disabled={savingBrief || brief.trim() === campaignBrief}>
+            {savingBrief ? 'Saving…' : 'Save brief'}
+          </button>
+          {briefError !== null && <p className="error">{briefError}</p>}
+        </form>
+      </section>
+
+      <h3>Pipeline</h3>
+      <Pipeline campaignId={campaign.id} hasBrief={hasBrief} />
+
+      <h3>Images</h3>
+      <ImageGenerator campaignId={campaign.id} />
+
+      <h3>Distribution pack</h3>
+      <DistributionPack campaignId={campaign.id} />
+
+      <h3>Paid brief pack</h3>
+      <PaidPack campaignId={campaign.id} />
+
+      <h3>Results</h3>
+      <Results campaignId={campaign.id} />
+    </div>
+  )
+}

--- a/web-admin/src/components/DistributionPack.test.tsx
+++ b/web-admin/src/components/DistributionPack.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { DistributionPack } from './DistributionPack'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN = 'c1'
+
+describe('DistributionPack', () => {
+  it('surfaces missing_placements rather than a pack that quietly omits them', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          assets: [
+            {
+              id: 'as1',
+              campaign_id: CAMPAIGN,
+              media_kind: 'image',
+              placement: null,
+              media_id: 'm1',
+              is_source: true,
+              url: 'https://example.com/source.png',
+            },
+          ],
+          missing_placements: ['feed_1x1', 'story_9x16'],
+          copy: [
+            { channel: 'linkedin', motion: 'organic', headline: 'H', body: 'B', cta: 'C', sources: [] },
+          ],
+          links: [{ channel: 'linkedin', variant: null, is_paid: false, url: 'https://x/c/tok' }],
+          guidance: 'Disclose paid placements per platform policy.',
+        }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    expect(await screen.findByText(/missing renders for: feed_1x1, story_9x16/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/linkedin/).length).toBeGreaterThan(0)
+    expect(screen.getByText('https://x/c/tok')).toBeInTheDocument()
+    expect(screen.getByText('Disclose paid placements per platform policy.')).toBeInTheDocument()
+  })
+
+  it('says plainly when a deployment has no public base URL, rather than a broken link', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          assets: [],
+          missing_placements: [],
+          copy: [],
+          links: [{ channel: 'linkedin', variant: null, is_paid: false, url: null }],
+          guidance: '',
+        }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    expect(await screen.findByText(/no public base url configured/i)).toBeInTheDocument()
+  })
+
+  it('reports a load failure with the server reason, not a raw body', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'No approved source creative for this campaign yet.' }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    expect(await screen.findByText(/no approved source creative/i)).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/DistributionPack.tsx
+++ b/web-admin/src/components/DistributionPack.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+
+import { getPack, type Pack } from '../lib/api'
+import { useClipboard } from '../lib/useClipboard'
+import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from './PackParts'
+
+/** The distribution pack (M5): assets, approved copy, tracked links and
+ * guidance, assembled from an **approved** copy artefact — `pack_routes.py`'s
+ * own "the milestone's actual deliverable" (M1–M4 only produce an approved
+ * plan; nothing an operator can publish comes out of them without this).
+ *
+ * `missing_placements` is shown, not hidden: this plugin only renders a
+ * campaign's source creative today, not per-placement crops (issue #36), and
+ * a pack that quietly omitted that gap would look complete when it is not.
+ */
+export function DistributionPack({ campaignId }: { campaignId: string }) {
+  const [pack, setPack] = useState<Pack | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { copied, copy, error: copyError } = useClipboard()
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      setPack(await getPack(campaignId))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="pack" aria-label="Distribution pack">
+      <button type="button" onClick={load} disabled={loading}>
+        {loading ? 'Loading…' : pack === null ? 'Load pack' : 'Reload pack'}
+      </button>
+
+      {error !== null && <p className="error">{error}</p>}
+      {copyError !== null && <p className="error">{copyError}</p>}
+
+      {pack !== null && (
+        <div className="pack-body">
+          <MissingPlacementsWarning missingPlacements={pack.missing_placements} />
+
+          <PackAssets assets={pack.assets} />
+
+          <h4>Copy</h4>
+          {pack.copy.length === 0 && <p className="empty">No approved copy channels.</p>}
+          <ul className="copy-list">
+            {pack.copy.map((c, i) => (
+              <li key={`${c.channel}-${i}`}>
+                <strong>{c.channel}</strong> <span className={`motion motion-${c.motion}`}>{c.motion}</span>
+                <p className="headline">{c.headline}</p>
+                <p>{c.body}</p>
+                <p className="cta">{c.cta}</p>
+              </li>
+            ))}
+          </ul>
+
+          <PackLinks links={pack.links} copied={copied} onCopy={copy} />
+
+          <PackGuidance guidance={pack.guidance} />
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web-admin/src/components/ImageGenerator.test.tsx
+++ b/web-admin/src/components/ImageGenerator.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { ImageGenerator } from './ImageGenerator'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN = 'c1'
+
+describe('ImageGenerator', () => {
+  it('generates a still and shows it', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          asset: { id: 'as1' },
+          media: { id: 'm1' },
+          url: 'https://example.com/still.png',
+          ledger: { id: 'l1', cost_usd: 0.04, unpriced: false },
+        }),
+      }),
+    )
+
+    render(<ImageGenerator campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Prompt'), 'a storefront photo')
+    await user.click(screen.getByRole('button', { name: /generate still/i }))
+
+    expect(await screen.findByAltText('Generated still')).toHaveAttribute(
+      'src',
+      'https://example.com/still.png',
+    )
+    expect(screen.getByText('Cost: $0.0400')).toBeInTheDocument()
+  })
+
+  it('shows "unpriced", never $0, when cost_usd is null', async () => {
+    // The null case is load-bearing — image_routes.py's own reasoning.
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          asset: { id: 'as1' },
+          media: { id: 'm1' },
+          url: 'https://example.com/still.png',
+          ledger: { id: 'l1', cost_usd: null, unpriced: true },
+        }),
+      }),
+    )
+
+    render(<ImageGenerator campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Prompt'), 'a storefront photo')
+    await user.click(screen.getByRole('button', { name: /generate still/i }))
+
+    expect(await screen.findByText('Cost: unpriced')).toBeInTheDocument()
+    expect(screen.queryByText(/\$0/)).not.toBeInTheDocument()
+  })
+
+  it('cannot be submitted with an empty prompt', () => {
+    render(<ImageGenerator campaignId={CAMPAIGN} />)
+    expect(screen.getByRole('button', { name: /generate still/i })).toBeDisabled()
+  })
+
+  it('surfaces a provider failure rather than silently doing nothing', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: async () => ({ detail: 'the image provider returned an error' }),
+      }),
+    )
+
+    render(<ImageGenerator campaignId={CAMPAIGN} />)
+    await user.type(screen.getByLabelText('Prompt'), 'a storefront photo')
+    await user.click(screen.getByRole('button', { name: /generate still/i }))
+
+    expect(await screen.findByText(/image provider returned an error/i)).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/ImageGenerator.tsx
+++ b/web-admin/src/components/ImageGenerator.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+
+import { generateStill, type GenerateStillResponse } from '../lib/api'
+
+/** `cost_usd` is nullable and the null case is load-bearing (`ledger.py` /
+ * `image_routes.py`): show "unpriced", never £0 — a £0 reads as "this cost
+ * nothing", which is a different and false claim from "this deployment could
+ * not price it". */
+function formatCost(ledger: GenerateStillResponse['ledger']): string {
+  if (ledger.unpriced || ledger.cost_usd === null) return 'unpriced'
+  return `$${ledger.cost_usd.toFixed(4)}`
+}
+
+/** Still-image generation (M6): a prompt in, a stored asset and its ledgered
+ * cost out. This route is the only path in the plugin that calls a provider
+ * to create image bytes (`image_routes.py`'s module docstring), so every
+ * asset it writes is, by construction, this campaign's source creative.
+ *
+ * Only shows stills generated in this browser session — there is no
+ * admin-reachable route to resolve a stored asset back to a fresh URL outside
+ * pack assembly (`pack_routes.py`'s `_asset_with_url` uses the SigV4-signed
+ * internal client this surface cannot reach), so a history of past
+ * generations belongs to the distribution pack view, not here.
+ */
+export function ImageGenerator({ campaignId }: { campaignId: string }) {
+  const [prompt, setPrompt] = useState('')
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [generated, setGenerated] = useState<GenerateStillResponse[]>([])
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setGenerating(true)
+    setError(null)
+    try {
+      const result = await generateStill(campaignId, prompt.trim())
+      setGenerated((prev) => [result, ...prev])
+      setPrompt('')
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  return (
+    <section className="images" aria-label="Still images">
+      <form onSubmit={submit} aria-label="Generate a still image">
+        <label htmlFor={`prompt-${campaignId}`}>Prompt</label>
+        <textarea
+          id={`prompt-${campaignId}`}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="A bright, welcoming photo of a small business storefront…"
+        />
+        <button type="submit" disabled={prompt.trim() === '' || generating}>
+          {generating ? 'Generating…' : 'Generate still'}
+        </button>
+      </form>
+
+      {error !== null && <p className="error">{error}</p>}
+
+      {generated.length === 0 && <p className="empty">No stills generated yet this session.</p>}
+
+      {generated.length > 0 && (
+        <ul className="stills">
+          {generated.map((g) => (
+            <li key={g.media.id}>
+              <img src={g.url} alt="Generated still" />
+              <p className="cost">Cost: {formatCost(g.ledger)}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/web-admin/src/components/PackParts.tsx
+++ b/web-admin/src/components/PackParts.tsx
@@ -1,0 +1,87 @@
+import type { PackAsset, PackLink } from '../lib/api'
+
+/** The organic pack (M5) and paid pack (M9) are the same shape with
+ * paid-specific additions on top (`paid_pack_routes.py`'s own module
+ * docstring: "the organic pack's shape... not a second assembler"). These
+ * four pieces — the missing-placements warning, the creative grid, the
+ * tracked-links list, and the guidance block — render identically in both,
+ * so they live here once rather than twice. A fix to the clipboard-copy
+ * failure path (see `useClipboard`) or to how a missing render is disclosed
+ * now lands in one place for both packs, not one and possibly not the
+ * other.
+ */
+
+export function MissingPlacementsWarning({ missingPlacements }: { missingPlacements: string[] }) {
+  if (missingPlacements.length === 0) return null
+  return (
+    <p className="warning">
+      Missing renders for: {missingPlacements.join(', ')} — only the source creative is available
+      for these placements so far.
+    </p>
+  )
+}
+
+export function PackAssets({ assets }: { assets: PackAsset[] }) {
+  return (
+    <>
+      <h4>Creative</h4>
+      {assets.length === 0 && <p className="empty">No creative yet.</p>}
+      <ul className="assets">
+        {assets.map((a) => (
+          <li key={a.id}>
+            <img src={a.url} alt={a.placement ?? 'Source creative'} />
+            <span>{a.is_source === true ? 'Source' : (a.placement ?? '—')}</span>
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+export function PackLinks({
+  links,
+  copied,
+  onCopy,
+}: {
+  links: PackLink[]
+  copied: string | null
+  onCopy: (url: string) => void
+}) {
+  return (
+    <>
+      <h4>Tracked links</h4>
+      {links.length === 0 && <p className="empty">No tracked links yet.</p>}
+      <ul className="minted">
+        {links.map((l, i) => (
+          <li key={`${l.channel}-${i}`}>
+            <span className="chan">
+              {l.channel}
+              {l.variant !== null && l.variant !== '' ? ` · ${l.variant}` : ''}
+              {l.is_paid === true ? ' · paid' : ''}
+            </span>
+            {l.url !== null ? (
+              <>
+                <code>{l.url}</code>
+                <button type="button" onClick={() => onCopy(l.url as string)}>
+                  {copied === l.url ? 'Copied' : 'Copy'}
+                </button>
+              </>
+            ) : (
+              <span className="empty">No public base URL configured for this deployment</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+export function PackGuidance({ guidance }: { guidance: string }) {
+  if (guidance === '') return null
+  return (
+    <>
+      <h4>Guidance</h4>
+      <p className="guidance">{guidance}</p>
+    </>
+  )
+}

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { PaidPack } from './PaidPack'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN = 'c1'
+
+describe('PaidPack', () => {
+  it('shows trimmed ad copy, targeting, budget, and spend as explicitly unmeasurable', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          ad_copy: [
+            {
+              channel: 'Facebook Feed',
+              platform: 'meta',
+              headline: 'Fast onboarding, done right',
+              headline_limit: 40,
+              headline_truncated: false,
+              body: 'A'.repeat(130),
+              body_limit: 125,
+              body_truncated: true,
+              cta: 'Learn more',
+              cta_limit: 20,
+              cta_truncated: false,
+            },
+          ],
+          assets: [],
+          missing_placements: ['feed_1x1'],
+          targeting: [{ name: 'Busy owners', description: 'Time-poor franchise owners.', sources: [] }],
+          budget: {
+            currency: 'USD',
+            channel_count: 1,
+            per_channel_daily: 20,
+            total_daily: 20,
+            test_window_days: 7,
+            total_test_budget: 140,
+            basis: 'A fixed starting-point heuristic.',
+          },
+          links: [],
+          guidance: '',
+          spend: {
+            measurable: false,
+            denominator: null,
+            reason: 'No route reachable from this plugin exposes this yet.',
+          },
+        }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/missing renders for: feed_1x1/i)).toBeInTheDocument()
+    expect(screen.getByText(/trimmed to 125 chars/i)).toBeInTheDocument()
+    expect(screen.getByText('Busy owners')).toBeInTheDocument()
+    expect(screen.getByText(/1 paid channel\(s\)/)).toBeInTheDocument()
+    expect(screen.getByText(/not measurable — no route reachable/i)).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/PaidPack.tsx
+++ b/web-admin/src/components/PaidPack.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+
+import { getPaidPack, type PaidPack as PaidPackData } from '../lib/api'
+import { useClipboard } from '../lib/useClipboard'
+import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from './PackParts'
+
+/** The paid brief pack (M9): ad copy at real platform character limits,
+ * creative, targeting drawn from the approved positioning, a declared budget
+ * heuristic, tracked links, and spend — reported as explicitly unmeasurable
+ * (issue #31), reusing the exact same `UnmeasuredMetric` shape the results
+ * dashboard uses, so "no data" reads the same way in both places rather than
+ * a bespoke zero here.
+ *
+ * Assets, tracked links, the missing-placements warning and guidance are the
+ * same pieces `DistributionPack` renders — shared via `PackParts.tsx` rather
+ * than duplicated (`paid_pack_routes.py`'s own module docstring: "this is
+ * the organic pack's shape, with paid-specific additions, not a second
+ * assembler").
+ */
+export function PaidPack({ campaignId }: { campaignId: string }) {
+  const [pack, setPack] = useState<PaidPackData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { copied, copy, error: copyError } = useClipboard()
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      setPack(await getPaidPack(campaignId))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="paid-pack" aria-label="Paid brief pack">
+      <button type="button" onClick={load} disabled={loading}>
+        {loading ? 'Loading…' : pack === null ? 'Load paid pack' : 'Reload paid pack'}
+      </button>
+
+      {error !== null && <p className="error">{error}</p>}
+      {copyError !== null && <p className="error">{copyError}</p>}
+
+      {pack !== null && (
+        <div className="pack-body">
+          <MissingPlacementsWarning missingPlacements={pack.missing_placements} />
+
+          <h4>Ad copy</h4>
+          <ul className="ad-copy">
+            {pack.ad_copy.map((c, i) => (
+              <li key={`${c.channel}-${i}`}>
+                <strong>{c.channel}</strong> <span className="platform">{c.platform}</span>
+                <p className="headline">
+                  {c.headline}
+                  {c.headline_truncated && (
+                    <span className="trimmed"> (trimmed to {c.headline_limit} chars)</span>
+                  )}
+                </p>
+                <p>
+                  {c.body}
+                  {c.body_truncated && <span className="trimmed"> (trimmed to {c.body_limit} chars)</span>}
+                </p>
+                <p className="cta">
+                  {c.cta}
+                  {c.cta_truncated && <span className="trimmed"> (trimmed to {c.cta_limit} chars)</span>}
+                </p>
+              </li>
+            ))}
+          </ul>
+
+          <h4>Targeting</h4>
+          {pack.targeting.length === 0 && <p className="empty">No segments to target.</p>}
+          <ul className="targeting">
+            {pack.targeting.map((s, i) => (
+              <li key={`${s.name}-${i}`}>
+                <strong>{s.name}</strong>
+                <p>{s.description}</p>
+              </li>
+            ))}
+          </ul>
+
+          <h4>Budget</h4>
+          <p>
+            {pack.budget.channel_count} paid channel(s) · ${pack.budget.per_channel_daily.toFixed(0)}/day
+            each · ${pack.budget.total_daily.toFixed(0)}/day total over {pack.budget.test_window_days} days
+            (${pack.budget.total_test_budget.toFixed(0)} total)
+          </p>
+          <p className="hint">{pack.budget.basis}</p>
+
+          <h4>Spend</h4>
+          <p className="unmeasurable">Not measurable — {pack.spend.reason}</p>
+
+          <PackAssets assets={pack.assets} />
+
+          <PackLinks links={pack.links} copied={copied} onCopy={copy} />
+
+          <PackGuidance guidance={pack.guidance} />
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { Pipeline } from './Pipeline'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN = 'c1'
+
+/** A `fetch` stub that answers every stage's GET as "not started yet" (404)
+ * unless `artefacts` supplies a row for that kind. */
+function fetchStub(artefacts: Record<string, { status: string; body?: string | null } | undefined> = {}) {
+  return vi.fn((url: string, init?: RequestInit) => {
+    const match = /\/artefacts\/([a-z_]+)$/.exec(url)
+    if (match && (!init || init.method === undefined)) {
+      const kind = match[1]
+      const row = artefacts[kind]
+      if (row === undefined) {
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          id: `a-${kind}`,
+          campaign_id: CAMPAIGN,
+          kind,
+          status: row.status,
+          body: row.body ?? null,
+          citations: null,
+          causation_id: null,
+          agent_run_id: null,
+        }),
+      })
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+  })
+}
+
+describe('Pipeline', () => {
+  it('renders all four stages, gating everything past research when nothing is approved', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', fetchStub())
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} />)
+
+    expect(await screen.findByRole('button', { name: /start research/i })).toBeEnabled()
+
+    const positioning = screen.getByTestId('stage-positioning')
+    expect(
+      await within(positioning).findByRole('button', { name: /start positioning/i }),
+    ).toBeDisabled()
+    expect(within(positioning).getByText(/approve the research stage first/i)).toBeInTheDocument()
+  })
+
+  it('blocks research itself when the campaign has no brief', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', fetchStub())
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={false} />)
+
+    const research = await screen.findByTestId('stage-research')
+    expect(within(research).getByRole('button', { name: /start research/i })).toBeDisabled()
+    expect(within(research).getByText(/no brief yet/i)).toBeInTheDocument()
+  })
+
+  it('unlocks positioning once research is approved, and renders its findings', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({
+        research: {
+          status: 'approved',
+          body: JSON.stringify({
+            summary: 'The market wants faster onboarding.',
+            findings: [
+              {
+                signal: 'Competitors take 3 weeks to onboard',
+                why_it_matters: 'Speed is a wedge',
+                sources: [{ url: 'https://example.com/report', note: 'Industry report' }],
+              },
+            ],
+          }),
+        },
+      }),
+    )
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} />)
+
+    expect(await screen.findByText('The market wants faster onboarding.')).toBeInTheDocument()
+
+    const positioning = screen.getByTestId('stage-positioning')
+    expect(within(positioning).getByRole('button', { name: /start positioning/i })).toBeEnabled()
+  })
+
+  it('approves a proposed stage and reflects the new status', async () => {
+    stubSession()
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.endsWith('/artefacts/research/approve')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 'a-research',
+            campaign_id: CAMPAIGN,
+            kind: 'research',
+            status: 'approved',
+            body: JSON.stringify({ summary: 'x', findings: [] }),
+            citations: null,
+            causation_id: null,
+            agent_run_id: null,
+          }),
+        })
+      }
+      if (typeof url === 'string' && url.endsWith('/artefacts/research') && init?.method === undefined) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: 'a-research',
+            campaign_id: CAMPAIGN,
+            kind: 'research',
+            status: 'proposed',
+            body: JSON.stringify({ summary: 'x', findings: [] }),
+            citations: null,
+            causation_id: null,
+            agent_run_id: null,
+          }),
+        })
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const user = userEvent.setup()
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} />)
+
+    const research = await screen.findByTestId('stage-research')
+    await user.click(within(research).getByRole('button', { name: /^approve$/i }))
+
+    expect(await within(research).findByText('Approved')).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState, type ReactNode } from 'react'
+
+import {
+  approveArtefact,
+  getArtefact,
+  parseArtefactBody,
+  rejectArtefact,
+  startChannelPlan,
+  startCopy,
+  startPositioning,
+  startResearch,
+  type Artefact,
+  type ArtefactKind,
+  type ChannelPlanBody,
+  type CopySetBody,
+  type PositioningBody,
+  type ResearchSynthesisBody,
+} from '../lib/api'
+import { ChannelPlanArtefact, CopyArtefact, PositioningArtefact, ResearchArtefact } from './ArtefactBody'
+import { PipelineStage } from './PipelineStage'
+
+interface StageState {
+  artefact: Artefact | null
+  loading: boolean
+  error: string | null
+  busy: boolean
+}
+
+interface Gate {
+  canStart: boolean
+  blockedReason: string | null
+}
+
+/** `ok`, and the one reason to show when it is not — collapses what would
+ * otherwise be a parallel `x ? null : '...'` ternary at every gate. */
+function reason(ok: boolean, blockedReason: string): Gate {
+  return { canStart: ok, blockedReason: ok ? null : blockedReason }
+}
+
+/** Whether each stage's artefact has cleared its approval gate — the only
+ * thing every `gate()` below reads. */
+interface Approved {
+  research: boolean
+  positioning: boolean
+  channel_plan: boolean
+}
+
+interface StageConfig {
+  kind: ArtefactKind
+  title: string
+  start: (campaignId: string) => Promise<Artefact>
+  /** The stage's real output, once it has one — never called for a `null`
+   * or still-`pending` artefact (see `Pipeline`'s render loop). */
+  renderBody: (artefact: Artefact) => ReactNode
+  gate: (approved: Approved, hasBrief: boolean) => Gate
+}
+
+/** Everything that varies per stage, in one place — a fifth stage is one new
+ * entry here, not four disjoint edits across a starter map, a body-render
+ * switch and a gate map with nothing enforcing they stay in step. */
+const STAGES: StageConfig[] = [
+  {
+    kind: 'research',
+    title: 'Research',
+    start: startResearch,
+    renderBody: (artefact) => {
+      const body = parseArtefactBody<ResearchSynthesisBody>(artefact)
+      return body !== null ? <ResearchArtefact body={body} /> : <p className="empty">No content to show.</p>
+    },
+    gate: (_approved, hasBrief) =>
+      reason(hasBrief, 'This campaign has no brief yet — add one above before starting research.'),
+  },
+  {
+    kind: 'positioning',
+    title: 'Positioning',
+    start: startPositioning,
+    renderBody: (artefact) => {
+      const body = parseArtefactBody<PositioningBody>(artefact)
+      return body !== null ? <PositioningArtefact body={body} /> : <p className="empty">No content to show.</p>
+    },
+    gate: (approved) => reason(approved.research, 'Approve the research stage first.'),
+  },
+  {
+    kind: 'channel_plan',
+    title: 'Channel plan',
+    start: startChannelPlan,
+    renderBody: (artefact) => {
+      const body = parseArtefactBody<ChannelPlanBody>(artefact)
+      return body !== null ? <ChannelPlanArtefact body={body} /> : <p className="empty">No content to show.</p>
+    },
+    gate: (approved) => reason(approved.positioning, 'Approve the positioning stage first.'),
+  },
+  {
+    kind: 'copy',
+    title: 'Copy',
+    start: startCopy,
+    renderBody: (artefact) => {
+      const body = parseArtefactBody<CopySetBody>(artefact)
+      return body !== null ? <CopyArtefact body={body} /> : <p className="empty">No content to show.</p>
+    },
+    gate: (approved) =>
+      reason(
+        approved.positioning && approved.channel_plan,
+        'Approve the positioning and channel-plan stages first.',
+      ),
+  },
+]
+
+function initialState(): Record<ArtefactKind, StageState> {
+  const empty = (): StageState => ({ artefact: null, loading: true, error: null, busy: false })
+  return { research: empty(), positioning: empty(), channel_plan: empty(), copy: empty() }
+}
+
+/** The pipeline (M3/M4/M5): research → positioning → channel plan → copy,
+ * each ending at a human approval gate. Without this, none of these agent
+ * runs can ever be reviewed, so the pipeline could not advance past its
+ * first stage from a browser at all.
+ *
+ * `hasBrief` gates the very first start: `start_research_route` 422s on a
+ * campaign with no brief, and nothing else in this pipeline can run before
+ * research does.
+ */
+export function Pipeline({ campaignId, hasBrief }: { campaignId: string; hasBrief: boolean }) {
+  const [state, setState] = useState<Record<ArtefactKind, StageState>>(initialState)
+
+  function patch(kind: ArtefactKind, next: Partial<StageState>) {
+    setState((prev) => ({ ...prev, [kind]: { ...prev[kind], ...next } }))
+  }
+
+  async function load(kind: ArtefactKind) {
+    patch(kind, { loading: true, error: null })
+    try {
+      const artefact = await getArtefact(campaignId, kind)
+      patch(kind, { artefact, loading: false })
+    } catch (e: unknown) {
+      patch(kind, { loading: false, error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  useEffect(() => {
+    setState(initialState())
+    for (const { kind } of STAGES) {
+      load(kind)
+    }
+    // campaignId is the only thing this effect should re-run on — `load`
+    // closes over it fresh on every render, so it is deliberately not in
+    // this dependency list. No react-hooks lint plugin is installed in this
+    // package, so there is no exhaustive-deps rule to satisfy or suppress.
+  }, [campaignId])
+
+  async function runMutation(kind: ArtefactKind, mutate: () => Promise<Artefact | null>) {
+    patch(kind, { busy: true, error: null })
+    try {
+      const artefact = await mutate()
+      patch(kind, { artefact, busy: false })
+    } catch (e: unknown) {
+      patch(kind, { busy: false, error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  const approved: Approved = {
+    research: state.research.artefact?.status === 'approved',
+    positioning: state.positioning.artefact?.status === 'approved',
+    channel_plan: state.channel_plan.artefact?.status === 'approved',
+  }
+
+  return (
+    <div className="pipeline">
+      {STAGES.map((stage) => {
+        const s = state[stage.kind]
+        const gate = stage.gate(approved, hasBrief)
+        // `pending`'s body is bookkeeping (e.g. research's in-flight run
+        // ids), not the real stage output — see `Artefact`'s own doc
+        // comment. Nothing to render until the gate has actually produced
+        // something.
+        const body = s.artefact !== null && s.artefact.status !== 'pending' ? stage.renderBody(s.artefact) : null
+        return (
+          <PipelineStage
+            key={stage.kind}
+            kind={stage.kind}
+            title={stage.title}
+            artefact={s.artefact}
+            loading={s.loading}
+            error={s.error}
+            canStart={gate.canStart}
+            blockedReason={gate.blockedReason}
+            busy={s.busy}
+            onStart={() => runMutation(stage.kind, () => stage.start(campaignId))}
+            onRefresh={() => runMutation(stage.kind, () => getArtefact(campaignId, stage.kind))}
+            onApprove={() => runMutation(stage.kind, () => approveArtefact(campaignId, stage.kind))}
+            onReject={() => runMutation(stage.kind, () => rejectArtefact(campaignId, stage.kind))}
+          >
+            {body}
+          </PipelineStage>
+        )
+      })}
+    </div>
+  )
+}

--- a/web-admin/src/components/PipelineStage.test.tsx
+++ b/web-admin/src/components/PipelineStage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Artefact } from '../lib/api'
+import { PipelineStage } from './PipelineStage'
+
+function artefact(status: Artefact['status']): Artefact {
+  return {
+    id: 'a1',
+    campaign_id: 'c1',
+    kind: 'research',
+    status,
+    body: null,
+    citations: null,
+    causation_id: null,
+    agent_run_id: null,
+  }
+}
+
+const noop = () => {}
+
+describe('PipelineStage', () => {
+  it('offers a start button, disabled with a reason, when the gate is not satisfied', () => {
+    render(
+      <PipelineStage
+        kind="positioning"
+        title="Positioning"
+        artefact={null}
+        loading={false}
+        error={null}
+        canStart={false}
+        blockedReason="Approve the research stage first."
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByText('Approve the research stage first.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /start positioning/i })).toBeDisabled()
+  })
+
+  it('offers an enabled start button once the gate is satisfied', async () => {
+    const onStart = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={null}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={onStart}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /start research/i }))
+    expect(onStart).toHaveBeenCalledOnce()
+  })
+
+  it('offers "check for result" while pending, not approve/reject', () => {
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('pending')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument()
+  })
+
+  it('offers approve and reject once proposed, and renders the artefact body', async () => {
+    const onApprove = vi.fn()
+    const onReject = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={onApprove}
+        onReject={onReject}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    expect(screen.getByText('the research findings')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /^approve$/i }))
+    expect(onApprove).toHaveBeenCalledOnce()
+    await user.click(screen.getByRole('button', { name: /^reject$/i }))
+    expect(onReject).toHaveBeenCalledOnce()
+  })
+
+  it('offers to run again once rejected', () => {
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('rejected')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /run research again/i })).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/PipelineStage.tsx
+++ b/web-admin/src/components/PipelineStage.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react'
+
+import type { Artefact, ArtefactKind, ArtefactStatus } from '../lib/api'
+
+const STATUS_LABEL: Record<ArtefactStatus, string> = {
+  pending: 'Running…',
+  proposed: 'Awaiting review',
+  approved: 'Approved',
+  rejected: 'Rejected',
+}
+
+interface PipelineStageProps {
+  kind: ArtefactKind
+  title: string
+  artefact: Artefact | null
+  loading: boolean
+  error: string | null
+  /** Whether the upstream gate this stage needs is satisfied. */
+  canStart: boolean
+  /** Human reason `canStart` is false, shown instead of a start button that
+   * would only 409. `null` when `canStart` is true. */
+  blockedReason: string | null
+  busy: boolean
+  onStart: () => void
+  onRefresh: () => void
+  onApprove: () => void
+  onReject: () => void
+  /** The rendered artefact body — `null` while there is nothing approved,
+   * proposed or rejected to show yet. */
+  children?: ReactNode
+}
+
+/** One pipeline stage's gate: `pending → proposed → approved | rejected`.
+ *
+ * The gate is the point (see `pipeline.py`'s module docstring) — this
+ * component is deliberately generic over all four stages (research,
+ * positioning, channel plan, copy) rather than four near-identical copies,
+ * because the gate shape is exactly the same for all of them; only the start
+ * action and the body renderer differ, and both are supplied by the caller.
+ */
+export function PipelineStage({
+  kind,
+  title,
+  artefact,
+  loading,
+  error,
+  canStart,
+  blockedReason,
+  busy,
+  onStart,
+  onRefresh,
+  onApprove,
+  onReject,
+  children,
+}: PipelineStageProps) {
+  const status = artefact?.status ?? null
+
+  return (
+    <section className="stage" aria-label={title} data-testid={`stage-${kind}`}>
+      <div className="stage-head">
+        <h4>{title}</h4>
+        {status !== null && <span className={`badge badge-${status}`}>{STATUS_LABEL[status]}</span>}
+      </div>
+
+      {loading && <p className="empty">Loading…</p>}
+      {error !== null && <p className="error">{error}</p>}
+
+      {!loading && (
+        <>
+          {status === null && (
+            <>
+              {blockedReason !== null && <p className="hint">{blockedReason}</p>}
+              <button type="button" onClick={onStart} disabled={!canStart || busy}>
+                {busy ? 'Starting…' : `Start ${title.toLowerCase()}`}
+              </button>
+            </>
+          )}
+
+          {status === 'pending' && (
+            <button type="button" onClick={onRefresh} disabled={busy}>
+              {busy ? 'Checking…' : 'Check for result'}
+            </button>
+          )}
+
+          {(status === 'proposed' || status === 'approved' || status === 'rejected') && children}
+
+          {status === 'proposed' && (
+            <div className="stage-actions">
+              <button type="button" onClick={onApprove} disabled={busy}>
+                {busy ? 'Approving…' : 'Approve'}
+              </button>
+              <button type="button" className="secondary" onClick={onReject} disabled={busy}>
+                {busy ? 'Rejecting…' : 'Reject'}
+              </button>
+            </div>
+          )}
+
+          {status === 'rejected' && (
+            <button type="button" onClick={onStart} disabled={!canStart || busy}>
+              {busy ? 'Starting…' : `Run ${title.toLowerCase()} again`}
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/web-admin/src/components/Results.test.tsx
+++ b/web-admin/src/components/Results.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as auth from '../lib/auth'
+import { Results } from './Results'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+describe('Results', () => {
+  it('shows real clicks, and leads/conversions/cost as not measurable — never as zero', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            {
+              campaign_id: 'c1',
+              campaign_name: 'Spring',
+              clicks: { total: 12, paid: 5, organic: 7, unknown_channel_type: 0 },
+              leads: {
+                measurable: false,
+                denominator: 12,
+                reason: 'No route reachable from this plugin exposes this yet.',
+              },
+              conversions: { measurable: false, denominator: null, reason: 'no transport' },
+              cost: { measurable: false, denominator: null, reason: 'no transport' },
+            },
+          ],
+          unattributed_clicks: 0,
+        }),
+      }),
+    )
+
+    render(<Results campaignId="c1" />)
+
+    expect(await screen.findByText(/12 total — 5 paid, 7 organic/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/not measurable/i)).toHaveLength(3)
+    expect(screen.getByText(/denominator: 12/)).toBeInTheDocument()
+    // Never render "0" for an unmeasurable count.
+    expect(screen.queryByText(/^0$/)).not.toBeInTheDocument()
+  })
+
+  it('says plainly when this campaign has no results yet', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ campaigns: [], unattributed_clicks: 0 }) }),
+    )
+
+    render(<Results campaignId="missing" />)
+
+    expect(await screen.findByText(/no results yet/i)).toBeInTheDocument()
+  })
+
+  it('reports a load failure rather than rendering nothing', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }))
+
+    render(<Results campaignId="c1" />)
+
+    expect(await screen.findByText(/could not load results/i)).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/Results.tsx
+++ b/web-admin/src/components/Results.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+
+import { getResults, type CampaignResults, type UnmeasuredMetric } from '../lib/api'
+
+/** One unmeasurable metric, rendered so it can never be mistaken for a zero.
+ * `results_routes.py`'s own discipline: "no data" is a structurally distinct
+ * thing from "zero" — a confident number that is wrong in a systematic
+ * direction is worse than a missing one. Every share carries its
+ * denominator, when one is known here. */
+function UnmeasuredCell({ label, metric }: { label: string; metric: UnmeasuredMetric }) {
+  return (
+    <p className="unmeasurable">
+      <strong>{label}:</strong> not measurable — {metric.reason}
+      {metric.denominator !== null && <> (denominator: {metric.denominator})</>}
+    </p>
+  )
+}
+
+/** The results dashboard (M8) for one campaign. `/results` itself is global —
+ * every campaign in the tenant, in one call — so this filters client-side to
+ * the campaign this detail view is showing, rather than adding a
+ * per-campaign route that does not exist server-side.
+ *
+ * Clicks are real, measured rows. Leads, conversions and cost are not — this
+ * plugin has no reachable transport to `demo_requests`/`lead_source_costs`
+ * (issue #31) — and are rendered as explicitly unmeasurable, never as a
+ * silent zero.
+ */
+export function Results({ campaignId }: { campaignId: string }) {
+  const [results, setResults] = useState<CampaignResults | null>(null)
+  const [found, setFound] = useState(true)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    getResults()
+      .then((all) => {
+        if (cancelled) return
+        const mine = all.campaigns.find((c) => c.campaign_id === campaignId) ?? null
+        setResults(mine)
+        setFound(mine !== null)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [campaignId])
+
+  if (loading) return <p className="empty">Loading…</p>
+  if (error !== null) return <p className="error">Could not load results: {error}</p>
+  if (!found || results === null) {
+    return <p className="empty">No results yet for this campaign.</p>
+  }
+
+  return (
+    <section className="results" aria-label="Results">
+      <h4>Clicks</h4>
+      <p>
+        {results.clicks.total} total — {results.clicks.paid} paid, {results.clicks.organic} organic
+        {results.clicks.unknown_channel_type > 0 && (
+          <>, {results.clicks.unknown_channel_type} of unknown channel type</>
+        )}
+      </p>
+
+      <UnmeasuredCell label="Leads" metric={results.leads} />
+      <UnmeasuredCell label="Conversions" metric={results.conversions} />
+      <UnmeasuredCell label="Cost" metric={results.cost} />
+    </section>
+  )
+}

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -173,3 +173,240 @@ button:disabled {
   word-break: break-all;
   font-size: 0.75rem;
 }
+
+button.back {
+  background: transparent;
+  color: #444;
+  padding: 0.35rem 0;
+  margin-bottom: 1rem;
+}
+
+button.back:hover {
+  color: #1a1a1a;
+}
+
+button.secondary {
+  background: #fff;
+  color: #444;
+  border: 1px solid #ccc;
+}
+
+.campaign-detail h3 {
+  margin-top: 2.5rem;
+  font-size: 1.1rem;
+  border-bottom: 1px solid #e5e5e5;
+  padding-bottom: 0.4rem;
+}
+
+.campaign-detail textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.5rem 0.6rem;
+  font: inherit;
+  font-size: 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  min-height: 5rem;
+  resize: vertical;
+}
+
+.stage {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.stage-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.stage-head h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: #eee;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.badge-pending {
+  background: #fff3cd;
+  color: #7a5b00;
+}
+
+.badge-proposed {
+  background: #e0ecff;
+  color: #1a4b9c;
+}
+
+.badge-approved {
+  background: #dcf5e3;
+  color: #16693a;
+}
+
+.badge-rejected {
+  background: #fbe0e0;
+  color: #9c1a1a;
+}
+
+.stage-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.artefact-body {
+  margin: 0.75rem 0;
+  font-size: 0.85rem;
+}
+
+.artefact-body h4,
+.artefact-body h5 {
+  margin: 1rem 0 0.25rem;
+  font-size: 0.85rem;
+}
+
+.artefact-body .finding {
+  padding: 0.5rem 0;
+  border-top: 1px solid #eee;
+}
+
+.artefact-body .summary,
+.artefact-body .pillar,
+.artefact-body .headline {
+  font-weight: 600;
+}
+
+.motion {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: #eee;
+  color: #555;
+  text-transform: uppercase;
+}
+
+.motion-paid {
+  background: #fdeacc;
+  color: #8a5a00;
+}
+
+.sources {
+  list-style: none;
+  padding: 0;
+  margin: 0.4rem 0 0;
+}
+
+.sources li {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.sources .note {
+  color: #666;
+}
+
+.no-sources {
+  font-size: 0.75rem;
+  color: #a11;
+  font-style: italic;
+}
+
+.warning {
+  background: #fff3cd;
+  color: #7a5b00;
+  border-radius: 4px;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.unmeasurable {
+  font-size: 0.85rem;
+  color: #555;
+  font-style: italic;
+}
+
+.trimmed {
+  color: #a66a00;
+  font-style: italic;
+  font-size: 0.8em;
+}
+
+.guidance {
+  white-space: pre-wrap;
+  font-size: 0.85rem;
+  background: #f7f7f7;
+  border-radius: 4px;
+  padding: 0.6rem 0.8rem;
+}
+
+.assets,
+.stills {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.assets li,
+.stills li {
+  width: 9rem;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.assets img,
+.stills img {
+  width: 100%;
+  height: 9rem;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #e5e5e5;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.stills .cost {
+  margin: 0.15rem 0 0;
+  color: #666;
+}
+
+.copy-list,
+.ad-copy,
+.targeting {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 1rem;
+}
+
+.copy-list li,
+.ad-copy li,
+.targeting li {
+  padding: 0.5rem 0;
+  border-top: 1px solid #eee;
+  font-size: 0.85rem;
+}
+
+.platform {
+  font-size: 0.7rem;
+  color: #666;
+  text-transform: uppercase;
+}

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createCampaign, listCampaigns } from './api'
+import {
+  approveArtefact,
+  createCampaign,
+  generateStill,
+  getArtefact,
+  getPack,
+  getResults,
+  listCampaigns,
+  parseArtefactBody,
+  startResearch,
+  updateCampaign,
+  type ResearchSynthesisBody,
+} from './api'
 import * as auth from './auth'
 
 afterEach(() => {
@@ -106,5 +118,191 @@ describe('createCampaign', () => {
     await expect(
       createCampaign({ name: 'x', destination_url: 'https://example.com' }),
     ).rejects.toThrow(/admin role/)
+  })
+})
+
+describe('updateCampaign', () => {
+  it('PATCHes generated CRUD, not an admin-app route', async () => {
+    stubSession('abc123')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: 'c1' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateCampaign('c1', { brief: 'Who this is for, and why now.' })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/plugins/marketing/campaigns/c1')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(init.body as string)).toEqual({ brief: 'Who this is for, and why now.' })
+  })
+})
+
+describe('pipeline artefacts', () => {
+  it('returns null on a 404 rather than throwing — "not started yet" is not an error', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }))
+    await expect(getArtefact('c1', 'research')).resolves.toBeNull()
+  })
+
+  it('starts research at the admin-app route, not generated CRUD', async () => {
+    stubSession('abc123')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: 'a1', status: 'pending' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await startResearch('c1')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/plugins/marketing/admin/campaigns/c1/research')
+  })
+
+  it('surfaces the server-authored reason on a 422, not a bare status', async () => {
+    // Unlike listCampaigns/createCampaign above, this hits the plugin's OWN
+    // admin route — the detail text is authored specifically for an
+    // operator to read (admin_app.py's start_research_route), not Core's
+    // generic-CRUD wording, so surfacing it is the point.
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({ detail: 'This campaign has no brief, so there is nothing to research.' }),
+      }),
+    )
+    await expect(startResearch('c1')).rejects.toThrow(/no brief/)
+  })
+
+  it('names the missing group on a 403 from the admin app', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ detail: "This surface requires the 'admin' group." }),
+      }),
+    )
+    await expect(startResearch('c1')).rejects.toThrow(/admin' group/)
+  })
+
+  it('approves at the artefact-scoped route', async () => {
+    stubSession('abc123')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: 'a1', status: 'approved' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await approveArtefact('c1', 'channel_plan')
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/plugins/marketing/admin/campaigns/c1/artefacts/channel_plan/approve')
+    expect(init.method).toBe('POST')
+  })
+})
+
+describe('parseArtefactBody', () => {
+  it('parses the JSON-serialised body column into its structured shape', () => {
+    const body: ResearchSynthesisBody = { summary: 'x', findings: [] }
+    const parsed = parseArtefactBody<ResearchSynthesisBody>({
+      id: 'a1',
+      campaign_id: 'c1',
+      kind: 'research',
+      status: 'proposed',
+      body: JSON.stringify(body),
+      citations: null,
+      causation_id: null,
+      agent_run_id: null,
+    })
+    expect(parsed).toEqual(body)
+  })
+
+  it('returns null rather than throwing on no artefact, no body, or unparseable JSON', () => {
+    expect(parseArtefactBody(null)).toBeNull()
+    expect(
+      parseArtefactBody({
+        id: 'a1',
+        campaign_id: 'c1',
+        kind: 'research',
+        status: 'pending',
+        body: null,
+        citations: null,
+        causation_id: null,
+        agent_run_id: null,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('generateStill', () => {
+  it('reports a null cost_usd as unpriced, never as $0', async () => {
+    // The null case is load-bearing (image_routes.py) — a caller must never
+    // read "cost_usd is null" as "this cost nothing".
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          asset: { id: 'as1' },
+          media: { id: 'm1' },
+          url: 'https://example.com/still.png',
+          ledger: { id: 'l1', cost_usd: null, unpriced: true },
+        }),
+      }),
+    )
+    const result = await generateStill('c1', 'a storefront photo')
+    expect(result.ledger.cost_usd).toBeNull()
+    expect(result.ledger.unpriced).toBe(true)
+  })
+})
+
+describe('getPack', () => {
+  it('surfaces missing_placements rather than hiding the gap', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: 'c1',
+          assets: [],
+          missing_placements: ['feed_1x1', 'story_9x16'],
+          copy: [],
+          links: [],
+          guidance: '',
+        }),
+      }),
+    )
+    const pack = await getPack('c1')
+    expect(pack.missing_placements).toEqual(['feed_1x1', 'story_9x16'])
+  })
+})
+
+describe('getResults', () => {
+  it('keeps leads/conversions/cost as UnmeasuredMetric, distinct from a real click count', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            {
+              campaign_id: 'c1',
+              campaign_name: 'Spring',
+              clicks: { total: 4, paid: 1, organic: 3, unknown_channel_type: 0 },
+              leads: { measurable: false, denominator: 4, reason: 'no transport' },
+              conversions: { measurable: false, denominator: null, reason: 'no transport' },
+              cost: { measurable: false, denominator: null, reason: 'no transport' },
+            },
+          ],
+          unattributed_clicks: 0,
+        }),
+      }),
+    )
+    const results = await getResults()
+    expect(results.campaigns[0].clicks.total).toBe(4)
+    expect(results.campaigns[0].leads.measurable).toBe(false)
   })
 })

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -25,6 +25,8 @@ export interface Campaign {
   name: string
   status: string
   destination_url: string | null
+  brief?: string | null
+  guidance?: string | null
 }
 
 const BASE = '/api/v1/plugins/marketing'
@@ -150,4 +152,397 @@ export async function mintLinks(
 
   const body = (await response.json()) as { links?: MintedLink[] }
   return body.links ?? []
+}
+
+// ── The rest of the campaign studio (M3–M6, M8, M9) ──────────────────────────
+//
+// Everything below calls `${ADMIN_BASE}` — the plugin's own routes
+// (`admin_app.py`, `channel_plan_routes.py`, `copy_routes.py`,
+// `image_routes.py`, `pack_routes.py`, `paid_pack_routes.py`,
+// `results_routes.py`), never generated CRUD directly, for the same reason
+// `mintLinks` above does not: each of these reads one row and writes several,
+// or assembles several tables into one response.
+//
+// `throwForResponse` differs from `listCampaigns`/`createCampaign`/
+// `mintLinks` above on purpose: those hit Core's *generic* CRUD, whose 403
+// text ("Administrator access required") is Core's own wording, not this
+// plugin's, and the test above deliberately does not surface it verbatim.
+// Everything below hits THIS plugin's own admin routes, whose `detail` text
+// is hand-authored specifically to be read by the operator — "This surface
+// requires the 'admin' group" (`require_group`'s own message), "This
+// campaign has no destination_url, so its links would lead nowhere", "The
+// research artefact must be approved before this can proceed (status:
+// proposed)". Extracting and showing that string is the point, not a
+// regression of the "never render a raw response body" rule: only a `detail`
+// field that is actually a string is ever shown, so an HTML error page or an
+// unparseable body still falls back to a plain status-coded message rather
+// than being dumped on screen.
+
+async function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const session = await getCurrentSession()
+  const idToken = session?.getIdToken().getJwtToken() ?? null
+  return fetch(path, {
+    ...init,
+    headers: {
+      ...(init.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  })
+}
+
+async function detailMessage(response: Response): Promise<string | null> {
+  try {
+    const body: unknown = await response.json()
+    if (
+      body !== null &&
+      typeof body === 'object' &&
+      'detail' in body &&
+      typeof (body as { detail?: unknown }).detail === 'string'
+    ) {
+      return (body as { detail: string }).detail
+    }
+  } catch {
+    // Not JSON, or an empty body — nothing safe to extract, fall through to a
+    // generic message rather than guessing at unstructured text.
+  }
+  return null
+}
+
+async function throwForResponse(response: Response, context: string): Promise<never> {
+  if (response.status === 401) {
+    throw new Error('not signed in (401) — sign in to the portal, then reload')
+  }
+  const detail = await detailMessage(response)
+  if (response.status === 403) {
+    throw new Error(detail !== null ? `${detail} (403)` : `you need the admin role to ${context} (403)`)
+  }
+  if (detail !== null) {
+    throw new Error(`${detail} (${response.status})`)
+  }
+  throw new Error(`could not ${context} (${response.status})`)
+}
+
+/** Update a campaign's own fields directly — generated CRUD, not an admin-app
+ * route. Used here for `brief`: nothing in the create form collects one (see
+ * `App.tsx`), and without a brief `start_research_route` 422s, so the
+ * pipeline's first stage can never start. */
+export async function updateCampaign(
+  campaignId: string,
+  patch: Partial<Pick<Campaign, 'name' | 'destination_url' | 'brief' | 'guidance'>>,
+): Promise<Campaign> {
+  const response = await authedFetch(`${BASE}/campaigns/${campaignId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+  if (!response.ok) return throwForResponse(response, 'update the campaign')
+  return (await response.json()) as Campaign
+}
+
+// ── The pipeline (M3/M4/M5): research → positioning → channel plan → copy ───
+
+export interface Source {
+  url: string
+  note: string
+}
+
+export interface ResearchFinding {
+  signal: string
+  why_it_matters: string
+  sources: Source[]
+}
+
+export interface ResearchSynthesisBody {
+  summary: string
+  findings: ResearchFinding[]
+}
+
+export interface Segment {
+  name: string
+  description: string
+  sources: Source[]
+}
+
+export interface MessagePillar {
+  pillar: string
+  rationale: string
+  sources: Source[]
+}
+
+export interface CallToAction {
+  text: string
+  rationale: string
+  sources: Source[]
+}
+
+export interface PositioningBody {
+  segments: Segment[]
+  pillars: MessagePillar[]
+  ctas: CallToAction[]
+}
+
+export interface ChannelRecommendation {
+  channel: string
+  motion: 'organic' | 'paid'
+  rank: number
+  rationale: string
+  sources: Source[]
+}
+
+export interface ChannelPlanBody {
+  channels: ChannelRecommendation[]
+}
+
+export interface ChannelCopy {
+  channel: string
+  motion: 'organic' | 'paid'
+  headline: string
+  body: string
+  cta: string
+  sources: Source[]
+}
+
+export interface CopySetBody {
+  channels: ChannelCopy[]
+}
+
+export type ArtefactKind = 'research' | 'positioning' | 'channel_plan' | 'copy'
+export type ArtefactStatus = 'pending' | 'proposed' | 'approved' | 'rejected'
+
+/** One pipeline-stage artefact row. `body`/`citations` are JSON-serialised
+ * text columns (plugin tables have no JSON column type — `biffo.plugin.json`'s
+ * own description of `marketing_artefact.body`), not parsed objects — use
+ * {@link parseArtefactBody}. `body` is only the real stage output once
+ * `status` has left `pending`; while `pending` it may hold bookkeeping (e.g.
+ * research's in-flight run ids) that no renderer here should try to read. */
+export interface Artefact {
+  id: string
+  campaign_id: string
+  kind: ArtefactKind
+  status: ArtefactStatus
+  body: string | null
+  citations: string | null
+  causation_id: string | null
+  agent_run_id: string | null
+}
+
+/** Parse an artefact's `body` against its kind's known shape, or `null` if
+ * there is nothing to parse (no artefact, no body, or — defensively — a body
+ * that does not parse as JSON). */
+export function parseArtefactBody<T>(artefact: Artefact | null): T | null {
+  if (artefact === null || artefact.body === null || artefact.body === '') return null
+  try {
+    return JSON.parse(artefact.body) as T
+  } catch {
+    return null
+  }
+}
+
+/** This campaign's latest artefact of `kind`, advancing it first if it is
+ * still `pending`. `null` on a 404 — "no artefact of this kind yet" is a
+ * normal state (nothing has been started), not an error to show. */
+export async function getArtefact(campaignId: string, kind: ArtefactKind): Promise<Artefact | null> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/artefacts/${kind}`)
+  if (response.status === 404) return null
+  if (!response.ok) return throwForResponse(response, `load the ${kind.replace('_', ' ')} stage`)
+  return (await response.json()) as Artefact
+}
+
+export async function approveArtefact(campaignId: string, kind: ArtefactKind): Promise<Artefact> {
+  const response = await authedFetch(
+    `${ADMIN_BASE}/campaigns/${campaignId}/artefacts/${kind}/approve`,
+    { method: 'POST' },
+  )
+  if (!response.ok) return throwForResponse(response, `approve the ${kind.replace('_', ' ')} stage`)
+  return (await response.json()) as Artefact
+}
+
+export async function rejectArtefact(campaignId: string, kind: ArtefactKind): Promise<Artefact> {
+  const response = await authedFetch(
+    `${ADMIN_BASE}/campaigns/${campaignId}/artefacts/${kind}/reject`,
+    { method: 'POST' },
+  )
+  if (!response.ok) return throwForResponse(response, `reject the ${kind.replace('_', ' ')} stage`)
+  return (await response.json()) as Artefact
+}
+
+export async function startResearch(campaignId: string): Promise<Artefact> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/research`, {
+    method: 'POST',
+  })
+  if (!response.ok) return throwForResponse(response, 'start research')
+  return (await response.json()) as Artefact
+}
+
+export async function startPositioning(campaignId: string): Promise<Artefact> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/positioning`, {
+    method: 'POST',
+  })
+  if (!response.ok) return throwForResponse(response, 'start positioning')
+  return (await response.json()) as Artefact
+}
+
+export async function startChannelPlan(campaignId: string): Promise<Artefact> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/channel-plan`, {
+    method: 'POST',
+  })
+  if (!response.ok) return throwForResponse(response, 'start channel planning')
+  return (await response.json()) as Artefact
+}
+
+export async function startCopy(campaignId: string): Promise<Artefact> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/copy`, {
+    method: 'POST',
+  })
+  if (!response.ok) return throwForResponse(response, 'start copy generation')
+  return (await response.json()) as Artefact
+}
+
+// ── Images (M6) ───────────────────────────────────────────────────────────────
+
+export interface GenerateStillResponse {
+  asset: Record<string, unknown>
+  media: { id: string } & Record<string, unknown>
+  url: string
+  /** `cost_usd` is nullable and the null case is load-bearing — `unpriced`
+   * says so explicitly so a caller never has to treat a missing cost as
+   * £0. */
+  ledger: { id: string; cost_usd: number | null; unpriced: boolean }
+}
+
+export async function generateStill(campaignId: string, prompt: string): Promise<GenerateStillResponse> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/stills`, {
+    method: 'POST',
+    body: JSON.stringify({ prompt }),
+  })
+  if (!response.ok) return throwForResponse(response, 'generate an image')
+  return (await response.json()) as GenerateStillResponse
+}
+
+// ── The distribution pack (M5) and paid pack (M9) ────────────────────────────
+
+export interface PackAsset {
+  id: string
+  campaign_id: string
+  media_kind: string
+  placement: string | null
+  media_id: string
+  is_source: boolean | null
+  url: string
+}
+
+export interface PackLink {
+  channel: string
+  variant: string | null
+  is_paid: boolean | null
+  /** `null` when this deployment has no public base URL configured — the
+   * pack still lists the channel, just with nothing to publish yet. */
+  url: string | null
+}
+
+export interface Pack {
+  campaign_id: string
+  assets: PackAsset[]
+  /** Placements `PLACEMENTS` names that have no rendered asset yet — reported
+   * honestly rather than the pack silently omitting them (issue #36 is the
+   * tracked gap that causes this). */
+  missing_placements: string[]
+  copy: ChannelCopy[]
+  links: PackLink[]
+  guidance: string
+}
+
+export async function getPack(campaignId: string): Promise<Pack> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/pack`)
+  if (!response.ok) return throwForResponse(response, 'load the distribution pack')
+  return (await response.json()) as Pack
+}
+
+export interface AdCopyVariant {
+  channel: string
+  platform: string
+  headline: string
+  headline_limit: number
+  headline_truncated: boolean
+  body: string
+  body_limit: number
+  body_truncated: boolean
+  cta: string
+  cta_limit: number
+  cta_truncated: boolean
+}
+
+export interface BudgetRecommendation {
+  currency: string
+  channel_count: number
+  per_channel_daily: number
+  total_daily: number
+  test_window_days: number
+  total_test_budget: number
+  basis: string
+}
+
+export interface PaidPack {
+  campaign_id: string
+  ad_copy: AdCopyVariant[]
+  assets: PackAsset[]
+  missing_placements: string[]
+  targeting: Segment[]
+  budget: BudgetRecommendation
+  links: PackLink[]
+  guidance: string
+  /** This plugin has no reachable transport to spend data (issue #31) — see
+   * {@link UnmeasuredMetric}. */
+  spend: UnmeasuredMetric
+}
+
+export async function getPaidPack(campaignId: string): Promise<PaidPack> {
+  const response = await authedFetch(`${ADMIN_BASE}/campaigns/${campaignId}/paid-pack`)
+  if (!response.ok) return throwForResponse(response, 'load the paid pack')
+  return (await response.json()) as PaidPack
+}
+
+// ── Results (M8) ──────────────────────────────────────────────────────────────
+
+export interface ClickBreakdown {
+  total: number
+  paid: number
+  organic: number
+  unknown_channel_type: number
+}
+
+/** A metric this endpoint cannot compute at all today — never a bare `null`
+ * or a `0`. `measurable` is always `false` on every instance the API
+ * constructs; `reason` says why. `denominator` is the population this metric
+ * would be a share of once it becomes measurable, when that population is
+ * itself known; `null` when it isn't. Render "not measurable" distinctly from
+ * zero — this plugin has no reachable transport to `demo_requests`/
+ * `lead_source_costs` (issue #31), so reporting zero would claim "we looked,
+ * and nothing happened," which is not a claim it can make today. */
+export interface UnmeasuredMetric {
+  measurable: false
+  denominator: number | null
+  reason: string
+}
+
+export interface CampaignResults {
+  campaign_id: string
+  campaign_name: string
+  clicks: ClickBreakdown
+  leads: UnmeasuredMetric
+  conversions: UnmeasuredMetric
+  cost: UnmeasuredMetric
+}
+
+export interface ResultsResponse {
+  campaigns: CampaignResults[]
+  /** Clicks whose `campaign_id` named no campaign this call could see —
+   * counted rather than silently dropped from every campaign's total. */
+  unattributed_clicks: number
+}
+
+export async function getResults(): Promise<ResultsResponse> {
+  const response = await authedFetch(`${ADMIN_BASE}/results`)
+  if (!response.ok) return throwForResponse(response, 'load results')
+  return (await response.json()) as ResultsResponse
 }

--- a/web-admin/src/lib/useClipboard.ts
+++ b/web-admin/src/lib/useClipboard.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+/** Copy text to the clipboard, tracking which string was last copied
+ * successfully so a caller can render "Copied" next to the right item.
+ *
+ * A clipboard write can be silently refused — permissions, or Safari outside
+ * a user gesture (`pack_routes.py`'s module docstring names this explicitly
+ * as one of M5's two unverified day-0 device warnings). Shared here rather
+ * than duplicated per pack view: a fix to this failure path belongs in one
+ * place, not in however many components render a "Copy" button.
+ */
+export function useClipboard() {
+  const [copied, setCopied] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function copy(text: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(text)
+      setError(null)
+    } catch {
+      // The text is still on screen and selectable either way — say so
+      // rather than showing a success that did not happen.
+      setCopied(null)
+      setError('could not copy — select the text and copy it manually')
+    }
+  }
+
+  return { copied, copy, error }
+}


### PR DESCRIPTION
## What changed

Seven backend milestones (M3–M6, M8, M9) had a working, tested API and no way to reach any of it from a browser. Adds a campaign detail view — opened from the existing campaign list — covering:

- **The pipeline (M3–M5)**: research, positioning, channel plan and copy, each rendered with its citations and gated behind explicit approve/reject controls (`pending -> proposed -> approved | rejected`). A brief editor is included since nothing else in the UI could set one, and without a brief the pipeline's first stage 422s and never starts.
- **Images (M6)**: generate a still, show it, and show its ledgered cost — a null `cost_usd` always renders as "unpriced", never as £0/$0.
- **The distribution pack (M5) and paid brief pack (M9)**: assets, copy, tracked links and guidance, with `missing_placements` surfaced rather than hidden.
- **Results (M8)**: real click counts, with leads/conversions/cost rendered as explicitly not-measurable (with reason and denominator), never as zero.

## Why

Without this, none of the M3–M5 approval gates could be operated at all, so the pipeline could not advance past its first stage from a browser.

## How

Every new call goes through `src/lib/api.ts` and carries the bearer token from `getCurrentSession()`, matching the existing `mintLinks`/`createCampaign` shape. `src/lib/useClipboard.ts` and `src/components/PackParts.tsx` hold logic shared between the organic and paid packs so the clipboard-copy failure path and the assets/links/guidance rendering exist once, not twice.

## Testing

`pnpm run test`, `typecheck`, `lint` and `build` all pass locally. 51 web-admin tests, all component tests stub `getCurrentSession`/`fetch` per the existing convention.

## Not verified

Nothing here has been checked against a live deployment — no running instance was available in this session. In particular: the presigned image URL rendering in an `<img>` tag, and the two device-specific pack warnings from the day-0 design (clipboard write on mobile Safari, `<a download>` on iOS) remain unverified on a real device, same caveat `pack_routes.py`'s own module docstring already carries.

## Scope note

Added a minimal brief editor to `CampaignDetail` (PATCHing `marketing_campaign.brief` via generated CRUD) — not explicitly one of the listed milestones, but without it a freshly created campaign has no way to ever start research, so the pipeline UI would otherwise be unusable end to end.
