### PR TITLE
docs(web-admin): document why api.ts does not delegate to api-core

### DIFF
--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -16,6 +16,37 @@
  * resolved from the portal's shared session — `auth.ts`/`identity.ts` here are
  * idea-scout's, copied rather than rewritten, because this is exactly the part
  * that should not be reinvented per plugin.
+ *
+ * ## Why this file does NOT delegate its fetching to `./api-core`
+ *
+ * `createRequest` (biffo-template#1492) is deliberately shared plumbing: fetch
+ * + bearer header + a generic `ApiError(status, text)` built from
+ * `res.text()`. This plugin's endpoints do something `createRequest` does not
+ * — they read the JSON `detail` field the plugin's own admin routes author
+ * specifically for an operator (`throwForResponse`/`detailMessage` below), and
+ * they reword 401/403/422/503 per endpoint ("you need the admin role to mint
+ * links", "this campaign has no destination URL"). `createRequest` throws
+ * before handing back the `Response`, so there is no seam left to layer that
+ * per-endpoint wording on top of it — adopting it here would collapse every
+ * one of those messages into one generic status-coded string, which is a
+ * behaviour change, not a refactor. That mismatch belongs upstream as a
+ * question for `api-core` (e.g. a hook to inspect the body before throwing),
+ * not silently absorbed here.
+ *
+ * `getFreshIdToken()` (auth.ts) was tried as a drop-in for the
+ * `getCurrentSession()` + `.getIdToken().getJwtToken()` pair every request
+ * function here repeats inline, and rejected for the same reason: not because
+ * it behaves differently (it doesn't — it is that exact pair, under one name,
+ * and this file already re-resolved a fresh token per call before this
+ * migration, by this same route), but because `api.test.ts` stubs
+ * `auth.getCurrentSession` via `vi.spyOn`, and `getFreshIdToken`'s internal
+ * call to `getCurrentSession` is a same-module reference Vitest's ESM spy does
+ * not intercept — three tests then hit the real (unmocked) Cognito pool
+ * resolution instead of the stub. Fixing that means changing what the test
+ * stubs, which is outside this migration's remit ("behaviour must not change,
+ * tests pass unchanged"). Kept as `getCurrentSession()` inline, exactly as
+ * before, in all four call sites (`createCampaign`, `listCampaigns`,
+ * `mintLinks`, `authedFetch`) — still per-request, still fresh every time.
  */
 
 import { getCurrentSession } from './auth'


### PR DESCRIPTION
## What

Investigated migrating `web-admin/src/lib/api.ts` onto the distributed
`api-core.ts` (`createRequest`/`ApiError`, delivered by #43,
biffo-template#1492). No functional code changed — only doc comments
were added, recording why full delegation was rejected, for the next
author.

## Why not delegated

**`createRequest` vs this plugin's own error handling.** `createRequest`
throws `ApiError(status, res.text())` before ever handing back the
`Response`. This plugin's endpoints read the JSON `detail` field
authored specifically for an operator by the plugin's own admin routes
(`throwForResponse`/`detailMessage`), and reword 401/403/422/503 per
endpoint ("you need the admin role to mint links", "this campaign has
no destination URL, so its links would lead nowhere"). There is no seam
left to layer that on top of `createRequest` — adopting it would
collapse every one of those operator-facing messages into one generic
status-coded string. That is a real capability gap in `api-core`
(no hook to inspect the body before it throws), not something this repo
should silently drop. Flagging it for `biffo-template` rather than
building around it here.

**`getFreshIdToken()` vs inline `getCurrentSession()`.** This repo never
had the frozen-token bug (ideation#69) because it already re-resolves
`getCurrentSession()` + `.getIdToken().getJwtToken()` inline, per
request, in all four call sites (`createCampaign`, `listCampaigns`,
`mintLinks`, `authedFetch`). `getFreshIdToken()` (now delivered here via
#43) is behaviourally identical — I tried it as a drop-in. It broke 3
tests: `getFreshIdToken`'s internal call to `getCurrentSession` is a
same-module reference that `api.test.ts`'s
`vi.spyOn(auth, 'getCurrentSession')` does not intercept (a known
Vitest/ESM spy limitation), so those tests hit the real Cognito pool
resolution instead of the stub. Fixing that means changing what the
tests stub, which is outside "behaviour must not change, tests pass
unchanged" — so I reverted to `getCurrentSession()` inline, unchanged.
**Token-resolution site count: unchanged at 4, still per-request.**

## What I verified

- `web-admin/src/lib/api-core.ts` and `auth.ts`'s `getFreshIdToken()`
  are present at `origin/dev` (delivered by #43, already merged).
- Confirmed via `git ls-tree -r origin/dev` and `git show`, not a
  filesystem `find` over a possibly-stale checkout.
- This repo has only `web-admin/` — no `web/` app (confirmed, not
  assumed).
- Full test suite: 59/59 passing, unchanged.
- `tsc --noEmit`: clean.
- `pnpm run lint` (web-admin): clean.
- Local `verify.sh` gate: all checks pass.
- Both endpoint bases (`BASE = /api/v1/plugins/marketing`,
  `ADMIN_BASE = /api/v1/plugins/marketing/admin`) unchanged.

## What I deliberately left alone

- All endpoint logic, error messages, and interfaces in `api.ts` —
  zero functional change, doc comments only.
- `api-core.ts` remains unused by this file, since the mismatch above
  makes adopting it unsafe without an upstream change.
- Did not attempt to change `api.test.ts` to make `getFreshIdToken`
  work — that would be editing tests to fit the migration rather than
  the reverse.

Refs biffo-template#1492
