### PR TITLE
fix(marketing): correct pipeline gate messages, add artefact-body test coverage

### DIFF
--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ChannelPlanArtefact,
+  CopyArtefact,
+  PositioningArtefact,
+  ResearchArtefact,
+  SourceList,
+} from './ArtefactBody'
+
+describe('SourceList', () => {
+  it('shows every source', () => {
+    render(
+      <SourceList
+        sources={[
+          { url: 'https://example.com/a', note: 'First source' },
+          { url: 'https://example.com/b', note: 'Second source' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('https://example.com/a')).toBeInTheDocument()
+    expect(screen.getByText('First source')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/b')).toBeInTheDocument()
+  })
+
+  it('says plainly when there are no sources — the zero-citation case', () => {
+    // pipeline.py's own guard means this case should be rare in practice,
+    // but a renderer must not crash or go blank on it.
+    render(<SourceList sources={[]} />)
+    expect(screen.getByText(/no sources cited/i)).toBeInTheDocument()
+  })
+})
+
+describe('ResearchArtefact', () => {
+  it('renders the summary and every finding with its sources', () => {
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'Owners want faster onboarding.',
+          findings: [
+            {
+              signal: 'Competitors take 3 weeks',
+              why_it_matters: 'Speed is a wedge',
+              sources: [{ url: 'https://example.com/report', note: 'Industry report' }],
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('Owners want faster onboarding.')).toBeInTheDocument()
+    expect(screen.getByText('Competitors take 3 weeks')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/report')).toBeInTheDocument()
+  })
+})
+
+describe('PositioningArtefact', () => {
+  it('renders segments, pillars and CTAs, each with their own sources', () => {
+    render(
+      <PositioningArtefact
+        body={{
+          segments: [
+            {
+              name: 'Busy owners',
+              description: 'Time-poor franchise owners.',
+              sources: [{ url: 'https://example.com/segment', note: 'Segment evidence' }],
+            },
+          ],
+          pillars: [
+            {
+              pillar: 'Onboard in a day, not a month',
+              rationale: 'Speed is the differentiator',
+              sources: [{ url: 'https://example.com/pillar', note: 'Pillar evidence' }],
+            },
+          ],
+          ctas: [
+            {
+              text: 'Book a demo',
+              rationale: 'Lowest-friction next step',
+              sources: [{ url: 'https://example.com/cta', note: 'CTA evidence' }],
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('Busy owners')).toBeInTheDocument()
+    expect(screen.getByText('Onboard in a day, not a month')).toBeInTheDocument()
+    expect(screen.getByText('Book a demo')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/segment')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/pillar')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/cta')).toBeInTheDocument()
+  })
+})
+
+describe('ChannelPlanArtefact', () => {
+  it('sorts channels by rank regardless of input order', () => {
+    render(
+      <ChannelPlanArtefact
+        body={{
+          channels: [
+            {
+              channel: 'Google Search',
+              motion: 'paid',
+              rank: 2,
+              rationale: 'Second priority',
+              sources: [{ url: 'https://example.com/google', note: 'Search intent data' }],
+            },
+            {
+              channel: 'LinkedIn',
+              motion: 'organic',
+              rank: 1,
+              rationale: 'Top priority',
+              sources: [{ url: 'https://example.com/linkedin', note: 'B2B reach data' }],
+            },
+          ],
+        }}
+      />,
+    )
+    const headings = screen.getAllByRole('heading', { level: 4 }).map((h) => h.textContent)
+    expect(headings[0]).toContain('LinkedIn')
+    expect(headings[1]).toContain('Google Search')
+  })
+})
+
+describe('CopyArtefact', () => {
+  it('renders headline, body and CTA for every channel', () => {
+    render(
+      <CopyArtefact
+        body={{
+          channels: [
+            {
+              channel: 'linkedin',
+              motion: 'organic',
+              headline: 'Faster onboarding, starting today',
+              body: 'Get your team live in under a day.',
+              cta: 'Book a demo',
+              sources: [{ url: 'https://example.com/copy', note: 'Copy grounding' }],
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('Faster onboarding, starting today')).toBeInTheDocument()
+    expect(screen.getByText('Get your team live in under a day.')).toBeInTheDocument()
+    expect(screen.getByText('Book a demo')).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -148,4 +148,27 @@ describe('Pipeline', () => {
 
     expect(await within(research).findByText('Approved')).toBeInTheDocument()
   })
+
+  it("names only the copy stage's actual missing upstream approval, not both every time", async () => {
+    // Positioning is already approved here — copy's blocked message must not
+    // tell the operator to redo it too, only to approve channel plan.
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({
+        research: { status: 'approved', body: JSON.stringify({ summary: 'x', findings: [] }) },
+        positioning: {
+          status: 'approved',
+          body: JSON.stringify({ segments: [], pillars: [], ctas: [] }),
+        },
+        channel_plan: { status: 'proposed', body: JSON.stringify({ channels: [] }) },
+      }),
+    )
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} />)
+
+    const copy = await screen.findByTestId('stage-copy')
+    expect(await within(copy).findByText(/approve the channel plan stage first/i)).toBeInTheDocument()
+    expect(within(copy).queryByText(/positioning/i)).not.toBeInTheDocument()
+  })
 })

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -98,11 +98,19 @@ const STAGES: StageConfig[] = [
       const body = parseArtefactBody<CopySetBody>(artefact)
       return body !== null ? <CopyArtefact body={body} /> : <p className="empty">No content to show.</p>
     },
-    gate: (approved) =>
-      reason(
-        approved.positioning && approved.channel_plan,
-        'Approve the positioning and channel-plan stages first.',
-      ),
+    gate: (approved) => {
+      // Names only the stage(s) actually still unapproved — a caller with
+      // channel-plan already approved and only positioning outstanding must
+      // not be told to redo channel-plan too.
+      const outstanding = [
+        !approved.positioning ? 'positioning' : null,
+        !approved.channel_plan ? 'channel plan' : null,
+      ].filter((s): s is string => s !== null)
+      return reason(
+        outstanding.length === 0,
+        `Approve the ${outstanding.join(' and ')} stage${outstanding.length > 1 ? 's' : ''} first.`,
+      )
+    },
   },
 ]
 

--- a/web-admin/src/components/PipelineStage.test.tsx
+++ b/web-admin/src/components/PipelineStage.test.tsx
@@ -134,4 +134,29 @@ describe('PipelineStage', () => {
     )
     expect(screen.getByRole('button', { name: /run research again/i })).toBeInTheDocument()
   })
+
+  it('explains why re-running is blocked, not just a disabled button with no reason', () => {
+    // A rejected stage whose upstream gate has since closed again (e.g. the
+    // campaign's brief was cleared) must say why "run again" cannot be
+    // clicked — the null-status case always did; the rejected case silently
+    // did not.
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('rejected')}
+        loading={false}
+        error={null}
+        canStart={false}
+        blockedReason="This campaign has no brief yet — add one above before starting research."
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByText(/no brief yet/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /run research again/i })).toBeDisabled()
+  })
 })

--- a/web-admin/src/components/PipelineStage.tsx
+++ b/web-admin/src/components/PipelineStage.tsx
@@ -67,11 +67,21 @@ export function PipelineStage({
 
       {!loading && (
         <>
-          {status === null && (
+          {/* `null` (never started) and `rejected` (started, then turned
+              down) share the exact same start gate — both need canStart and
+              both explain themselves with the same blockedReason when it
+              isn't met. Only the button's own label differs. Keeping this as
+              one branch is what stopped the rejected case from silently
+              losing the hint the null case always had. */}
+          {(status === null || status === 'rejected') && (
             <>
               {blockedReason !== null && <p className="hint">{blockedReason}</p>}
               <button type="button" onClick={onStart} disabled={!canStart || busy}>
-                {busy ? 'Starting…' : `Start ${title.toLowerCase()}`}
+                {busy
+                  ? 'Starting…'
+                  : status === 'rejected'
+                    ? `Run ${title.toLowerCase()} again`
+                    : `Start ${title.toLowerCase()}`}
               </button>
             </>
           )}
@@ -93,12 +103,6 @@ export function PipelineStage({
                 {busy ? 'Rejecting…' : 'Reject'}
               </button>
             </div>
-          )}
-
-          {status === 'rejected' && (
-            <button type="button" onClick={onStart} disabled={!canStart || busy}>
-              {busy ? 'Starting…' : `Run ${title.toLowerCase()} again`}
-            </button>
           )}
         </>
       )}


### PR DESCRIPTION
## What changed

A full code-review pass on the campaign-studio admin UI (merged separately, PR #53) landed after that PR was already merged and surfaced two real bugs plus a test gap that a condensed earlier version of the same review had not flagged:

1. **`Pipeline.tsx`'s copy-stage gate message was wrong when only one of its two upstream approvals was missing.** It always said "Approve the positioning and channel-plan stages first," even with positioning already approved and only channel-plan outstanding. Every other stage's message names only its actual blocker; copy's did not.
2. **`PipelineStage.tsx`'s `rejected` branch never showed `blockedReason`.** The `null` (never-started) branch always explained why "Start" was disabled; the `rejected` branch rendered a disabled "Run again" with no explanation at all. Unified the two branches (same start gate, different button label) so they can't drift apart the same way again.
3. **No test rendered `PositioningArtefact`, `ChannelPlanArtefact` (including its rank sort) or `CopyArtefact` against real data** — only `ResearchArtefact` was exercised, indirectly, via `Pipeline.test.tsx`'s fetch stub. Added `ArtefactBody.test.tsx` covering all four renderers and `SourceList`'s zero-citation branch.

## Out of scope, filed separately

Two further findings from the same review don't belong in this fix:

- `pack_routes.py` picks a campaign's source creative with no ordering when more than one still has been generated — a backend gap, newly reachable now that the admin UI makes generating a second still a one-click action.
- `auth.ts`'s session resolution isn't memoized in-flight, so the pipeline's five concurrent calls on mount each re-run it — but `auth.ts` is explicitly not owned by this repo (copied from idea-scout, not rewritten locally per this repo's own convention), so a fix belongs upstream.

## Testing

`pnpm run test` (59 tests, up from 51), `typecheck`, `lint` and `build` all pass locally.
