### PR TITLE
feat(marketing): channel taxonomy table and idempotent seeding (#76 increment 1)

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -324,6 +324,71 @@
           "required_role": ["admin"]
         }
       }
+    },
+    {
+      "name": "marketing_channel",
+      "description": "The channel taxonomy (#67, #76 increment 1): a closed, admin-extensible vocabulary of stable channel ids, replacing the free-text `channel` strings that let a 121-character agent-generated name overflow `marketing_link.channel` (#75). `key` is the stable, machine-safe identifier a future `ChannelRecommendation`/`ChannelCopy`/`marketing_link` will reference (#76 increment 2, not this table) — it plays the role the manifest's auto-injected `id` (a Core-generated UUID) cannot, since that is neither short nor stable across a re-seed. Nothing here is platform-, vertical- or tenant-specific: this plugin installs on every Biffo platform, and the taxonomy is deliberately broad (digital and offline/field) rather than encoding any one operator's vocabulary.",
+      "columns": [
+        {
+          "name": "key",
+          "type": "String(64)",
+          "nullable": false,
+          "description": "Stable machine-safe identifier, e.g. 'google_search_paid'. Short by construction — every seeded key is well under this column's 64-character ceiling — so the #75 overflow class cannot recur through a channel referenced by key rather than by a hand-typed name. Relabelling must never change this: it is what a future recommendation/copy/link row will reference, and changing it under an existing reference would silently break the join it exists to make structural."
+        },
+        {
+          "name": "label",
+          "type": "String(200)",
+          "nullable": false,
+          "description": "Operator-facing name, e.g. 'Google Search ads'. May be long and descriptive — this is the field an operator reads; `key` is the field code and storage join on. Splitting the two is what makes #75's overflow impossible rather than merely unlikely: the field that can be long is never the field that is stored short."
+        },
+        {
+          "name": "motion",
+          "type": "String(16)",
+          "nullable": false,
+          "description": "organic | paid. Lives on the channel, not only on a recommendation: 'Google Search ads' is inherently paid, and LinkedIn-organic/LinkedIn-paid are different channels with different work attached, so this is a property of what the channel IS rather than something an agent asserts independently each time. Plain String — plugin tables have no enum type."
+        },
+        {
+          "name": "category",
+          "type": "String(32)",
+          "nullable": false,
+          "description": "One of: search, social, video, email, content, communities, partner, events, trade_press, direct_mail, local_field (#67's taxonomy shape). Groups channels for display; not itself referenced by any other table."
+        },
+        {
+          "name": "ad_platform",
+          "type": "String(32)",
+          "nullable": true,
+          "description": "Optional. The ad platform this channel's spend and character limits belong to (e.g. 'google', 'meta', 'linkedin', 'tiktok'), NULL for channels with no platform-specific limits (organic search, direct mail, events, ...). Exists now so the shape a future `_platform_for_channel` lookup needs (replacing today's substring guessing) does not require a second schema change — the lookup itself is #76 increment 2, out of scope here."
+        }
+      ],
+      "indexes": [
+        {
+          "name": "idx_marketing_channel_tenant_key",
+          "columns": ["tenant_id", "key"],
+          "unique": true
+        }
+      ],
+      "permissions": {
+        "list": {
+          "allowed": true,
+          "required_role": []
+        },
+        "read": {
+          "allowed": true,
+          "required_role": []
+        },
+        "create": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "update": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "delete": {
+          "allowed": true,
+          "required_role": ["admin"]
+        }
+      }
     }
   ],
   "api_routes": [
@@ -452,6 +517,41 @@
       "table": "marketing_click",
       "operation": "read",
       "description": "Read one click."
+    },
+    {
+      "method": "GET",
+      "path": "/channels",
+      "table": "marketing_channel",
+      "operation": "list",
+      "description": "List the channel taxonomy for the caller's tenant. Readable by any authenticated caller — the operator selection UI (#67) and the seed script both need it."
+    },
+    {
+      "method": "GET",
+      "path": "/channels/{id}",
+      "table": "marketing_channel",
+      "operation": "read",
+      "description": "Read one channel."
+    },
+    {
+      "method": "POST",
+      "path": "/channels",
+      "table": "marketing_channel",
+      "operation": "create",
+      "description": "Add a channel (admin only) — used by the default-taxonomy seed script and by an instance adding its own channel."
+    },
+    {
+      "method": "PATCH",
+      "path": "/channels/{id}",
+      "table": "marketing_channel",
+      "operation": "update",
+      "description": "Relabel, recategorise or reassign a channel (admin only). `key` is not editable through this generic route in practice — nothing calls it — but Core does not restrict which columns a generic update may touch, so this is a documented convention, not an enforced one."
+    },
+    {
+      "method": "DELETE",
+      "path": "/channels/{id}",
+      "table": "marketing_channel",
+      "operation": "delete",
+      "description": "Remove a channel (admin only). A future recommendation/copy/link row that already referenced this channel's key would be orphaned, same trade-off as idea-scout's business-model categories."
     }
   ],
   "event_subscriptions": [

--- a/scripts/seed_marketing_channels.py
+++ b/scripts/seed_marketing_channels.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Seed the default channel taxonomy (#67, #76 increment 1).
+
+Modelled directly on `biffo-plugin-idea-scout`'s `scripts/seed_business_models.py`
+— same mechanism, same idempotency shape — **not** on this repo's own
+`seed_fan_in_workflow.py`, which posts to a Core orchestration endpoint that has
+never existed (#60) and had therefore never once worked. This script instead
+hits the plugin's own public generic-CRUD mount, `/api/v1/plugins/marketing/*`,
+which is the same mount `marketing_campaign`/`marketing_link`/etc. already use in
+production (see `admin_app.py`'s module docstring: "The UI calls
+`/api/v1/plugins/marketing/campaigns` directly — one hop") — a live, exercised
+mechanism, unlike the fan-in workflow's endpoint.
+
+## Idempotent and re-runnable, without clobbering an instance's own additions
+
+Generic CRUD has no upsert — every POST creates a row — so a blind re-run would
+duplicate every channel. This script lists what the tenant already has, then
+creates only the default channels whose `key` is missing. Concretely:
+
+- **Running it twice is a no-op the second time**: nothing to create, so
+  nothing is created.
+- **An instance-added channel is never touched.** This script only ever POSTs
+  a channel from `CHANNELS` below whose `key` is absent; it never PATCHes or
+  DELETEs an existing row, default or custom. A one-way overwrite would delete
+  exactly the customisation this design exists to allow (the same trap
+  `shared-files.json` documents at estate level for `mustBeUniform`).
+- **An upgrade that adds a new default channel reaches an existing install**:
+  re-running this script after `CHANNELS` grows creates only the newly-added
+  keys — every previously-seeded or instance-added row is untouched.
+
+## Tenant scoping
+
+`marketing_channel` is a generic-CRUD table (`owner-scoped-tables`), so every
+row carries the caller's `tenant_id` automatically — there is no single global
+row shared across tenants. Run this once per tenant that needs the default
+taxonomy, with an admin token for that tenant. (There is no per-install,
+no-token seeding path here: `BiffoPluginBase.on_install()` is never invoked —
+see `biffo_plugin_sdk.plugin`'s module docstring — and the SDK's other
+self-seeding path, `POST /internal/plugins/me/config/seed`, is for the
+plugin's own config, not tenant-scoped table rows.)
+
+Usage:
+    CORE_API_URL=https://<api-id>.execute-api.<region>.amazonaws.com \
+    ADMIN_BEARER_TOKEN=<a real Cognito admin id/access token> \
+    python scripts/seed_marketing_channels.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+_CHANNELS_PATH = "/api/v1/plugins/marketing/channels"
+
+#: The default taxonomy (#67): broad on purpose, digital AND offline/field, and
+#: deliberately free of any platform-, vertical- or tenant-specific vocabulary —
+#: this plugin installs on every Biffo platform. `key` values are short,
+#: lower-case, underscore-separated slugs; the picker/label copy is what an
+#: operator actually reads. `ad_platform` is set only where a channel's spend
+#: and character limits genuinely belong to one platform's ad product; it is
+#: `None` for organic-only, owned, or platform-agnostic channels.
+#:
+#: `category` values are exactly #67's eleven: search, social, video, email,
+#: content, communities, partner, events, trade_press, direct_mail, local_field
+#: — asserted by `tests/test_marketing_seed_marketing_channels.py`.
+CHANNELS: list[dict[str, Any]] = [
+    # ── Search ───────────────────────────────────────────────────────────────
+    {
+        "key": "search_organic",
+        "label": "Organic search (SEO)",
+        "motion": "organic",
+        "category": "search",
+        "ad_platform": None,
+    },
+    {
+        "key": "google_search_paid",
+        "label": "Google Search ads",
+        "motion": "paid",
+        "category": "search",
+        "ad_platform": "google",
+    },
+    # ── Social — organic and paid are separate channels (#67) ──────────────────
+    {
+        "key": "facebook_organic",
+        "label": "Facebook — organic",
+        "motion": "organic",
+        "category": "social",
+        "ad_platform": None,
+    },
+    {
+        "key": "facebook_paid",
+        "label": "Facebook ads",
+        "motion": "paid",
+        "category": "social",
+        "ad_platform": "meta",
+    },
+    {
+        "key": "instagram_organic",
+        "label": "Instagram — organic",
+        "motion": "organic",
+        "category": "social",
+        "ad_platform": None,
+    },
+    {
+        "key": "instagram_paid",
+        "label": "Instagram ads",
+        "motion": "paid",
+        "category": "social",
+        "ad_platform": "meta",
+    },
+    {
+        "key": "linkedin_organic",
+        "label": "LinkedIn — organic",
+        "motion": "organic",
+        "category": "social",
+        "ad_platform": None,
+    },
+    {
+        "key": "linkedin_paid",
+        "label": "LinkedIn ads",
+        "motion": "paid",
+        "category": "social",
+        "ad_platform": "linkedin",
+    },
+    {
+        "key": "tiktok_organic",
+        "label": "TikTok — organic",
+        "motion": "organic",
+        "category": "social",
+        "ad_platform": None,
+    },
+    {
+        "key": "tiktok_paid",
+        "label": "TikTok ads",
+        "motion": "paid",
+        "category": "social",
+        "ad_platform": "tiktok",
+    },
+    {
+        "key": "x_organic",
+        "label": "X (Twitter) — organic",
+        "motion": "organic",
+        "category": "social",
+        "ad_platform": None,
+    },
+    {
+        "key": "x_paid",
+        "label": "X (Twitter) ads",
+        "motion": "paid",
+        "category": "social",
+        "ad_platform": "x",
+    },
+    # ── Video — short-form and long-form (#67) ──────────────────────────────
+    {
+        "key": "youtube_organic",
+        "label": "YouTube — organic (long-form)",
+        "motion": "organic",
+        "category": "video",
+        "ad_platform": None,
+    },
+    {
+        "key": "youtube_paid",
+        "label": "YouTube ads",
+        "motion": "paid",
+        "category": "video",
+        "ad_platform": "google",
+    },
+    {
+        "key": "short_form_video_organic",
+        "label": "Short-form video — organic (Reels/Shorts/clips)",
+        "motion": "organic",
+        "category": "video",
+        "ad_platform": None,
+    },
+    # ── Email ────────────────────────────────────────────────────────────────
+    {
+        "key": "email_owned_list",
+        "label": "Email — owned list",
+        "motion": "organic",
+        "category": "email",
+        "ad_platform": None,
+    },
+    {
+        "key": "email_newsletter_sponsorship",
+        "label": "Newsletter sponsorship",
+        "motion": "paid",
+        "category": "email",
+        "ad_platform": None,
+    },
+    # ── Content ──────────────────────────────────────────────────────────────
+    {
+        "key": "blog_seo_content",
+        "label": "Blog / SEO content",
+        "motion": "organic",
+        "category": "content",
+        "ad_platform": None,
+    },
+    {
+        "key": "guest_content",
+        "label": "Guest content (guest posts, cross-posting)",
+        "motion": "organic",
+        "category": "content",
+        "ad_platform": None,
+    },
+    {
+        "key": "webinar",
+        "label": "Webinar",
+        "motion": "organic",
+        "category": "content",
+        "ad_platform": None,
+    },
+    # ── Communities ──────────────────────────────────────────────────────────
+    {
+        "key": "online_communities",
+        "label": "Online communities (forums, groups)",
+        "motion": "organic",
+        "category": "communities",
+        "ad_platform": None,
+    },
+    # ── Partner / affiliate ──────────────────────────────────────────────────
+    {
+        "key": "partner_comarketing",
+        "label": "Partner co-marketing",
+        "motion": "organic",
+        "category": "partner",
+        "ad_platform": None,
+    },
+    {
+        "key": "affiliate_referral",
+        "label": "Affiliate / referral",
+        "motion": "paid",
+        "category": "partner",
+        "ad_platform": None,
+    },
+    # ── Events ───────────────────────────────────────────────────────────────
+    {
+        "key": "trade_show_presence",
+        "label": "Trade show / expo presence",
+        "motion": "organic",
+        "category": "events",
+        "ad_platform": None,
+    },
+    {
+        "key": "own_event",
+        "label": "Own event",
+        "motion": "organic",
+        "category": "events",
+        "ad_platform": None,
+    },
+    {
+        "key": "event_sponsorship",
+        "label": "Event sponsorship",
+        "motion": "paid",
+        "category": "events",
+        "ad_platform": None,
+    },
+    # ── Trade press ──────────────────────────────────────────────────────────
+    {
+        "key": "trade_press_earned",
+        "label": "Trade press — earned coverage",
+        "motion": "organic",
+        "category": "trade_press",
+        "ad_platform": None,
+    },
+    {
+        "key": "trade_press_paid",
+        "label": "Trade press — paid placement",
+        "motion": "paid",
+        "category": "trade_press",
+        "ad_platform": None,
+    },
+    # ── Direct mail ──────────────────────────────────────────────────────────
+    {
+        "key": "direct_mail",
+        "label": "Direct mail",
+        "motion": "paid",
+        "category": "direct_mail",
+        "ad_platform": None,
+    },
+    # ── Local / field ────────────────────────────────────────────────────────
+    {
+        "key": "local_field_activity",
+        "label": "Local / field activity (territory, in-person)",
+        "motion": "organic",
+        "category": "local_field",
+        "ad_platform": None,
+    },
+    {
+        "key": "local_paid_advertising",
+        "label": "Local paid advertising (press, radio, out-of-home)",
+        "motion": "paid",
+        "category": "local_field",
+        "ad_platform": None,
+    },
+]
+
+#: #67's closed set of categories. Kept here, next to `CHANNELS`, so a typo'd
+#: category in a new entry fails the test that checks every row against it
+#: rather than silently adding a twelfth category nobody decided on.
+CATEGORIES: frozenset[str] = frozenset(
+    {
+        "search",
+        "social",
+        "video",
+        "email",
+        "content",
+        "communities",
+        "partner",
+        "events",
+        "trade_press",
+        "direct_mail",
+        "local_field",
+    }
+)
+
+
+def _request(method: str, url: str, token: str, body: dict | None = None) -> Any:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)  # noqa: S310
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        return json.loads(resp.read() or b"null")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="print, change nothing")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        print(json.dumps(CHANNELS, indent=2))
+        return 0
+
+    api = os.environ.get("CORE_API_URL", "").rstrip("/")
+    token = os.environ.get("ADMIN_BEARER_TOKEN", "")
+    if not api or not token:
+        print("CORE_API_URL and ADMIN_BEARER_TOKEN are both required.", file=sys.stderr)
+        return 2
+
+    url = f"{api}{_CHANNELS_PATH}"
+    try:
+        existing = _request("GET", url, token) or []
+    except urllib.error.HTTPError as exc:
+        print(f"Could not list channels: {exc.code} {exc.reason}", file=sys.stderr)
+        return 1
+
+    # Idempotent by key, and never touches a row it did not just create — see
+    # the module docstring's "never clobbers an instance's own additions".
+    have = {row.get("key") for row in existing}
+    created = 0
+    for channel in CHANNELS:
+        if channel["key"] in have:
+            continue
+        try:
+            _request("POST", url, token, channel)
+        except urllib.error.HTTPError as exc:
+            print(f"Failed on {channel['key']}: {exc.code} {exc.reason}", file=sys.stderr)
+            return 1
+        created += 1
+
+    skipped = len(CHANNELS) - created
+    print(f"Created {created} channel(s); {skipped} already present.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_marketing_seed_marketing_channels.py
+++ b/tests/test_marketing_seed_marketing_channels.py
@@ -1,0 +1,276 @@
+"""The default channel taxonomy (#67, #76 increment 1), and the seeder's
+idempotency/preservation guarantees — asserted rather than trusted, same
+rationale as `test_marketing_seed_fan_in_workflow.py` and idea-scout's
+`test_idea_scout_seed_business_models.py`.
+
+Three things this suite exists to prove, because the issue is explicit that
+nothing else proves them:
+
+1. Seeding twice is a no-op.
+2. Re-seeding never touches (never PATCHes, never DELETEs) a row it did not
+   just create itself — which is what keeps an instance-added channel alive
+   across an upgrade that adds new default channels.
+3. Every seeded `key` is short enough, by construction, that the #75 overflow
+   (a 121-character agent-generated channel name landing in a `String(64)`
+   column) cannot recur through a channel referenced by key.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from _scripts import load_script
+
+seed = load_script("seed_marketing_channels")
+CHANNELS = seed.CHANNELS
+CATEGORIES = seed.CATEGORIES
+
+#: #67's own list, verbatim, so a typo'd or invented category in `CHANNELS`
+#: fails here rather than silently becoming a twelfth category nobody decided
+#: on.
+_EXPECTED_CATEGORIES = frozenset(
+    {
+        "search",
+        "social",
+        "video",
+        "email",
+        "content",
+        "communities",
+        "partner",
+        "events",
+        "trade_press",
+        "direct_mail",
+        "local_field",
+    }
+)
+
+#: The categories #67 calls "offline/field" — the breadth this taxonomy exists
+#: to cover beyond a digital-only list.
+_OFFLINE_FIELD_CATEGORIES = frozenset({"events", "trade_press", "direct_mail", "local_field"})
+
+#: A digital sample, so "covers digital and offline/field" is checked as a
+#: conjunction rather than assumed from the offline half alone.
+_DIGITAL_CATEGORIES = frozenset({"search", "social", "video", "email"})
+
+
+# ── The taxonomy itself ──────────────────────────────────────────────────────
+
+
+def test_categories_are_exactly_hashtag_67s_set() -> None:
+    assert CATEGORIES == _EXPECTED_CATEGORIES
+
+
+def test_every_channel_declares_a_known_category() -> None:
+    for channel in CHANNELS:
+        assert channel["category"] in CATEGORIES, channel["key"]
+
+
+def test_taxonomy_covers_digital_and_offline_field_breadth() -> None:
+    """The load-bearing coverage test: #67 exists specifically because a
+    digital-only list would exclude the routes franchise (and other
+    field-heavy) operators convert through most. Both halves must be
+    present, not just declared as valid categories."""
+    used = {channel["category"] for channel in CHANNELS}
+    assert _OFFLINE_FIELD_CATEGORIES <= used, used
+    assert _DIGITAL_CATEGORIES <= used, used
+
+
+def test_every_channel_has_a_motion_of_organic_or_paid() -> None:
+    for channel in CHANNELS:
+        assert channel["motion"] in ("organic", "paid"), channel["key"]
+
+
+def test_motion_lives_on_the_channel_not_only_on_a_recommendation() -> None:
+    """#67's settled design: LinkedIn-organic and LinkedIn-paid (and the same
+    pair for every other network with both) are separate channels, not one
+    channel with a motion asserted elsewhere."""
+    keys = {channel["key"] for channel in CHANNELS}
+    for network in ("facebook", "instagram", "linkedin", "tiktok", "x"):
+        assert f"{network}_organic" in keys, network
+        assert f"{network}_paid" in keys, network
+
+
+def test_every_channel_has_a_non_empty_operator_facing_label() -> None:
+    for channel in CHANNELS:
+        assert channel["label"].strip(), channel["key"]
+
+
+def test_ad_platform_is_either_none_or_a_real_lowercase_slug() -> None:
+    for channel in CHANNELS:
+        platform = channel["ad_platform"]
+        assert platform is None or (platform == platform.lower() and platform.strip())
+
+
+def test_taxonomy_has_no_duplicate_keys() -> None:
+    keys = [channel["key"] for channel in CHANNELS]
+    assert len(set(keys)) == len(keys)
+
+
+def test_taxonomy_contains_nothing_platform_or_vertical_specific() -> None:
+    """This plugin installs on every Biffo platform. Franchise operators are
+    the motivating example for breadth (#67), not a reason to encode
+    franchise vocabulary — the same leak class as #46 (a product-specific
+    Cognito group reaching a plugin meant for all of them), one schema level
+    up."""
+    banned = ("franchise", "tabsii", "biffo")
+    for channel in CHANNELS:
+        haystack = f"{channel['key']} {channel['label']}".lower()
+        for word in banned:
+            assert word not in haystack, f"{channel['key']!r} mentions {word!r}"
+
+
+# ── Keys: short and stable by construction (the #75 guard) ──────────────────
+
+
+def test_keys_are_short_stable_machine_safe_slugs() -> None:
+    """`key` is a `String(64)` column — the same width `marketing_link.channel`
+    was when a 121-character agent-generated name overflowed it (#75). Every
+    seeded key is asserted well under half that ceiling, so the overflow class
+    cannot recur through a channel referenced by key rather than by whatever
+    string an agent chose to write."""
+    for channel in CHANNELS:
+        key = channel["key"]
+        assert re.fullmatch(r"[a-z][a-z0-9_]*", key), key
+        assert len(key) <= 32, f"{key!r} is {len(key)} chars — nowhere near #75's 121"
+
+
+def test_the_75_case_itself_cannot_occur() -> None:
+    """The exact failure from #75, replayed against this table's shape rather
+    than against `marketing_link` directly (that migration is #76 increment
+    2's job): the longest key in the default taxonomy is nowhere near a
+    121-character overflow of a 64-character column."""
+    overflowing_name = (
+        "Google Search ads (non-brand: terms like 'franchise management "
+        "software UK', 'franchise operations pricing per location')"
+    )
+    assert len(overflowing_name) == 121
+    assert all(len(channel["key"]) < len(overflowing_name) for channel in CHANNELS)
+
+
+# ── The seed script's behaviour ──────────────────────────────────────────────
+
+
+class _FakeCore:
+    """A minimal in-memory stand-in for the tenant's `marketing_channel` rows,
+    behind the exact seam (`seed._request`) the real script calls through.
+    Records every method used, so a test can assert the script never issues a
+    PATCH or DELETE — the structural half of "never clobbers an instance's own
+    additions"."""
+
+    def __init__(self, initial: list[dict[str, Any]] | None = None) -> None:
+        self.rows: list[dict[str, Any]] = [dict(row) for row in (initial or [])]
+        self.methods_used: list[str] = []
+
+    def request(self, method: str, url: str, token: str, body: dict | None = None) -> Any:
+        self.methods_used.append(method)
+        if method == "GET":
+            return list(self.rows)
+        if method == "POST":
+            assert body is not None
+            row = {**body, "id": f"row-{len(self.rows)}"}
+            self.rows.append(row)
+            return row
+        raise AssertionError(f"unexpected method {method!r} — the seeder must never call this")
+
+
+def _run_seed(monkeypatch, fake: _FakeCore) -> int:
+    monkeypatch.setattr(seed, "_request", fake.request)
+    monkeypatch.setenv("CORE_API_URL", "https://example.test")
+    monkeypatch.setenv("ADMIN_BEARER_TOKEN", "a-real-token")
+    monkeypatch.setattr("sys.argv", ["seed_marketing_channels.py"])
+    return seed.main()
+
+
+def test_seeding_from_empty_creates_every_default_channel(monkeypatch) -> None:
+    fake = _FakeCore()
+    rc = _run_seed(monkeypatch, fake)
+    assert rc == 0
+    assert {row["key"] for row in fake.rows} == {c["key"] for c in CHANNELS}
+
+
+def test_seeding_twice_is_a_no_op(monkeypatch) -> None:
+    fake = _FakeCore()
+    _run_seed(monkeypatch, fake)
+    first_run_rows = len(fake.rows)
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0
+    assert len(fake.rows) == first_run_rows, "second run must create nothing new"
+
+
+def test_reseeding_preserves_an_instance_added_channel(monkeypatch) -> None:
+    """The other half of the idempotency requirement: an instance that added
+    its own channel (not in the default taxonomy) must still have it, byte
+    for byte, after a re-seed — including after an upgrade that adds a new
+    default channel this instance never had before."""
+    custom_channel = {
+        "key": "regional_billboard_ads",
+        "label": "Regional billboard advertising",
+        "motion": "paid",
+        "category": "local_field",
+        "ad_platform": None,
+        "id": "existing-custom-row",
+    }
+    fake = _FakeCore(initial=[custom_channel])
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0
+    assert custom_channel in fake.rows, "the instance-added channel must survive re-seeding"
+    assert "PATCH" not in fake.methods_used
+    assert "PUT" not in fake.methods_used
+    assert "DELETE" not in fake.methods_used
+
+
+def test_an_upgrade_adding_a_default_channel_reaches_an_existing_install(monkeypatch) -> None:
+    """Simulates the scenario #67/#76 name explicitly: an install that already
+    ran this script, then a later plugin version adds one more default
+    channel to `CHANNELS`. Re-running must create only the new one."""
+    already_seeded = [{**c, "id": f"seeded-{c['key']}"} for c in CHANNELS]
+    fake = _FakeCore(initial=already_seeded)
+
+    new_channel = {
+        "key": "podcast_sponsorship",
+        "label": "Podcast sponsorship",
+        "motion": "paid",
+        "category": "content",
+        "ad_platform": None,
+    }
+    monkeypatch.setattr(seed, "CHANNELS", [*CHANNELS, new_channel])
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0
+    keys_after = {row["key"] for row in fake.rows}
+    assert "podcast_sponsorship" in keys_after
+    assert keys_after == {c["key"] for c in CHANNELS} | {"podcast_sponsorship"}
+
+
+def test_missing_credentials_is_a_clear_failure_not_a_silent_noop(monkeypatch) -> None:
+    monkeypatch.delenv("CORE_API_URL", raising=False)
+    monkeypatch.delenv("ADMIN_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr("sys.argv", ["seed_marketing_channels.py"])
+    assert seed.main() == 2
+
+
+def test_dry_run_prints_without_network(capsys, monkeypatch) -> None:
+    """`--dry-run` must not require `CORE_API_URL`/a token — it is how an
+    operator reviews the taxonomy before touching an environment."""
+    monkeypatch.delenv("CORE_API_URL", raising=False)
+    monkeypatch.delenv("ADMIN_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr("sys.argv", ["seed_marketing_channels.py", "--dry-run"])
+
+    assert seed.main() == 0
+    assert "google_search_paid" in capsys.readouterr().out
+
+
+def test_it_hits_the_same_public_crud_mount_the_other_marketing_tables_use() -> None:
+    """Pinned rather than assumed. `admin_app.py`'s own module docstring
+    records that the UI reaches `marketing_campaign` etc. at
+    `/api/v1/plugins/marketing/campaigns` directly, and that mount is live in
+    production — unlike `seed_fan_in_workflow.py`'s orchestration endpoint,
+    which had never once existed (#60). This script targets the same,
+    already-proven mount, not a new or guessed one."""
+    assert seed._CHANNELS_PATH == "/api/v1/plugins/marketing/channels"


### PR DESCRIPTION
First half of #76 (#67 increment 1): a real channel taxonomy with stable
ids, replacing the free-text `channel` strings behind #75.

Scoped deliberately: **the table and its seeding only.** Migrating
`ChannelRecommendation`/`ChannelCopy`/`marketing_link` onto these ids, and
replacing `_platform_for_channel`, is the second half and is not in this PR.

## The table

`marketing_channel`, added to `biffo.plugin.json` (generic CRUD, per-tenant
via Core's `owner-scoped-tables`):

| column | notes |
|---|---|
| `key` | stable, machine-safe (`String(64)`), e.g. `google_search_paid`. This plays the role the issue's sketch called `id` — Core auto-injects its own UUID `id` on every plugin table, so the stable slug needs a different name. `key` matches the existing estate precedent (`idea_scout_business_models.key`) rather than inventing a new convention. |
| `label` | operator-facing, `String(200)`, may be long — e.g. "Google Search ads" |
| `motion` | `organic` \| `paid`, lives on the channel (not asserted separately per recommendation) |
| `category` | one of #67's eleven: search, social, video, email, content, communities, partner, events, trade_press, direct_mail, local_field |
| `ad_platform` | nullable; the ad platform this channel's spend/limits belong to (google, meta, linkedin, tiktok, ...), so increment 2's `_platform_for_channel` replacement is a lookup, not a schema change |

Unique index on `(tenant_id, key)`.

## Seeding

`scripts/seed_marketing_channels.py`, run once per tenant with an admin
token. Modelled on `biffo-plugin-idea-scout`'s `seed_business_models.py` —
**not** on this repo's own `seed_fan_in_workflow.py`, whose orchestration
endpoint has never once existed (#60). This script instead hits the
plugin's own public generic-CRUD mount (`/api/v1/plugins/marketing/channels`),
the same mount `marketing_campaign`/`marketing_link` already use live in
production, per `admin_app.py`'s own module docstring.

- **Idempotent and re-runnable**: it lists what the tenant already has, and
  creates only the default channels whose `key` is missing. Running it twice
  creates nothing the second time.
- **Never clobbers an instance's own additions**: it only ever POSTs a
  missing default `key`. It never PATCHes or DELETEs any row, so a channel
  an instance added itself — or a channel a previous version of this script
  already seeded — survives every re-run untouched.
- **An upgrade that adds a new default channel reaches an existing install**:
  re-running after the taxonomy grows creates only the newly-added keys.

`BiffoPluginBase.on_install()` is never invoked (confirmed in
`biffo_plugin_sdk.plugin`'s own module docstring), so this has to be an
operator-run script rather than an install hook — same conclusion #67
already reached.

## Existing dev data

Increment 1 does not touch `ChannelRecommendation`, `ChannelCopy` or
`marketing_link` at all, so the free-text channel names on dev's existing
approved campaigns are untouched by this PR either way. **Declaring that dev
demo data disposable** rather than attempting a mapping now: a real mapping
needs the join logic increment 2 builds, and guessing at it before that join
exists would be mapping against a moving target. Increment 2 is where this
gets decided for real — either backfill dev's artefacts onto seeded keys, or
treat the existing dev campaigns as throwaway and start clean.

## Verification

`tests/test_marketing_seed_marketing_channels.py`:
- seeding twice is a no-op
- re-seeding preserves an instance-added channel (and asserts the script
  never issues PATCH/PUT/DELETE)
- an upgrade adding a new default channel reaches an already-seeded install
- every seeded key is well under the 121 characters that broke #75, and the
  #75 case itself is replayed against this shape
- taxonomy coverage: #67's digital categories (search, social, video, email)
  **and** offline/field categories (events, trade_press, direct_mail,
  local_field) are both present, not just declared valid
- no platform-, vertical- or tenant-specific vocabulary in any key/label
  (the #46 leak class, one schema level up)
- `--dry-run` prints without needing credentials

`tests/test_marketing_manifest.py`'s existing parametrised checks (column
types, no auto-column redeclaration, no FKs, route/table pairing, route path
derivation) already cover `marketing_channel` and its routes automatically —
no changes needed there, and they pass.

Also ran the manifest through the SDK's authoritative validator:
`load_manifest()` (the same model Core/the CLI validate against) — passes.
The vendored `registry-schema.json` check is pre-existing and advisory-only
(`continue-on-error: true` in `ci.yml`, documented there as failing on every
table's `description` field even before this PR).

Full suite: 386 passed. `uv run ruff format`/`ruff check`/`pyright` clean.
Push gate (`verify`) passed locally before pushing.

Refs #76, #67, #75.
