### PR TITLE
fix(marketing): derive the pack's base URL from the request at every call site

### DIFF
--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -91,10 +91,10 @@ import json
 from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from . import admin_app, pipeline, principal_client
-from .config import public_base_url
+from .config import public_base_url_for
 from .definitions import PLACEMENTS
 from .links import destination_with_utms, mint_token, tracked_url
 
@@ -181,7 +181,12 @@ async def _asset_with_url(core_client: BiffoAPIClient, asset: dict[str, Any]) ->
 
 
 async def _ensure_links(
-    campaign_id: str, channels: list[dict[str, Any]], *, campaign: dict[str, Any], admin_token: str
+    campaign_id: str,
+    channels: list[dict[str, Any]],
+    *,
+    campaign: dict[str, Any],
+    admin_token: str,
+    base_url: str,
 ) -> list[dict[str, Any]]:
     """One tracked link per channel in the approved copy — minted once and
     reused on every later pack request, never re-minted, so opening the pack
@@ -201,7 +206,6 @@ async def _ensure_links(
     existing = links_resp.json() or []
     have_channels = {link["channel"] for link in existing}
 
-    base_url = public_base_url()
     out = [
         {
             "channel": link["channel"],
@@ -266,6 +270,7 @@ async def _ensure_links(
 @router.get("/campaigns/{campaign_id}/pack")
 async def get_pack_route(
     campaign_id: str,
+    request: Request,
     core_client: BiffoAPIClient = Depends(get_core_client),
     campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
     admin: Any = Depends(require_admin),
@@ -308,7 +313,13 @@ async def get_pack_route(
     )
     assets_with_urls = [await _asset_with_url(core_client, a) for a in assets]
 
-    links = await _ensure_links(campaign_id, channels, campaign=campaign, admin_token=admin.token)
+    links = await _ensure_links(
+        campaign_id,
+        channels,
+        campaign=campaign,
+        admin_token=admin.token,
+        base_url=public_base_url_for(request.headers.get("origin"), request.headers.get("referer")),
+    )
 
     return {
         "campaign_id": campaign_id,

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -53,9 +53,9 @@ import json
 from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, create_core_client
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from . import admin_app, pack_routes, pipeline, principal_client
+from . import admin_app, config, pack_routes, pipeline, principal_client
 from .results_routes import UnmeasuredMetric
 
 require_admin = admin_app.require_admin
@@ -237,6 +237,7 @@ def _budget_recommendation(paid_channel_count: int) -> dict[str, Any]:
 @router.get("/campaigns/{campaign_id}/paid-pack")
 async def get_paid_pack_route(
     campaign_id: str,
+    request: Request,
     core_client: BiffoAPIClient = Depends(get_core_client),
     campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
     admin: Any = Depends(require_admin),
@@ -312,7 +313,13 @@ async def get_paid_pack_route(
     assets_with_urls = [await pack_routes._asset_with_url(core_client, a) for a in assets]
 
     links = await pack_routes._ensure_links(
-        campaign_id, paid_channels, campaign=campaign, admin_token=admin.token
+        campaign_id,
+        paid_channels,
+        campaign=campaign,
+        admin_token=admin.token,
+        base_url=config.public_base_url_for(
+            request.headers.get("origin"), request.headers.get("referer")
+        ),
     )
     # `_ensure_links` returns every link Core holds for this campaign, not
     # just the `paid_channels` subset passed in — see issue #48. Filtered

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -124,10 +124,10 @@ from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 
 from . import admin_app, principal_client
-from .config import public_base_url
+from .config import public_base_url_for
 from .links import tracked_url
 
 require_founder = require_group("founder")
@@ -252,6 +252,7 @@ async def _resolve_asset_url(core_client: BiffoAPIClient, asset: dict[str, Any])
 @router.get("/campaigns/{campaign_id}/pack")
 async def get_pack_route(
     campaign_id: str,
+    request: Request,
     core_client: BiffoAPIClient = Depends(get_core_client),
     campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
     founder: Any = Depends(require_founder),
@@ -302,7 +303,7 @@ async def get_pack_route(
     link_rows = await _list_all(
         campaign_client, f"{_INTERNAL_PREFIX}/links", {"campaign_id": campaign_id}
     )
-    base_url = public_base_url()
+    base_url = public_base_url_for(request.headers.get("origin"), request.headers.get("referer"))
     links = [
         {
             "channel": link.get("channel") or "",

--- a/tests/test_marketing_base_url_call_sites.py
+++ b/tests/test_marketing_base_url_call_sites.py
@@ -1,0 +1,92 @@
+"""No module outside `config.py` may call `public_base_url()`.
+
+`config.public_base_url()` reads this deployment's configured base URL. On the
+**shared plugin host** — where `admin_ingress` and `user_ingress` apps actually
+run — that configuration does not exist: a plugin's Terraform sets environment
+on the plugin's OWN Lambda, which is a different function. `config.py`'s own
+docstring records this. So `public_base_url()` returns nothing there, forever,
+and every caller inside a request path fails.
+
+`public_base_url_for(origin, referer)` exists because of that, deriving the base
+URL from the request instead. It was added in #51 and adopted at **one call site
+of three**: the mint route got it; `pack_routes._ensure_links` and `user_app`'s
+pack route kept the config-only version and returned a 503 on a real deployment
+("No public base URL is configured for this deployment") while every test passed.
+That is #72, and this guard exists so the next author cannot repeat it.
+
+**Why an AST walk rather than a grep.** A textual search for
+``public_base_url()`` matches this file, matches comments and docstrings that
+merely name it — including the ones above — and matches ``public_base_url_for``
+unless the pattern is written very carefully. A guard that can be satisfied by
+its own text is the failure this estate has recorded repeatedly: the check
+passes because it cannot really run. Walking the tree asks the only question
+that matters — *is there a call node whose callee is this name* — and cannot be
+fooled by prose.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "marketing"
+
+#: The one module allowed to call it: `public_base_url_for` falls back to
+#: `public_base_url()` when a request carries no usable Origin/Referer.
+_ALLOWED = {"config.py"}
+
+_BANNED = "public_base_url"
+
+
+def _calls_to(tree: ast.AST, name: str) -> list[int]:
+    """Line numbers of every call whose callee is exactly `name`.
+
+    Matches a bare call (`public_base_url()`) and an attribute call
+    (`config.public_base_url()`) — both reach the same function, and only one
+    of the two forms being caught is how a sweep misses a call site.
+    `public_base_url_for` is a different `id`/`attr` and is not matched.
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == name:
+            hits.append(node.lineno)
+        elif isinstance(func, ast.Attribute) and func.attr == name:
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_module_outside_config_calls_public_base_url() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC.glob("*.py")):
+        if path.name in _ALLOWED:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for lineno in _calls_to(tree, _BANNED):
+            offenders.append(f"{path.name}:{lineno}")
+
+    assert not offenders, (
+        "These call `config.public_base_url()`, which returns nothing on the shared "
+        "plugin host where these apps actually run — so the route 503s in deployment "
+        "while every test passes (#72). Use `public_base_url_for(origin, referer)` and "
+        "take a `Request`:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_can_actually_fail() -> None:
+    """The guard must detect the thing it claims to detect.
+
+    A guard whose passing condition is never exercised is indistinguishable
+    from one that cannot fire. This asserts the detector itself, against source
+    that is never imported — both call forms, plus the near-miss that must NOT
+    be flagged.
+    """
+    tree = ast.parse(
+        "public_base_url()\n"
+        "config.public_base_url()\n"
+        "public_base_url_for(a, b)\n"
+        "config.public_base_url_for(a, b)\n"
+    )
+    assert _calls_to(tree, _BANNED) == [1, 2]

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -34,7 +34,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from marketing import admin_app, pack_routes
+from marketing import admin_app, config, pack_routes
 from marketing.definitions import PLACEMENTS
 
 _CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000c5"
@@ -187,7 +187,7 @@ def _app(*, core_client: _FakeStorageClient, campaign_client: _FakeCampaignClien
 
 @pytest.fixture(autouse=True)
 def _base_url(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(pack_routes, "public_base_url", lambda: _BASE_URL)
+    monkeypatch.setattr(pack_routes, "public_base_url_for", lambda *_: _BASE_URL)
 
 
 # ── failure paths ────────────────────────────────────────────────────────────
@@ -369,3 +369,51 @@ def test_does_not_remint_a_link_for_a_channel_that_already_has_one(
     assert resp.json()["links"][0]["url"] == f"{_BASE_URL}/c/existing-token"
     # No new link written.
     assert core.links == [core.links[0]]
+
+
+def test_link_urls_come_from_the_request_origin_not_from_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real derivation, with nothing patched over it.
+
+    Every other test here patches `public_base_url_for`, so none of them can
+    tell whether the route calls it at all. That is exactly how #72 shipped:
+    `_ensure_links` still called the **config-only** `public_base_url()`, which
+    returns nothing on the shared plugin host where this app actually runs, and
+    the deployed route 503'd ("No public base URL is configured for this
+    deployment") while every test here stayed green.
+
+    So this one deliberately does **not** use the `_base_url` fixture's patch —
+    it sends a real `Origin` header and asserts the minted URL was built from
+    it. It fails if anyone reverts a call site to the configured value, because
+    no configuration is set in this process.
+    """
+    core = _FakeCore(copy_artefact=_copy_artefact(_CHANNELS))
+    core.links.append(
+        {
+            "id": "link-existing",
+            "campaign_id": _CAMPAIGN,
+            "token": "existing-token",
+            "channel": "Instagram Reels",
+            "variant": None,
+            "is_paid": False,
+            "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+        }
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    # Undo the autouse fixture: this test is about the un-patched path.
+    monkeypatch.setattr(pack_routes, "public_base_url_for", config.public_base_url_for)
+    # And make sure a configured value cannot rescue it if the origin is ignored.
+    monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
+
+    client = TestClient(
+        _app(core_client=_FakeStorageClient(), campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.get(
+        f"/campaigns/{_CAMPAIGN}/pack",
+        headers={"origin": "https://tenant.example.test"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["links"][0]["url"] == "https://tenant.example.test/c/existing-token"

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -202,7 +202,7 @@ def _base_url(monkeypatch: pytest.MonkeyPatch):
     # `_ensure_links` (reused from `pack_routes`) reads `public_base_url`
     # through that module's own imported name — patched there, matching
     # `test_marketing_pack_routes.py`'s own fixture exactly.
-    monkeypatch.setattr(pack_routes, "public_base_url", lambda: _BASE_URL)
+    monkeypatch.setattr(paid_pack_routes.config, "public_base_url_for", lambda *_: _BASE_URL)
 
 
 # ── failure paths ────────────────────────────────────────────────────────────

--- a/tests/test_marketing_user_app.py
+++ b/tests/test_marketing_user_app.py
@@ -164,7 +164,7 @@ def configured_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     patching `user_app`'s own reference to it is isolated from `config`'s
     process-lifetime cache — no other test's cached value can leak in, and
     this test cannot leak one out either."""
-    monkeypatch.setattr(user_app, "public_base_url", lambda: _BASE_URL)
+    monkeypatch.setattr(user_app, "public_base_url_for", lambda *_: _BASE_URL)
 
 
 # ── /campaigns ────────────────────────────────────────────────────────────
@@ -436,7 +436,7 @@ def test_pack_omits_link_urls_when_no_public_base_url_is_configured(
     """A link with no base URL configured still appears — with `url: null` —
     rather than the whole pack failing, since assets/copy may still be
     useful with no base URL wired up yet."""
-    monkeypatch.setattr(user_app, "public_base_url", lambda: "")
+    monkeypatch.setattr(user_app, "public_base_url_for", lambda *_: "")
     fake_signed_client(
         {
             f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (


### PR DESCRIPTION
Both packs 503 on dev with *"No public base URL is configured for this deployment"*, for any campaign whose approved channels do not already have links — the normal case.

## Cause: an incomplete fix

`public_base_url_for(origin, referer)` was added in #51 because a plugin's Terraform sets environment on the plugin's **own** Lambda, while `admin_ingress` and `user_ingress` run on the **shared plugin host** — a different function — so the configured value is never present there.

It was adopted at one call site of three:

| call site | was | now |
|---|---|---|
| `admin_app.py` — mint links | `public_base_url_for(...)` | unchanged |
| `pack_routes._ensure_links` | `public_base_url()` | fixed |
| `user_app.py` — Surface B pack | `public_base_url()` | fixed |

`paid_pack_routes` inherited it by reusing `_ensure_links`, which is why both packs failed identically.

`_ensure_links` now takes `base_url` as a parameter so it stays request-agnostic; the three routes resolve it from their own `Request`.

## Two guards, both proven fail-first

**An AST walk** asserting no module outside `config.py` calls `public_base_url()`. Deliberately not a grep — a textual search matches its own docstring and the near-miss `public_base_url_for`, so it could pass by describing itself. Reverting the source makes it name both offenders exactly (`pack_routes.py:204`, `user_app.py:305`). It also asserts the detector can fail, against source never imported.

**A route test sending a real `Origin` header with nothing mocked over the helper.** Every other pack test patches `public_base_url_for`, so none of them can tell whether the route calls it at all — which is exactly why this shipped green. This one unpatches it and asserts the minted URL was built from the header.

## Verification

347 tests pass. Confirmed on dev the 503 was the application's own, not infrastructure: zero Throttles and zero Errors on `plugin-host` and `core-api`, account concurrency 1000.

Live confirmation that the pack assembles is outstanding, and will be done after this deploys.

Closes #72
