### PR TITLE
fix(marketing): stop pack_routes leaking cross-channel links and pick a deterministic source

### DIFF
--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -140,7 +140,7 @@ def _core_error(exc: BiffoAPIError) -> HTTPException:
 
 async def _existing_assets(
     campaign_id: str, *, campaign_client: principal_client.PrincipalCoreClient
-) -> tuple[list[dict[str, Any]], list[str]]:
+) -> tuple[list[dict[str, Any]], list[str], int]:
     """Whatever ``marketing_asset`` rows already exist for this campaign,
     plus the subset of ``PLACEMENTS`` that has no row yet. Never renders —
     see the module docstring for why generation time, not pack time, is
@@ -185,6 +185,15 @@ async def _existing_assets(
     for the same underlying rows; it does not touch Core, so it cannot by
     itself restore "exactly one source per campaign" as a stored fact — only
     ``generate_still_route`` superseding the prior row can do that.
+
+    The count dropped is returned as this function's third element rather
+    than only logged: this module's own convention for "the API silently
+    hid something" is response-level disclosure (``missing_placements``
+    already does exactly this), not a log line only CloudWatch sees — and
+    without it, every request looks clean regardless of how many duplicate
+    source rows have piled up, so nothing short of reading the raw
+    ``marketing_asset`` table would ever surface the underlying #54 gap to
+    an operator or a future maintainer.
     """
     assets = await campaign_client.get(
         f"{_INTERNAL_PREFIX}/assets", params={"campaign_id": campaign_id}
@@ -192,15 +201,17 @@ async def _existing_assets(
     assets = assets or []
 
     sources = [a for a in assets if a.get("is_source")]
+    superseded_source_count = 0
     if len(sources) > 1:
         canonical_id = max(sources, key=lambda a: (a.get("created_at") or "", a.get("id") or ""))[
             "id"
         ]
+        superseded_source_count = len(sources) - 1
         assets = [a for a in assets if not a.get("is_source") or a.get("id") == canonical_id]
 
     have_placements = {a["placement"] for a in assets if a.get("placement")}
     missing_placements = [p for p in PLACEMENTS if p not in have_placements]
-    return assets, missing_placements
+    return assets, missing_placements, superseded_source_count
 
 
 async def _asset_with_url(core_client: BiffoAPIClient, asset: dict[str, Any]) -> dict[str, Any]:
@@ -287,6 +298,26 @@ async def _ensure_links(
     tenant's own custom channel keeps a key motion-exclusive — a bare
     ``channel_key`` match would let an existing organic link suppress the
     mint of the paid one this call actually asked for.
+
+    Both the "already have" and "is wanted" checks below go through
+    :func:`_link_motions`/``_requested_key`` rather than a tuple literal
+    repeated at each call site — two symmetric-looking expressions that are
+    actually asymmetric (``channel``/``is_paid`` vs ``channel_key``/
+    ``motion``) is exactly the shape that lets one future edit (e.g. adding
+    ``variant`` to the key) update three of four sites and silently reopen
+    #48. ``marketing_link.is_paid`` is nullable, and generic CRUD's own
+    ``create`` is exposed to any admin, not only this function's own mint
+    loop (which always writes a concrete bool) — so a ``NULL`` row is a real
+    possibility, not a hypothetical. It is deliberately NOT folded to
+    ``False``: ``results_routes.py`` already rejected that exact fold for
+    this same column ("folding that into organic ... is exactly the 'share
+    over classifiable inputs' mistake"), and doing it here would let one
+    ambiguous row both trigger a duplicate mint (it would not satisfy the
+    paid request) and vanish from a paid pack's own ``links`` (it would not
+    match the paid filter either). A ``NULL`` row is instead treated as
+    already covering *whichever* motion is asked for — "don't know" must
+    never justify writing a second link, and must never make an existing
+    one disappear from the pack that already shows it.
     """
     links_resp = await admin_app._core(
         "GET", f"{_INTERNAL_PREFIX}/links", admin_token, params={"campaign_id": campaign_id}
@@ -294,8 +325,14 @@ async def _ensure_links(
     links_resp.raise_for_status()
     existing = links_resp.json() or []
 
-    requested = {(c.get("channel_key"), c.get("motion") == "paid") for c in channels}
-    have = {(link["channel"], bool(link.get("is_paid"))) for link in existing}
+    def _requested_key(c: dict[str, Any]) -> tuple[Any, bool]:
+        return c.get("channel_key"), c.get("motion") == "paid"
+
+    def _link_motions(link: dict[str, Any]) -> set[bool]:
+        is_paid = link.get("is_paid")
+        return {True, False} if is_paid is None else {bool(is_paid)}
+
+    requested = {_requested_key(c) for c in channels}
 
     # The response's own "channel" key is kept (not renamed to "channel_key")
     # for admin-UI backward compatibility — `PackParts.tsx`/`PaidPack.tsx`
@@ -311,10 +348,18 @@ async def _ensure_links(
             "url": tracked_url(base_url, link["token"]) if base_url else None,
         }
         for link in existing
-        if (link["channel"], bool(link.get("is_paid"))) in requested
+        if any((link["channel"], motion) in requested for motion in _link_motions(link))
     ]
 
-    missing = [c for c in channels if (c.get("channel_key"), c.get("motion") == "paid") not in have]
+    channel_motions: dict[Any, set[bool]] = {}
+    for link in existing:
+        channel_motions.setdefault(link["channel"], set()).update(_link_motions(link))
+
+    missing = [
+        c
+        for c in channels
+        if _requested_key(c)[1] not in channel_motions.get(_requested_key(c)[0], set())
+    ]
     if not missing:
         return out
 
@@ -420,7 +465,7 @@ async def get_pack_route(
     except pipeline.StaleChannelPlanError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
-    assets, missing_placements = await _existing_assets(
+    assets, missing_placements, superseded_source_count = await _existing_assets(
         campaign_id, campaign_client=campaign_client
     )
     assets_with_urls = [await _asset_with_url(core_client, a) for a in assets]
@@ -437,6 +482,7 @@ async def get_pack_route(
         "campaign_id": campaign_id,
         "assets": assets_with_urls,
         "missing_placements": missing_placements,
+        "superseded_source_count": superseded_source_count,
         "copy": channels,
         "links": links,
         "guidance": campaign.get("guidance") or "",

--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -159,11 +159,44 @@ async def _existing_assets(
     ``/pack`` and ``/paid-pack``, because this check runs *after* the copy
     gate in ``get_pack_route``/``get_paid_pack_route`` — a third 404 site in
     those functions that #64's own two-site reading of the source missed.
+    #64 deleted the single ``next((a for a in assets if a.get("is_source")),
+    None)`` pick along with the 404 it guarded — this function no longer
+    picks a source at all, which is issue #54's premise as originally filed:
+    that literal call site is gone.
+
+    **The invariant it guarded is not gone, though.**
+    ``image_routes.generate_still_route`` writes a new ``is_source=True``
+    row on every call and nothing supersedes the one it replaces (still
+    true today — issue #54, and out of scope for this function: that write
+    path belongs to a concurrent change, see ``image_routes.py``), so more
+    than one can exist for a real campaign. Left unfiltered, the pack would
+    show every one of them labelled "Source" (``PackParts.tsx``:
+    ``a.is_source === true ? 'Source' : ...``), with no way for an operator
+    to tell which is actually in effect, and no guarantee the set stays the
+    same between two requests. So this function picks, deterministically,
+    which single row gets to keep ``is_source: True`` in what it returns:
+    **newest ``created_at`` wins** — the most recent generation is what an
+    operator who just clicked "generate again" means by "the" creative, and
+    the admin UI already reinforces that reading by rendering the newest
+    generation first. Every other ``is_source=True`` row is dropped from the
+    response outright (not merely relabelled — a superseded source with no
+    placement carries nothing else worth showing). This is a presentation
+    fix, pure function of ``assets`` and therefore byte-identical on repeat
+    for the same underlying rows; it does not touch Core, so it cannot by
+    itself restore "exactly one source per campaign" as a stored fact — only
+    ``generate_still_route`` superseding the prior row can do that.
     """
     assets = await campaign_client.get(
         f"{_INTERNAL_PREFIX}/assets", params={"campaign_id": campaign_id}
     )
     assets = assets or []
+
+    sources = [a for a in assets if a.get("is_source")]
+    if len(sources) > 1:
+        canonical_id = max(sources, key=lambda a: (a.get("created_at") or "", a.get("id") or ""))[
+            "id"
+        ]
+        assets = [a for a in assets if not a.get("is_source") or a.get("id") == canonical_id]
 
     have_placements = {a["placement"] for a in assets if a.get("placement")}
     missing_placements = [p for p in PLACEMENTS if p not in have_placements]
@@ -239,13 +272,30 @@ async def _ensure_links(
     rather than composing a URL some fourth way. No SSRF-shaped surface
     here: both calls are to Core's own internal CRUD mount, never to a URL
     read out of a response.
+
+    Filtered to ``channels`` and keyed on ``(channel_key, is_paid)``, not
+    the bare ``channel_key`` alone (issue #48). ``existing`` is every link
+    Core has ever minted for the campaign — channel planning can be re-run,
+    so it can hold links for channels this call's ``channels`` no longer
+    names at all, and those must not leak into ``out``.
+    ``paid_pack_routes.get_paid_pack_route`` used to filter its own result
+    back down for exactly this reason; that workaround is gone now that the
+    filter lives here, at the source, where every caller gets it for free.
+    The dedup is motion-aware for the same reason: the seeded taxonomy gives
+    an organic and a paid version of "the same" channel distinct
+    ``channel_key``s (#76), but nothing in this plugin enforces that a
+    tenant's own custom channel keeps a key motion-exclusive — a bare
+    ``channel_key`` match would let an existing organic link suppress the
+    mint of the paid one this call actually asked for.
     """
     links_resp = await admin_app._core(
         "GET", f"{_INTERNAL_PREFIX}/links", admin_token, params={"campaign_id": campaign_id}
     )
     links_resp.raise_for_status()
     existing = links_resp.json() or []
-    have_channels = {link["channel"] for link in existing}
+
+    requested = {(c.get("channel_key"), c.get("motion") == "paid") for c in channels}
+    have = {(link["channel"], bool(link.get("is_paid"))) for link in existing}
 
     # The response's own "channel" key is kept (not renamed to "channel_key")
     # for admin-UI backward compatibility — `PackParts.tsx`/`PaidPack.tsx`
@@ -261,9 +311,10 @@ async def _ensure_links(
             "url": tracked_url(base_url, link["token"]) if base_url else None,
         }
         for link in existing
+        if (link["channel"], bool(link.get("is_paid"))) in requested
     ]
 
-    missing = [c for c in channels if c.get("channel_key") not in have_channels]
+    missing = [c for c in channels if (c.get("channel_key"), c.get("motion") == "paid") not in have]
     if not missing:
         return out
 

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -361,6 +361,9 @@ async def get_paid_pack_route(
     )
     assets_with_urls = [await pack_routes._asset_with_url(core_client, a) for a in assets]
 
+    # `_ensure_links` filters to the `paid_channels` subset passed in, and
+    # dedups motion-aware, at the source — issue #48. This route used to
+    # filter the result back down again itself; that workaround is gone.
     links = await pack_routes._ensure_links(
         campaign_id,
         paid_channels,
@@ -370,16 +373,6 @@ async def get_paid_pack_route(
             request.headers.get("origin"), request.headers.get("referer")
         ),
     )
-    # `_ensure_links` returns every link Core holds for this campaign, not
-    # just the `paid_channels` subset passed in — see issue #48. Filtered
-    # back down here rather than at the source, since fixing it properly
-    # needs `pack_routes.py`, which several agents work in concurrently and
-    # this change does not touch. This does not fix the rarer case issue #48
-    # also describes (a paid channel sharing an organic channel's exact name
-    # would still surface that organic link instead of minting a paid one) —
-    # that half needs the source fix.
-    paid_channel_keys = {c["channel_key"] for c in paid_channels}
-    links = [link for link in links if link.get("channel") in paid_channel_keys]
 
     return {
         "campaign_id": campaign_id,

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -356,7 +356,7 @@ async def get_paid_pack_route(
 
     ad_platforms = await _channel_ad_platforms(admin.token)
 
-    assets, missing_placements = await pack_routes._existing_assets(
+    assets, missing_placements, superseded_source_count = await pack_routes._existing_assets(
         campaign_id, campaign_client=campaign_client
     )
     assets_with_urls = [await pack_routes._asset_with_url(core_client, a) for a in assets]
@@ -379,6 +379,7 @@ async def get_paid_pack_route(
         "ad_copy": [_ad_copy_variant(c, ad_platforms) for c in paid_channels],
         "assets": assets_with_urls,
         "missing_placements": missing_placements,
+        "superseded_source_count": superseded_source_count,
         "targeting": targeting,
         "budget": _budget_recommendation(len(paid_channels)),
         "links": links,

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -486,3 +486,125 @@ def test_link_urls_come_from_the_request_origin_not_from_configuration(
 
     assert resp.status_code == 200
     assert resp.json()["links"][0]["url"] == "https://tenant.example.test/c/existing-token"
+
+
+# ── issue #48: leaked links, motion-blind dedup ──────────────────────────────
+
+
+def test_does_not_leak_stale_channel_links_and_mints_paid_when_only_organic_shares_the_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #48, both halves, against the real taxonomy shape rather than a
+    hand-rolled short channel name.
+
+    `existing` can hold more than the current copy's channels ever asked
+    about — channel planning gets re-run, and old links are never deleted —
+    so a stale `search_organic` link (from an earlier plan that no longer
+    survives into this approved copy) must not leak into a pack that no
+    longer requests it. And the seeded taxonomy gives an organic and a paid
+    version of "the same" channel distinct `channel_key`s (#76), but nothing
+    in this plugin enforces that a tenant's own custom channel keeps a key
+    motion-exclusive — so an existing ORGANIC link for `event_sponsorship`
+    must not suppress minting the PAID one this copy actually asks for.
+    """
+    awkward_channels = [
+        {
+            "channel_key": "event_sponsorship",
+            "motion": "paid",
+            "headline": "Meet us on the show floor this quarter",
+            "body": "Live demos, no queue, real answers from the people who built it.",
+            "cta": "Book a slot",
+            "sources": [{"url": "https://example.com/e", "note": "n"}],
+        }
+    ]
+    core = _FakeCore(copy_artefact=_copy_artefact(awkward_channels))
+    core.links.extend(
+        [
+            {
+                "id": "link-stale-unrelated-channel",
+                "campaign_id": _CAMPAIGN,
+                "token": "stale-token",
+                "channel": "search_organic",
+                "variant": None,
+                "is_paid": False,
+                "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+            },
+            {
+                "id": "link-same-key-organic-motion",
+                "campaign_id": _CAMPAIGN,
+                "token": "organic-token",
+                "channel": "event_sponsorship",
+                "variant": None,
+                "is_paid": False,
+                "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+            },
+        ]
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    links = resp.json()["links"]
+
+    # Neither the unrelated stale link nor the same-key organic one leaked;
+    # exactly the requested paid channel comes back.
+    assert len(links) == 1
+    assert links[0]["channel"] == "event_sponsorship"
+    assert links[0]["is_paid"] is True
+    assert links[0]["url"] != f"{_BASE_URL}/c/organic-token"
+
+    # The dedup did not skip minting because an organic link already "had"
+    # the channel_key — a new paid link was actually written.
+    assert core.links[-1]["channel"] == "event_sponsorship"
+    assert core.links[-1]["is_paid"] is True
+
+
+# ── issue #54: source creative selection ─────────────────────────────────────
+
+
+def test_picks_the_newest_source_deterministically_when_more_than_one_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #54: `image_routes.generate_still_route` writes a new
+    `is_source=True` row on every call and nothing supersedes the one it
+    replaces, so more than one can exist for a campaign — the admin UI's
+    `ImageGenerator` makes "generate again" the obvious, one-click thing to
+    do. The pack must return the same single source on every request, not
+    whichever row Core happens to list first: newest `created_at` wins (the
+    most recent generation is what an operator who just re-generated means
+    by "the" creative — the UI already renders it first for the same
+    reason), and the superseded row must not still appear labelled "Source"
+    alongside it.
+
+    Fed in both list orders so the assertion cannot pass by accident of
+    Core's own ordering — the whole point is that it must not matter.
+    """
+    core = _FakeCore(copy_artefact=_copy_artefact(_CHANNELS))
+    monkeypatch.setattr(admin_app, "_core", core)
+    older = {
+        **_source_asset(),
+        "id": "asset-source-older",
+        "media_id": "media-older",
+        "created_at": "2026-08-01T00:00:00Z",
+    }
+    newer = {
+        **_source_asset(),
+        "id": "asset-source-newer",
+        "media_id": "media-newer",
+        "created_at": "2026-08-05T00:00:00Z",
+    }
+
+    for ordered_assets in ([older, newer], [newer, older]):
+        campaign_client = _FakeCampaignClient(assets=list(ordered_assets))
+        client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+        resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["assets"]) == 1
+        assert body["assets"][0]["is_source"] is True
+        assert body["assets"][0]["media_id"] == "media-newer"

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -608,3 +608,74 @@ def test_picks_the_newest_source_deterministically_when_more_than_one_exists(
         assert len(body["assets"]) == 1
         assert body["assets"][0]["is_source"] is True
         assert body["assets"][0]["media_id"] == "media-newer"
+
+        # The drop is disclosed, not silent — same discipline as
+        # `missing_placements`: an operator or future maintainer reading
+        # only the response still learns a source was superseded.
+        assert body["superseded_source_count"] == 1
+
+
+def test_reports_zero_superseded_sources_when_at_most_one_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The disclosure field itself must not read as "something was hidden"
+    when nothing was — a bare source-only pack (the common case today) must
+    report 0, not omit the field or report a stale count."""
+    core = _FakeCore(copy_artefact=_copy_artefact(_CHANNELS))
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    assert resp.json()["superseded_source_count"] == 0
+
+
+def test_does_not_remint_or_drop_a_link_with_null_is_paid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`marketing_link.is_paid` is nullable, and generic CRUD's own `create`
+    is exposed to any admin — not only `_ensure_links`'s own mint loop,
+    which always writes a concrete bool — so a `NULL` row is a real
+    possibility. `results_routes.py` already refuses to fold that NULL into
+    `organic`/`False` for this same column; `_ensure_links` must not either,
+    or an ambiguous existing link both gets duplicate-minted (it satisfies
+    neither "already have paid" nor "already have organic") and vanishes
+    from the pack's own `links` (it matches neither filter). A NULL row
+    must be treated as already covering whichever motion is actually asked
+    for."""
+    awkward_channels = [
+        {
+            "channel_key": "event_sponsorship",
+            "motion": "paid",
+            "headline": "Meet us on the show floor this quarter",
+            "body": "Live demos, no queue, real answers from the people who built it.",
+            "cta": "Book a slot",
+            "sources": [{"url": "https://example.com/e", "note": "n"}],
+        }
+    ]
+    core = _FakeCore(copy_artefact=_copy_artefact(awkward_channels))
+    core.links.append(
+        {
+            "id": "link-null-is-paid",
+            "campaign_id": _CAMPAIGN,
+            "token": "null-is-paid-token",
+            "channel": "event_sponsorship",
+            "variant": None,
+            "is_paid": None,
+            "destination_url": "https://example.com/landing?utm_campaign=" + _CAMPAIGN,
+        }
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    links = resp.json()["links"]
+
+    # The existing NULL-is_paid link is treated as already covering the
+    # paid request: no second link minted, and the existing one still shows.
+    assert len(links) == 1
+    assert links[0]["url"] == f"{_BASE_URL}/c/null-is-paid-token"
+    assert core.links == [core.links[0]]


### PR DESCRIPTION
Closes #48
Closes #54

Both live in `pack_routes.py` and would collide as separate PRs, so one PR fixes both. Branched fresh off `origin/dev` after today's `#76`/`#72`/`#64` changes; read the current file before touching anything, since #48's own comment predates the taxonomy migration.

## #48 — leaked links, motion-blind dedup

`_ensure_links` built `out` from every link Core had ever minted for the campaign, not the caller's requested `channels`, and deduped on bare `channel_key` — motion-blind. Fixed both at the source:

- `out` is now filtered to `(channel_key, is_paid)` pairs the caller actually requested.
- The dedup check (`missing`) is keyed on `(channel_key, is_paid)`, not bare `channel_key`, so an existing link at a channel_key with one motion cannot suppress minting one for the same key with the other motion.

**The downstream filter in `paid_pack_routes.get_paid_pack_route` is gone.** It used to re-filter `_ensure_links`'s result back down to the paid subset itself, with a comment saying the real fix belonged in `pack_routes.py`. That workaround is deleted; `paid_pack_routes.py` now just calls `_ensure_links` and trusts the result.

Added `test_does_not_leak_stale_channel_links_and_mints_paid_when_only_organic_shares_the_key` in `test_marketing_pack_routes.py`, using real taxonomy channel keys (`search_organic`, `event_sponsorship`) rather than short hand-written names: an existing link for a channel outside the current copy's channels (a stale channel-plan re-run) must not leak, and an existing *organic* link sharing a *paid* request's exact `channel_key` must not suppress the paid mint.

## #54 — source creative selection

The literal code the issue cites — `next((a for a in assets if a.get("is_source")), None)` — is **already gone**. It was deleted (along with the 404 it guarded) by `#64`/`#68`, earlier today, before this PR branched. `_existing_assets` no longer picks a source at all; it returns every `marketing_asset` row unfiltered. So the issue's premise as literally filed no longer holds against the current file — noting that per the dispatch brief, rather than fixing a call site that isn't there.

The underlying invariant problem is still real, though, just relocated: with no pick at all, a campaign with more than one `is_source=True` row (trivially reachable now via the admin UI's "generate again") shows **every** one of them labelled "Source" in the pack (`PackParts.tsx`: `a.is_source === true ? 'Source' : ...`), in whatever order Core returns them — worse than non-deterministic, actually ambiguous.

**Decision: newest `created_at` wins**, and I made it deterministic rather than just labelled. `_existing_assets` now: when more than one `is_source=True` row exists, picks the one with the latest `created_at` (id as tiebreak) and drops every other `is_source=True` row from the response entirely (not merely relabelled — a superseded source carries no placement and nothing else worth showing). Newest-wins matches operator intent ("generate again because I don't like this one") and matches what the admin UI already visually implies (`setGenerated((prev) => [result, ...prev])` renders the newest first).

**This is presentation-only and I'm naming that rather than quietly overclaiming it.** It is a pure function of `assets`, so the pack is byte-identical on repeat for the same underlying DB state — which is the concrete property M5 requires and the issue's failure scenario describes losing. But it does not touch Core, so it cannot restore "exactly one source per campaign" as a *stored* fact — more than one `is_source=True` row can still exist in the DB, just no longer surfaced ambiguously. The issue's own suggested fix names two options; the other (`generate_still_route` superseding the prior row on write) is the structural fix and lives in `image_routes.py`, which the dispatch brief explicitly puts out of scope for this change (owned by a concurrent agent). Closing #54 here because it resolves the issue's literal failure scenario (non-deterministic/ambiguous pack rendering) via the option the issue itself offered as acceptable — but the DB-level invariant is still open if anyone wants to file it separately against `image_routes.py`.

Added `test_picks_the_newest_source_deterministically_when_more_than_one_exists`: two source assets, fed in both list orders, asserting the response always contains exactly one `is_source: true` row and it's always the newer one.

## Verification

Both new tests were run red first (temporarily reverted `pack_routes.py`/`paid_pack_routes.py` via `git stash`, confirmed both new tests failed, restored). Full suite: `uv run pytest` — 402 passed. `uv run ruff format` / `uv run ruff check` / `uv run pyright` all clean on the changed files. `web-admin/` untouched; `pnpm install --ignore-workspace` run before starting, no lockfile changes. Not verified against a live deployment — this is unit-test-only verification of API behavior, no click-through against a running admin UI.

## Follow-up commit: two gaps a review pass found in the first commit

A `/code-review` pass against this branch surfaced two real issues in the `_ensure_links` fix above, both now addressed in a second commit:

1. **`bool(link.get("is_paid"))` folded a NULL `is_paid` to `False`.** `marketing_link.is_paid` is nullable, and generic CRUD's own `create` is exposed to any admin, not only `_ensure_links`'s own mint loop (which always writes a concrete bool) — so a NULL row is reachable, not hypothetical. Folding it to `False` let an ambiguous existing link both get duplicate-minted (it matched neither "have paid" nor "have organic" under the tuple-set check) and vanish from a paid pack's own `links`. `results_routes.py` already rejects exactly this fold for the same column, bucketing NULL separately rather than guessing — `_ensure_links` now agrees: a NULL row is treated as already covering whichever motion is actually requested, so it's never re-minted and never silently dropped. New test: `test_does_not_remint_or_drop_a_link_with_null_is_paid`.
2. **The four places that decide "already have this channel+motion" vs "is this channel+motion wanted" were each written out as a repeated tuple literal**, two pairs that look symmetric but aren't (`channel`/`is_paid` vs `channel_key`/`motion`) — exactly the shape where a future key change (e.g. adding `variant`) updates three of four sites and silently reopens #48. Replaced with two small shared helpers (`_requested_key`, `_link_motions`) used at every call site.

Also added, since the reviewer flagged it as worth naming even though non-blocking: `_existing_assets` now threads a `superseded_source_count` through both pack responses, so a superseded `is_source` row being dropped (the #54 fix) is disclosed the same way `missing_placements` already discloses a gap, rather than being invisible outside a log line. New tests: `test_reports_zero_superseded_sources_when_at_most_one_exists`, plus an added assertion in the existing newest-wins test.

Both new tests were also confirmed red against the first commit before the fix, then green after. Full suite after this commit: 404 passed. Local push gate (`ruff-check`, `ruff-format`, `pyright`, `pytest`, `lint`/`typecheck`/`test` for `web-admin`) all green on push.
