### PR TITLE
fix(marketing): stop the pack routes 404ing on a campaign with no assets yet

### DIFF
--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -146,19 +146,24 @@ async def _existing_assets(
     see the module docstring for why generation time, not pack time, is
     where that belongs.
 
-    Raises 404 if this campaign has no source creative (``is_source=True``)
-    yet — there is nothing to build a pack from.
+    Returns ``([], PLACEMENTS)`` when nothing exists yet — a campaign whose
+    still was never generated (image generation not yet run, or #63's
+    missing provider key) is a valid, assemblable pack: the gap belongs in
+    ``missing_placements``, exactly as the module docstring already promises
+    ("missing_placements... says so explicitly rather than silently
+    pretending they exist"), not behind a 404 raised here.
+
+    **This used to require an ``is_source=True`` row and 404 when none
+    existed** ("No approved source creative for this campaign yet."). That
+    was issue #64: a campaign with copy fully approved still 404d on
+    ``/pack`` and ``/paid-pack``, because this check runs *after* the copy
+    gate in ``get_pack_route``/``get_paid_pack_route`` — a third 404 site in
+    those functions that #64's own two-site reading of the source missed.
     """
     assets = await campaign_client.get(
         f"{_INTERNAL_PREFIX}/assets", params={"campaign_id": campaign_id}
     )
     assets = assets or []
-    source = next((a for a in assets if a.get("is_source")), None)
-    if source is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No approved source creative for this campaign yet.",
-        )
 
     have_placements = {a["placement"] for a in assets if a.get("placement")}
     missing_placements = [p for p in PLACEMENTS if p not in have_placements]

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -232,7 +232,18 @@ def test_409s_when_copy_is_not_approved(monkeypatch: pytest.MonkeyPatch) -> None
     assert resp.status_code == 409
 
 
-def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_assembles_with_no_assets_reporting_every_placement_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #64: a campaign with copy approved but no `marketing_asset` rows
+    at all — image generation never run, e.g. #63's missing provider key —
+    must still assemble a pack. `_existing_assets` used to require an
+    `is_source=True` row and 404 ("No approved source creative for this
+    campaign yet.") when none existed, a THIRD 404 site in `get_pack_route`
+    the issue's own two-site read of the function missed: it fires after the
+    copy-approval gate has already passed, so a fully-approved campaign with
+    no image generated still 404s, contradicting the module docstring's own
+    "missing_placements... rather than silently pretending they exist"."""
     core = _FakeCore(copy_artefact=_copy_artefact(_CHANNELS))
     monkeypatch.setattr(admin_app, "_core", core)
     client = TestClient(
@@ -241,8 +252,11 @@ def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) ->
 
     resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
 
-    assert resp.status_code == 404
-    assert "source creative" in resp.json()["detail"].lower()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["assets"] == []
+    assert set(body["missing_placements"]) == set(PLACEMENTS)
+    assert body["copy"] == _CHANNELS
 
 
 def test_422s_when_the_campaign_has_no_destination_for_a_channel_that_needs_minting(

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -311,7 +311,14 @@ def test_404s_when_the_approved_positioning_has_no_segments(
     assert "segments" in resp.json()["detail"].lower()
 
 
-def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_assembles_with_no_assets_reporting_every_placement_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #64, same root cause as `test_marketing_pack_routes.py`'s own
+    regression test: `pack_routes._existing_assets` (reused here) used to
+    404 ("No approved source creative for this campaign yet.") whenever no
+    `marketing_asset` row existed at all, even with copy and positioning both
+    fully approved — a campaign whose still was never generated (#63)."""
     core = _FakeCore(
         copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
         positioning_artefact=_positioning_artefact(_SEGMENTS),
@@ -323,8 +330,10 @@ def test_404s_when_no_source_creative_exists(monkeypatch: pytest.MonkeyPatch) ->
 
     resp = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
 
-    assert resp.status_code == 404
-    assert "source creative" in resp.json()["detail"].lower()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["assets"] == []
+    assert set(body["missing_placements"]) == set(PLACEMENTS)
 
 
 # ── the happy path ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What was actually wrong

Not what the issue predicted. The issue's own reasoning ("`pack_routes.get_pack_route` can only 404 on 'campaign not found' or `_latest_artefact(...) is None`") was a plausible-but-incomplete read of the function — it named two 404 sites and missed a third, further down, inside `_existing_assets`, called *after* the copy-approval gate has already passed.

`_existing_assets` required a `marketing_asset` row with `is_source=True` and raised 404 ("No approved source creative for this campaign yet.") whenever none existed. A campaign whose still was never generated — image generation not yet run, or the missing provider key tracked in #63 — has *zero* `marketing_asset` rows, not just missing placement crops. So a campaign with copy fully approved (which has nothing to do with images) still 404'd on both `/pack` and `/paid-pack`.

I checked the issue's own prime suspect first (`_latest_artefact` returning `None` on the pack path due to a different Core client) and it does not hold: `pack_routes.get_pack_route` fetches the copy artefact via `admin_app._latest_artefact(campaign_id, "copy", admin.token)` — the *literal same function, called with the literal same arguments* as `admin_app.get_artefact_route` (the endpoint that renders the APPROVED badge). There is no second client in that call at all; `get_campaign_client`/`PrincipalCoreClient` is only used for the `marketing_asset` lookup in `_existing_assets`, a separate function entirely. Given that, the two routes cannot disagree on the copy artefact by construction, and they don't — the actual 404 fires one step later, on the asset check.

This also explains why `test_marketing_pack_routes.py` was green while dev was broken: `test_404s_when_no_source_creative_exists` asserted the 404 as *correct* behaviour, which is exactly backwards — the module's own docstring already promises `missing_placements` should carry this gap, not a 404.

## Fix

`pack_routes._existing_assets` no longer requires a source asset to exist. It returns `([], PLACEMENTS)` when nothing exists yet, same as it already does for partial gaps. `paid_pack_routes.py` reuses this function, so both routes are fixed together.

## Tests

- Rewrote `test_404s_when_no_source_creative_exists` in both `test_marketing_pack_routes.py` and `test_marketing_paid_pack_routes.py` into `test_assembles_with_no_assets_reporting_every_placement_missing`, asserting 200 with `assets: []` and every `PLACEMENTS` entry in `missing_placements`.
- Fail-first verified: added the new assertions against the unmodified code first, watched them fail with `404 != 200`, then applied the fix and watched them pass.
- Full suite: 327 passed (`uv run pytest`), plus `sh scripts/biffo.sh verify` (ruff, pyright, pytest, terraform-fmt, plugin-tf, plugin-names, adr-numbering, gitleaks, and web-admin lint/typecheck/test) all green.

## Not verified

No live-deployment check — I don't have a session against wherever this plugin is actually deployed (biffo-platform or tabsii dev). The diagnosis is grounded in reading `pack_routes.py`/`admin_app.py` directly and in a fail-first test that reproduces the exact reported symptom (copy approved, pack 404s) from a campaign shape that matches the issue's own narrative closely: research → positioning → channel plan → copy were each approved through the UI, but image generation (M6) was never mentioned as having been run. If the real dev campaign *does* have a source asset and still 404s, this fix does not explain that case and the diagnosis should be treated as incomplete, not closed.

Refs #63 (the missing provider key is what leaves a campaign with zero assets in the first place; not fixed here)

Closes #64
