### PR TITLE
fix(marketing): seed the fan-in workflow at the path Core actually mounts

### DIFF
--- a/scripts/seed_fan_in_workflow.py
+++ b/scripts/seed_fan_in_workflow.py
@@ -46,8 +46,13 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-# Importable without the package installed, so an operator can run this from a
-# checkout without a `uv sync` first.
+# Resolve `marketing.*` from the checkout rather than an installed package.
+#
+# This used to claim the script ran without a `uv sync` first. It does not, and
+# never did: `marketing.definitions` imports `marketing/__init__.py`, which
+# imports `plugin.py`, which imports `aws_lambda_powertools`. A bare `python3`
+# run dies on that import before reaching any of this file's own logic. Run it
+# with `uv run python scripts/seed_fan_in_workflow.py` from the checkout.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from marketing.definitions import (  # noqa: E402
@@ -61,7 +66,14 @@ from marketing.definitions import (  # noqa: E402
 
 WORKFLOW_NAME = "Marketing — synthesise research once both angles complete"
 
-_DEFINITIONS_PATH = "/api/v1/admin/orchestration/workflows"
+#: Core mounts the orchestration router at `/api/v1/orchestration`, NOT under
+#: `/api/v1/admin`. This carried a stray `admin/` segment until 2026-08-11,
+#: which meant the script 404'd on every run in every environment and had
+#: therefore never once seeded a definition. Verified against the deployed
+#: `openapi.json` rather than read from source — with a valid admin token,
+#: `/api/v1/orchestration/workflows` answers 200 and the `admin/` variant
+#: answers 404, indistinguishable from a route that does not exist.
+_DEFINITIONS_PATH = "/api/v1/orchestration/workflows"
 
 
 def definition(*, synthesis_model: str = DEFAULT_SYNTHESIS_MODEL) -> dict:

--- a/tests/test_marketing_seed_fan_in_workflow.py
+++ b/tests/test_marketing_seed_fan_in_workflow.py
@@ -81,3 +81,27 @@ def test_it_is_enabled_and_named_stably() -> None:
 
     assert payload["enabled"] is True
     assert payload["name"] == WORKFLOW_NAME
+
+
+def test_it_posts_to_the_path_core_actually_mounts() -> None:
+    """Every other test here validates the *payload* and none validated the
+    *endpoint*, so the script shipped posting to a path that has never existed
+    and the suite stayed green.
+
+    Core mounts workflow-definition CRUD at `/api/v1/orchestration/workflows`.
+    `/api/v1/admin/orchestration` is a different router that exposes only
+    `/test` (the dry-run), so the `admin/` variant 404s exactly like a route
+    that was never defined — which is why nothing surfaced it: the seeder
+    reported `Could not list workflows: 404 Not Found` and that reads as a
+    permissions or environment problem, not a wrong URL.
+
+    Measured against deployed dev on 2026-08-11 with a valid admin token:
+    `/api/v1/orchestration/workflows` -> 200, `/api/v1/admin/...` -> 404,
+    identical to a known-bad control path.
+
+    This pins the string; it cannot prove Core still mounts it there. A
+    404 from this script means check the deployed `openapi.json` before
+    assuming the token or environment is at fault.
+    """
+    assert _seed._DEFINITIONS_PATH == "/api/v1/orchestration/workflows"
+    assert "/admin/" not in _seed._DEFINITIONS_PATH


### PR DESCRIPTION
The seeder posted to `/api/v1/admin/orchestration/workflows`. That path has never existed — Core mounts workflow CRUD at `/api/v1/orchestration/workflows`, and `/api/v1/admin/orchestration` is a different router exposing only `/test`.

So the script 404'd on every run in every environment and had never once seeded a definition.

Measured against deployed dev with a valid admin token: the correct path answers **200**, the script's path answers **404** — identical to a deliberately bogus control path.

## Why it survived

The failure reads as a permissions or environment problem (`Could not list workflows: 404 Not Found`), not a wrong URL. And the consequence is silent, exactly as the script's own docstring predicted: without the definition a research run never leaves `pending` while both research agents still run and still bill.

Observed on dev today — two agents completed, the orchestrator received both completion events, matched no workflow, dispatched nothing, logged nothing.

**Eight tests passed throughout.** All validated the payload; none validated the endpoint.

## Verified

Seeded against dev with the corrected path, then drove the pipeline in a browser: fan-out → synthesis → artefact awaiting review → **approved**, with citations rendered.

## Also in here

- The import-shim comment claimed the script runs without `uv sync`. It never could — `marketing.definitions` imports `plugin.py` → `aws_lambda_powertools`.
- A guard test pinning the path, which states what it cannot prove: it pins a string, and cannot know Core still mounts it there.

`biffo-plugin-idea-scout` carries the identical wrong path and is **not** fixed here — tracked in the issue.

Refs #60
