### PR TITLE
feat(marketing): generate stills through OpenRouter, with a real ledger cost

### DIFF
--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -96,6 +96,60 @@ _PARAMETER_ENV = "MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER"
 _OPENAI_IMAGES_URL = "https://api.openai.com/v1/images/generations"
 _OPENAI_MODEL = "gpt-image-1"
 
+#: OpenRouter's dedicated Image API. **Not** chat completions — issue #63
+#: went in assuming image models were only reachable through
+#: `/api/v1/chat/completions`, with the image folded into message content.
+#: That assumption did not survive contact with OpenRouter's current docs:
+#: as of 2026-08-11 there is a first-class `POST /api/v1/images` endpoint
+#: (openrouter.ai/docs/guides/overview/multimodal/image-generation),
+#: confirmed live by posting `{}` to it and reading back a validation error
+#: naming exactly `model` and `prompt` as the required fields. Its response
+#: shape is close cousin to OpenAI's own Images API below — a `data` array
+#: of `{"b64_json", "media_type"}` — which is what keeps this adapter this
+#: short.
+_OPENROUTER_IMAGES_URL = "https://openrouter.ai/api/v1/images"
+
+#: The model is configuration, not a constant like `_OPENAI_MODEL` above —
+#: direct env only, no SSM parameter, because a model slug is not a secret.
+_MODEL_ENV = "MARKETING_IMAGE_PROVIDER_MODEL"
+
+#: ``google/gemini-3.1-flash-image`` ("Nano Banana 2"): the cheapest of the
+#: 11 image-output models in OpenRouter's live catalogue at issue-filing time
+#: (2026-08-11), and one confirmed (via its own `/endpoints` discovery
+#: response) to price per output *token* rather than per flat image — which
+#: is exactly the shape this adapter needs to report a real, non-fabricated
+#: cost. Override with `_MODEL_ENV` for a different model without a code
+#: change.
+_DEFAULT_OPENROUTER_MODEL = "google/gemini-3.1-flash-image"
+
+#: Filename extension for each `media_type` OpenRouter's Image API can return
+#: (`output_format`: png/jpeg/webp, or svg from vectorization models). Falls
+#: back to `png` for anything unrecognised or absent, matching
+#: `OpenAIImageProvider`'s own fixed choice.
+_EXTENSION_BY_CONTENT_TYPE = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+}
+
+
+def _openrouter_model() -> str:
+    """The configured OpenRouter image model, or the default."""
+    return os.environ.get(_MODEL_ENV, "").strip() or _DEFAULT_OPENROUTER_MODEL
+
+
+def _as_number(value: object) -> float | None:
+    """``value`` as a ``float``, or ``None`` if it is missing or not a
+    number. ``bool`` is deliberately excluded even though it is an ``int``
+    subclass — a JSON ``true``/``false`` here would mean OpenRouter's
+    response shape changed underneath this adapter, not a real cost/token
+    count."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
+
+
 #: Resolved once per Lambda container, mirroring `config.public_base_url`'s
 #: cache: `None` means "not yet looked up", distinct from `""` meaning
 #: "looked up, and there is nothing there" — without that distinction an
@@ -214,4 +268,104 @@ class OpenAIImageProvider:
             units=1.0,
             unit_kind="image",
             cost_usd=None,
+        )
+
+
+class OpenRouterImageProvider:
+    """`ImageProvider` backed by OpenRouter's dedicated Image API
+    (`POST /api/v1/images`) — one key for both this plugin's text stages
+    (via Core's agent runtime) and its stills, and the second, independent
+    proof of issue #5's requirement 3: a provider swap that needed no change
+    to `image_routes.py`, this time for real rather than only via the tests'
+    fake.
+
+    **This provider's responses carry a real price**, unlike
+    `OpenAIImageProvider` above. OpenRouter's Image API returns a `usage`
+    object with `prompt_tokens` / `completion_tokens` / `total_tokens` /
+    `cost` on every successful generation (confirmed against the live docs,
+    2026-08-11 — see `_OPENROUTER_IMAGES_URL`'s comment). `cost_usd` is
+    populated from `usage.cost` whenever it comes back as a number; the
+    `ImageProvider` contract's null case stays reachable rather than dead
+    code by falling back to `None` if OpenRouter ever omits it for a given
+    model or provider route, instead of fabricating `0.0`.
+
+    **Units stay verbatim in OpenRouter's own accounting unit: tokens**, not
+    a normalised "1 image". OpenRouter's own `/endpoints` discovery API shows
+    some providers billing per image and others per megapixel or token
+    internally, but the Image API always reports usage back to the caller in
+    tokens (`total_tokens`) alongside the resulting `cost` — that is the
+    provider's own unit for this response, in the same sense
+    `agent_runs.cost_usd` elsewhere in this estate is sourced from a chat
+    completion's own token-based `usage`. Reducing it to `units=1.0,
+    unit_kind="image"` here would bake in the exact conversion the module
+    docstring's contract says never to perform.
+    """
+
+    def __init__(
+        self, *, timeout: float = 60.0, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
+        self._timeout = timeout
+        #: `None` in production — real network. Tests pass an
+        #: `httpx.MockTransport`, matching `OpenAIImageProvider`.
+        self._transport = transport
+
+    async def generate_still(self, *, prompt: str) -> GeneratedImage:
+        api_key = _api_key()
+        if not api_key:
+            raise ImageProviderError(
+                f"No image provider API key configured ({_DIRECT_ENV} / "
+                f"{_PARAMETER_ENV} are both unset)."
+            )
+
+        model = _openrouter_model()
+
+        async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
+            try:
+                response = await client.post(
+                    _OPENROUTER_IMAGES_URL,
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json={"model": model, "prompt": prompt},
+                )
+            except httpx.HTTPError as exc:
+                raise ImageProviderError(f"OpenRouter request failed: {exc}") from exc
+
+        if response.status_code != httpx.codes.OK:
+            raise ImageProviderError(
+                f"OpenRouter returned {response.status_code}: {response.text[:500]}"
+            )
+
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise ImageProviderError("OpenRouter response was not valid JSON.") from exc
+
+        items = body.get("data") or []
+        if not items:
+            raise ImageProviderError("OpenRouter returned no image data.")
+
+        b64 = items[0].get("b64_json")
+        if not b64:
+            raise ImageProviderError("OpenRouter response had no b64_json payload.")
+
+        try:
+            content = base64.b64decode(b64, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise ImageProviderError("OpenRouter's b64_json payload did not decode.") from exc
+
+        content_type = items[0].get("media_type") or "image/png"
+        extension = _EXTENSION_BY_CONTENT_TYPE.get(content_type, "png")
+
+        usage = body.get("usage") or {}
+        cost_usd = _as_number(usage.get("cost"))
+        units = _as_number(usage.get("total_tokens")) or 0.0
+
+        return GeneratedImage(
+            content=content,
+            content_type=content_type,
+            filename=f"{uuid.uuid4()}.{extension}",
+            provider="openrouter",
+            model=model,
+            units=units,
+            unit_kind="token",
+            cost_usd=cost_usd,
         )

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -369,3 +369,49 @@ class OpenRouterImageProvider:
             unit_kind="token",
             cost_usd=cost_usd,
         )
+
+
+#: Chooses which concrete `ImageProvider` a deployment uses. Values are
+#: vendor names, never a platform or tenant name — this plugin installs on
+#: every Biffo platform, so nothing configuration-facing here may assume one
+#: of them (the class of defect biffo-template#1450's shared-set writeup
+#: calls out: a group/vocabulary that exists on one product leaking into
+#: code meant for all of them).
+_PROVIDER_ENV = "MARKETING_IMAGE_PROVIDER"
+
+#: OpenRouter is the default (issue #63): it is the only implementation here
+#: whose response carries a real, non-fabricated cost, and getting the
+#: ledger off permanent `unpriced` rows is the reason this provider exists.
+_DEFAULT_PROVIDER = "openrouter"
+
+#: One factory per accepted `_PROVIDER_ENV` value. A `dict` rather than an
+#: `if`/`elif` chain so the accepted-values list in
+#: :func:`create_image_provider`'s error message and this mapping cannot
+#: drift apart.
+_PROVIDER_FACTORIES: dict[str, type[ImageProvider]] = {
+    "openrouter": OpenRouterImageProvider,
+    "openai": OpenAIImageProvider,
+}
+
+
+def create_image_provider() -> ImageProvider:
+    """This deployment's configured `ImageProvider`, chosen by
+    `MARKETING_IMAGE_PROVIDER` (default: ``"openrouter"``).
+
+    An **unset** value picks the default. An **unrecognised** one is a hard
+    `ImageProviderError`, never a silent fallback to the default or to
+    whichever entry happens to be first in `_PROVIDER_FACTORIES` — a typo'd
+    value (``"openrouetr"``) must surface as a failure, not quietly bill an
+    operator through a provider they did not choose and hand back a cost
+    field shaped differently from the one they expected. Comparison is
+    case-insensitive and trims whitespace only; it does not otherwise guess.
+    """
+    choice = os.environ.get(_PROVIDER_ENV, "").strip().lower() or _DEFAULT_PROVIDER
+    try:
+        factory = _PROVIDER_FACTORIES[choice]
+    except KeyError:
+        accepted = ", ".join(sorted(_PROVIDER_FACTORIES))
+        raise ImageProviderError(
+            f"Unknown {_PROVIDER_ENV}={choice!r}. Expected one of: {accepted}."
+        ) from None
+    return factory()

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -8,7 +8,11 @@ that file concurrently, and `admin_app.py` gains exactly one line — the
 The flow, in the order issue #5 asks for it:
 
 1. `image_provider.ImageProvider.generate_still` — behind the port, so a
-   provider swap never touches this file (issue #5's requirement 3).
+   provider swap never touches the route, the storage upload, or the
+   ledger-write payload below (issue #5's requirement 3). The one place this
+   file is *meant* to know a choice exists is `get_image_provider()`, whose
+   body is entirely `image_provider.create_image_provider()` — it names no
+   vendor itself, only the generic call that resolves one (issue #63).
 2. Store the bytes via Core's plugin object-storage capability
    (biffo-template#1437): presign, upload, confirm with `head_object`. The
    documented flow is "browser PUT" because the capability's usual caller is
@@ -50,7 +54,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from . import principal_client
-from .image_provider import GeneratedImage, ImageProvider, ImageProviderError, OpenAIImageProvider
+from .image_provider import (
+    GeneratedImage,
+    ImageProvider,
+    ImageProviderError,
+    create_image_provider,
+)
 
 require_admin = require_group("admin")
 
@@ -93,12 +102,27 @@ def _validated_campaign_id(campaign_id: str) -> str:
 
 def get_image_provider() -> ImageProvider:
     """One provider per request, matching `admin_app.get_agent_gateway`'s
-    shape. `OpenAIImageProvider` is the only production implementation this
-    milestone ships; tests override this dependency with a fake — proving
-    issue #5's requirement 3 (a provider swap is an implementation change,
-    not a rewrite) rather than merely asserting it in prose.
+    shape. Which concrete class gets constructed is
+    `image_provider.create_image_provider`'s call, driven by the
+    `MARKETING_IMAGE_PROVIDER` env var — this function, and this file, still
+    name no vendor directly. Tests override this dependency with a fake —
+    proving issue #5's requirement 3 (a provider swap is an implementation
+    change, not a rewrite) rather than merely asserting it in prose; the
+    live `create_image_provider` choice (issue #63) is the same claim proven
+    a second, independent way, because a factory naming which concrete
+    implementation to build is the one place that is *meant* to know about
+    them — the route handler below, the storage upload, and the ledger
+    payload it writes still touch none of it.
+
+    A misconfigured `MARKETING_IMAGE_PROVIDER` fails here, as a 502, rather
+    than reaching the route body at all — the same mapping `ImageProviderError`
+    gets everywhere else in this router (see `generate_still_route` below),
+    not a bare 500 an operator would have to guess the cause of.
     """
-    return OpenAIImageProvider()
+    try:
+        return create_image_provider()
+    except ImageProviderError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
 
 def get_core_client() -> BiffoAPIClient:

--- a/tests/test_marketing_image_provider_selection.py
+++ b/tests/test_marketing_image_provider_selection.py
@@ -1,0 +1,103 @@
+"""`create_image_provider` (issue #63 follow-up) — which concrete
+`ImageProvider` a deployment gets, chosen by `MARKETING_IMAGE_PROVIDER`.
+
+Covers the selection itself (default, each accepted value, the unknown-value
+failure) directly against `image_provider.create_image_provider`, plus one
+route-level test proving `image_routes.get_image_provider` maps that failure
+to a 502 rather than reaching the route body or crashing as a bare 500 —
+without overriding `get_image_provider` itself, so this is the one test in
+the suite that exercises the real factory through the real router.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import marketing.image_provider as image_provider
+from marketing import image_routes
+from marketing.image_provider import (
+    ImageProviderError,
+    OpenAIImageProvider,
+    OpenRouterImageProvider,
+    create_image_provider,
+)
+
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ef"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch):
+    """A configured API key (selection doesn't need one to succeed — only
+    `generate_still` does) and no leftover `MARKETING_IMAGE_PROVIDER` from a
+    previous test."""
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY", "sk-test-not-real")  # noqa: S105
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER", raising=False)
+    image_provider.reset_api_key_cache()
+    yield
+    image_provider.reset_api_key_cache()
+
+
+def test_default_is_openrouter() -> None:
+    """Unset picks OpenRouter — the only implementation with a real cost,
+    which is the whole reason issue #63 exists."""
+    assert isinstance(create_image_provider(), OpenRouterImageProvider)
+
+
+def test_explicit_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "openrouter")
+    assert isinstance(create_image_provider(), OpenRouterImageProvider)
+
+
+def test_explicit_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "openai")
+    assert isinstance(create_image_provider(), OpenAIImageProvider)
+
+
+def test_value_is_case_and_whitespace_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "  OpenAI  ")
+    assert isinstance(create_image_provider(), OpenAIImageProvider)
+
+
+def test_unknown_value_fails_loudly_rather_than_falling_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo must not silently pick the default (or anything else) — an
+    operator would then be billed by a provider they never chose, with a
+    cost field shaped differently from the one they expected."""
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "openrouetr")
+
+    with pytest.raises(ImageProviderError, match="openrouetr"):
+        create_image_provider()
+
+
+def test_unknown_value_error_names_the_accepted_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "bogus")
+
+    with pytest.raises(ImageProviderError, match="openai") as exc_info:
+        create_image_provider()
+    assert "openrouter" in str(exc_info.value)
+
+
+def _admin_user():
+    return type("U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"})()
+
+
+def test_route_maps_an_unknown_provider_choice_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Through the real router, with `get_image_provider` NOT overridden:
+    proves the mapping lives where an operator actually hits it, not only at
+    the unit level above."""
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER", "bogus")
+
+    app = FastAPI()
+    app.include_router(image_routes.router)
+    app.dependency_overrides[image_routes.require_admin] = _admin_user
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert response.status_code == 502
+    assert "bogus" in response.json()["detail"]

--- a/tests/test_marketing_openrouter_image_provider.py
+++ b/tests/test_marketing_openrouter_image_provider.py
@@ -1,0 +1,193 @@
+"""`OpenRouterImageProvider` (issue #63) — over `httpx.MockTransport`, never
+the network.
+
+Mirrors `test_marketing_image_provider.py`'s shape for `OpenAIImageProvider`,
+with the one asymmetry the module docstring calls out: OpenRouter's Image API
+*does* return a price, so the interesting cases here are "a real cost gets
+carried through" and, just as load-bearing, "a response with no `usage.cost`
+still renders as unpriced (`None`), never a fabricated `0.0`" — the same
+null-cost contract `OpenAIImageProvider`'s tests exercise, proven here on a
+provider where it is the exceptional case rather than the constant one.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import pytest
+
+import marketing.image_provider as image_provider
+from marketing.image_provider import GeneratedImage, ImageProviderError, OpenRouterImageProvider
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nnot a real png but bytes are bytes"
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode()
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY", "sk-or-test-not-real")  # noqa: S105
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_MODEL", raising=False)
+    image_provider.reset_api_key_cache()
+    yield
+    image_provider.reset_api_key_cache()
+
+
+def _provider(handler) -> OpenRouterImageProvider:
+    """An `OpenRouterImageProvider` whose one outbound call is served by
+    `handler` over an in-memory transport — no socket, ever."""
+    return OpenRouterImageProvider(transport=httpx.MockTransport(handler))
+
+
+async def test_generate_still_parses_the_image_and_the_real_cost() -> None:
+    """OpenRouter's Image API returns a priced `usage` object — the ledger
+    row this issue exists to make non-null."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer sk-or-test-not-real"
+        return httpx.Response(
+            200,
+            json={
+                "created": 1748372400,
+                "data": [{"b64_json": _PNG_B64, "media_type": "image/png"}],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 4175,
+                    "total_tokens": 4175,
+                    "cost": 0.04,
+                },
+            },
+        )
+
+    image = await _provider(handler).generate_still(prompt="a friendly logo")
+
+    assert isinstance(image, GeneratedImage)
+    assert image.content == _PNG_BYTES
+    assert image.content_type == "image/png"
+    assert image.filename.endswith(".png")
+    assert image.provider == "openrouter"
+    assert image.model == "google/gemini-3.1-flash-image"
+    assert image.unit_kind == "token"
+    assert image.units == 4175.0
+    assert image.cost_usd == 0.04
+
+
+async def test_generate_still_reports_unpriced_when_usage_has_no_cost() -> None:
+    """A response with no `usage.cost` (a model/route OpenRouter has not
+    priced) must render as `cost_usd=None`, never `0.0` — the same contract
+    `OpenAIImageProvider` upholds in the constant case, exercised here in the
+    exceptional one."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"b64_json": _PNG_B64, "media_type": "image/png"}],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 10, "total_tokens": 10},
+            },
+        )
+
+    image = await _provider(handler).generate_still(prompt="anything")
+
+    assert image.cost_usd is None
+    assert image.units == 10.0
+    assert image.unit_kind == "token"
+
+
+async def test_generate_still_reports_unpriced_when_usage_is_entirely_absent() -> None:
+    """No `usage` key at all is the same "no price returned" fact as a
+    `usage` with no `cost` field — still `None`, still zero-valued units
+    rather than a crash."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"b64_json": _PNG_B64}]})
+
+    image = await _provider(handler).generate_still(prompt="anything")
+
+    assert image.cost_usd is None
+    assert image.units == 0.0
+
+
+async def test_generate_still_sends_the_prompt_and_default_model() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": [{"b64_json": _PNG_B64}], "usage": {}})
+
+    await _provider(handler).generate_still(prompt="a friendly logo, flat style")
+
+    assert seen["body"]["prompt"] == "a friendly logo, flat style"
+    assert seen["body"]["model"] == "google/gemini-3.1-flash-image"
+
+
+async def test_generate_still_honours_a_configured_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The model is configuration (issue #63), not a hardcoded constant like
+    `OpenAIImageProvider`'s `_OPENAI_MODEL` — `MARKETING_IMAGE_PROVIDER_MODEL`
+    overrides the default with no code change."""
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_MODEL", "openai/gpt-5-image-mini")
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": [{"b64_json": _PNG_B64}], "usage": {}})
+
+    image = await _provider(handler).generate_still(prompt="anything")
+
+    assert seen["body"]["model"] == "openai/gpt-5-image-mini"
+    assert image.model == "openai/gpt-5-image-mini"
+
+
+async def test_generate_still_uses_the_returned_media_type_and_extension() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"b64_json": _PNG_B64, "media_type": "image/webp"}],
+                "usage": {"total_tokens": 5, "cost": 0.001},
+            },
+        )
+
+    image = await _provider(handler).generate_still(prompt="anything")
+
+    assert image.content_type == "image/webp"
+    assert image.filename.endswith(".webp")
+
+
+async def test_generate_still_raises_on_a_non_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": {"message": "bad prompt"}})
+
+    with pytest.raises(ImageProviderError, match="400"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_data_is_empty() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": []})
+
+    with pytest.raises(ImageProviderError, match="no image data"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_b64_json_is_missing() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"media_type": "image/png"}]})
+
+    with pytest.raises(ImageProviderError, match="b64_json"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_without_a_configured_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", raising=False)
+    image_provider.reset_api_key_cache()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should never reach the transport with no key")
+
+    with pytest.raises(ImageProviderError, match="No image provider API key"):
+        await _provider(handler).generate_still(prompt="anything")


### PR DESCRIPTION
Issue 63. Adds `OpenRouterImageProvider` in `src/marketing/image_provider.py` as a second `ImageProvider` implementation, alongside `OpenAIImageProvider` (kept, still fully tested), and wires it in as the deployment's *configured* choice, defaulting to OpenRouter.

## Corrected premise: it's a dedicated REST endpoint, not chat completions

The issue assumed OpenRouter serves image models only through `/api/v1/chat/completions`. That did not hold up: as of 2026-08-11, OpenRouter has a dedicated `POST /api/v1/images` endpoint (confirmed against the live docs, and against the endpoint itself — posting `{}` returns a Zod validation error naming exactly `model` and `prompt` as required). Its response shape (`data: [{b64_json, media_type}]`) is close to OpenAI's own Images API, which is what keeps this adapter about the same size as `OpenAIImageProvider`.

## `image_routes.py` — one deliberate line, and the criterion still holds

First push of this PR left `image_routes.py` untouched entirely. Per review, the coordinator made the call to wire the new provider in as the one actually used — as **configuration**, not a second hardcode: `get_image_provider()` now delegates to a new `image_provider.create_image_provider()`, selected by `MARKETING_IMAGE_PROVIDER` (`"openrouter"` default / `"openai"`).

**M6's third acceptance criterion — "swapping the provider is an implementation change, not a rewrite" — holds, and is worth recording as met rather than left ambiguous.** The route handler, the storage upload, and the ledger-write payload are byte-for-byte unchanged; they still depend only on the `ImageProvider` Protocol and the fields on `GeneratedImage`. The only code that now knows concrete vendor names is `create_image_provider()` in `image_provider.py` — the module the original docstring already designates as the one place allowed to name a vendor — and `get_image_provider()`'s body, which is one delegating call plus an error-status mapping, naming no vendor itself. A factory whose job is choosing which implementation to construct is, structurally, the one place that's *meant* to know — this is what the swap looks like when the seam is real, not a rewrite reaching back into the route.

Defaulting to `openrouter` is the point of the issue: it's the only implementation whose response carries a real cost, so the ledger stops recording `unpriced` on every row.

## Selection is loud on failure, never silent

An unset `MARKETING_IMAGE_PROVIDER` picks the default. An unrecognised value (a typo, e.g. `openrouetr`) raises `ImageProviderError` naming the bad value and the accepted ones — never a silent fallback to the default or to whichever provider happens to be first. `get_image_provider()` maps that to a `502` before the route body ever runs, the same status this router already uses for "the provider is misconfigured" (a missing API key), rather than an opaque `500`. Both the unit-level selection and the route-level mapping are tested (`tests/test_marketing_image_provider_selection.py`), including a request through the real router with no dependency override, proving the 502 happens where an operator would actually hit it.

Config names, defaults and docstrings stay generic — `"openrouter"` / `"openai"` are vendor names, not platform or tenant vocabulary, since this plugin ships to every Biffo platform.

## Cost — real, not fabricated

OpenRouter's Image API returns a `usage` object (`prompt_tokens`/`completion_tokens`/`total_tokens`/`cost`) on every successful generation. `cost_usd` is populated from `usage.cost` when it's a real number, and falls back to `None` (never `0.0`) if a given model/route ever omits it — verified with a test that sends back a response with no `cost` field at all, and one with no `usage` key at all.

## Units — verbatim, in OpenRouter's unit

`unit_kind="token"`, `units=usage.total_tokens`. OpenRouter's own per-endpoint discovery API shows some providers billing per image, others per megapixel or token internally — but the Image API always reports usage back in tokens alongside the cost, so tokens are the provider's own unit here, not a normalisation I invented.

## Model — configurable

`MARKETING_IMAGE_PROVIDER_MODEL` (direct env, no SSM — a model slug isn't a secret), defaulting to `google/gemini-3.1-flash-image` ("Nano Banana 2"), the cheapest of the 11 image-output models in OpenRouter's catalogue at issue-filing time, and confirmed via its own `/endpoints` record to price per output token.

## Credential

Reuses the existing `MARKETING_IMAGE_PROVIDER_API_KEY` / `MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER` resolution as-is — same slot, now needs to hold an OpenRouter key by default rather than an OpenAI one. **Not provisioned**: whether the plugin's Lambda can reach an existing estate OpenRouter key, or needs its own SSM parameter set, is an infra decision outside this PR's scope — flagging rather than inventing a value.

## Testing

- `tests/test_marketing_openrouter_image_provider.py` (new, 12 tests): parses a priced response, the null-cost case (no `cost` field, and no `usage` key at all), the configured-model override, non-PNG media types, and the same error-mapping tests `OpenAIImageProvider` has. All over `httpx.MockTransport`, no network.
- `tests/test_marketing_image_provider_selection.py` (new, 7 tests): default, each explicit value, case/whitespace handling, the unknown-value failure and its message, and the route-level 502 mapping through the real router.
- Full suite: 344 passed locally (`uv run pytest`), pyright and ruff clean, push gate green on both commits.

## Not verified

No OpenRouter key is available to me, so I could not run this against the real endpoint — only against a mocked transport built from the documented (and endpoint-confirmed) request/response shape. To finish verification: an OpenRouter-capable key needs to land in `MARKETING_IMAGE_PROVIDER_API_KEY`/`_PARAMETER` on dev, and then a real `POST /campaigns/{id}/stills` call would confirm the response actually parses and the ledger row carries a non-null `cost_usd` end to end.

Closes #63
