### PR TITLE
chore(shared): sync template-shared files

### DIFF
--- a/web-admin/src/lib/api-core.test.ts
+++ b/web-admin/src/lib/api-core.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, createRequest } from './api-core'
+
+/**
+ * Guards for the distributed admin-API request core (biffo-template#1492),
+ * and in particular for the `onError` mapper added so the marketing plugin
+ * could adopt it without losing its endpoint-specific messages.
+ */
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function stubFetch(res: Response) {
+  const fetchMock = vi.fn().mockResolvedValue(res)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+describe('createRequest without a mapper (the default path)', () => {
+  it('throws ApiError carrying the status and the response body', async () => {
+    stubFetch(new Response('you may not do that', { status: 403 }))
+    const request = createRequest(() => 'tok', '/base')
+
+    await expect(request('GET', '/thing')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('falls back to statusText when the body is empty', async () => {
+    stubFetch(new Response('', { status: 500, statusText: 'Internal Server Error' }))
+    const request = createRequest(() => 'tok', '/base')
+
+    await expect(request('GET', '/thing')).rejects.toThrow('Internal Server Error')
+  })
+})
+
+describe('createRequest with an onError mapper', () => {
+  /**
+   * THE POINT OF THE HOOK. The mapper must be able to read the JSON body,
+   * which means `request()` must not have consumed the stream before calling
+   * it. A mapper handed an already-read Response sees an empty body and falls
+   * back to a generic message — the silent degradation this exists to stop.
+   */
+  it('hands the mapper a response whose body is still readable', async () => {
+    stubFetch(jsonResponse(403, { detail: 'you are not an admin of this brand' }))
+    const request = createRequest(
+      () => 'tok',
+      '/base',
+      async (res, context) => {
+        const body = (await res.json()) as { detail?: string }
+        throw new Error(`${body.detail} (${res.status}) while trying to ${context}`)
+      },
+    )
+
+    await expect(request('POST', '/links', {}, '/base', 'mint links')).rejects.toThrow(
+      'you are not an admin of this brand (403) while trying to mint links',
+    )
+  })
+
+  it('passes the per-call context through, and undefined when omitted', async () => {
+    const seen: (string | undefined)[] = []
+    stubFetch(jsonResponse(500, {}))
+    const request = createRequest(
+      () => 'tok',
+      '/base',
+      (_res, context) => {
+        seen.push(context)
+        throw new Error('mapped')
+      },
+    )
+
+    await expect(request('GET', '/a', undefined, '/base', 'load campaigns')).rejects.toThrow(
+      'mapped',
+    )
+    stubFetch(jsonResponse(500, {}))
+    await expect(request('GET', '/b')).rejects.toThrow('mapped')
+
+    expect(seen).toEqual(['load campaigns', undefined])
+  })
+
+  it('never reaches the default ApiError once the mapper has thrown', async () => {
+    stubFetch(jsonResponse(403, { detail: 'nope' }))
+    const request = createRequest(
+      () => 'tok',
+      '/base',
+      () => {
+        throw new Error('mapped')
+      },
+    )
+
+    // If the default path still ran, this would be an ApiError instead.
+    await expect(request('GET', '/thing')).rejects.not.toBeInstanceOf(ApiError)
+  })
+
+  /**
+   * A mapper is typed `=> never`, but types are not enforcement at runtime and
+   * this is the dangerous failure: a mapper that returns normally would let
+   * `request()` fall through to the default throw. That is recoverable. What
+   * must never happen is a failed request RESOLVING — so this pins that even a
+   * misbehaving mapper cannot turn a 403 into a successful call.
+   */
+  it('still throws if a mapper wrongly returns instead of throwing', async () => {
+    stubFetch(jsonResponse(403, { detail: 'nope' }))
+    const request = createRequest(() => 'tok', '/base', (() => undefined) as never)
+
+    await expect(request('GET', '/thing')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('does not run the mapper on a successful response', async () => {
+    stubFetch(jsonResponse(200, { ok: true }))
+    const onError = vi.fn(() => {
+      throw new Error('should not run')
+    })
+    const request = createRequest(() => 'tok', '/base', onError as never)
+
+    await expect(request('GET', '/thing')).resolves.toEqual({ ok: true })
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/web-admin/src/lib/api-core.ts
+++ b/web-admin/src/lib/api-core.ts
@@ -27,17 +27,47 @@ export class ApiError extends Error {
 export type GetIdToken = () => string | null | Promise<string | null>
 
 /**
+ * Maps a failed response into the error a plugin wants to surface, INSTEAD of
+ * the default `ApiError(status, body)`.
+ *
+ * It receives the `Response` with its body **unread**, so it can `.json()` the
+ * payload — Core returns `{"detail": "..."}` for a permission failure, and a
+ * plugin usually wants that sentence rather than a status code. It also
+ * receives the per-call `context` string, because the useful wording is
+ * endpoint-specific: "you need the admin role to **mint links**" is actionable
+ * where "403" is not.
+ *
+ * Added for biffo-template#1492. The marketing plugin could not adopt this core
+ * without it: `createRequest` read the body into a string and threw immediately,
+ * leaving no seam to inspect it first, so migrating would have collapsed a dozen
+ * hand-written, endpoint-specific messages into one generic status string. That
+ * is a behaviour regression, and the plugin correctly refused rather than
+ * dropping them — the gap was in this module, not in the plugin.
+ *
+ * MUST NOT RETURN NORMALLY: it either throws, or returns a rejected promise.
+ * The `never` return type says so; a mapper that falls through would make
+ * `request()` resolve `undefined` for a failed call, which is the silent-success
+ * shape this estate spends most of its time eliminating. `assertThrew` in
+ * `api-core.test.ts` holds that line.
+ */
+export type ErrorMapper = (
+  response: Response,
+  context: string | undefined,
+) => Promise<never> | never
+
+/**
  * Build a `request<T>(method, path, body?, base?)` function bound to a token
  * source and a default base. A plugin's own api.ts calls this once per
  * `createApi()` and defines its endpoints on top of the result — see the
  * starter `api.ts` in this same directory for the worked shape.
  */
-export function createRequest(getIdToken: GetIdToken, defaultBase: string) {
+export function createRequest(getIdToken: GetIdToken, defaultBase: string, onError?: ErrorMapper) {
   return async function request<T>(
     method: string,
     path: string,
     body?: unknown,
     base: string = defaultBase,
+    context?: string,
   ): Promise<T> {
     const token = await getIdToken()
     const res = await fetch(`${base}${path}`, {
@@ -49,6 +79,12 @@ export function createRequest(getIdToken: GetIdToken, defaultBase: string) {
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     })
     if (!res.ok) {
+      // The mapper runs FIRST, and gets the response with its body still
+      // unread. Order is load-bearing: `res.text()` below consumes the stream,
+      // and a mapper handed an already-consumed Response cannot call `.json()`
+      // — it would silently see an empty body and fall back to a generic
+      // message, which is the exact failure this hook exists to prevent.
+      if (onError) await onError(res, context)
       // Read the body for the reason: Core returns a JSON detail for a
       // permission failure, and "403" alone tells an admin nothing about
       // which rule bit.


### PR DESCRIPTION
Distributed by `biffo-template`'s `scripts/shared-sync.sh`.

Sibling and plugin repos are separate repositories with no `core-manifest.json`, so `biffo core upgrade` cannot reach them. The documented channel was "vendor into the skeleton plus a one-time manual copy-in", which only ever helped repos created afterwards — and is why this repo was running a local gate two versions old.

Files synced verbatim from the template (see `shared-files.json` there):

- `scripts/biffo.sh`
- `.githooks/commit-msg`
- `.githooks/pre-commit`
- `.githooks/pre-push`
- `scripts/install-hooks.sh`
- `scripts/destructive-plan.mjs`
- `scripts/check-destructive-plan.mjs`
- `scripts/js-dependency-audit.sh`
- `scripts/py-dependency-audit.sh`
- `scripts/check-closing-keywords.mjs`
- `scripts/routing-smoke-test.sh`
- `scripts/routing-smoke-test.test.sh`

- `web-admin/src/lib/api-core.ts` (kept in step; canonical copy is `_skeletons/plugin-template/web-admin/src/lib/api-core.ts`)
- `web-admin/src/lib/api-core.test.ts` (kept in step; canonical copy is `_skeletons/plugin-template/web-admin/src/lib/api-core.test.ts`)


Run `sh scripts/gate-coverage.sh` after merging to see this repo's gate measured against its own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)