### PR TITLE
fix(marketing): ledger charge before storage; stop caching transient SSM errors

### DIFF
--- a/src/marketing/config.py
+++ b/src/marketing/config.py
@@ -94,7 +94,7 @@ def _from_ssm(parameter: str) -> str | None:
     - `None` when the call itself failed — must NOT be cached; see
       `public_base_url` for what the caller does with that.
     """
-    value = ssm.read_parameter(parameter)
+    value = ssm.read_parameter(parameter, purpose="public base URL")
     if value is None:
         return None
     return value.strip().rstrip("/")

--- a/src/marketing/config.py
+++ b/src/marketing/config.py
@@ -19,6 +19,8 @@ from urllib.parse import urlsplit
 
 from aws_lambda_powertools import Logger
 
+from . import ssm
+
 logger = Logger(child=True)
 
 #: Set directly in local development and in tests. Takes precedence over SSM so
@@ -45,6 +47,11 @@ def public_base_url() -> str:
     a 503 that says what is missing. A link minted against a missing base URL
     would be published as a bare `/c/<token>`, which fails silently in whatever
     feed it was pasted into rather than at the moment it was created.
+
+    A call that could not even reach SSM (issue #25) also returns `""` **for
+    this call only** — see `_from_ssm` — without caching that as the answer,
+    so a transient blip on one cold start does not read as "not configured"
+    for the rest of that container's warm life.
     """
     global _cached
 
@@ -66,31 +73,31 @@ def public_base_url() -> str:
         _cached = ""
         return _cached
 
-    _cached = _from_ssm(parameter)
+    result = _from_ssm(parameter)
+    if result is None:
+        # Could not ask (issue #25) — fail only this call. `_cached` stays
+        # `None` so the next call retries rather than repeating a non-answer.
+        return ""
+    _cached = result
     return _cached
 
 
-def _from_ssm(parameter: str) -> str:
-    """Fetch `parameter`, or `""` if it is absent or unreadable.
+def _from_ssm(parameter: str) -> str | None:
+    """Fetch `parameter`, normalised for a base URL.
 
-    Imported inside the function so neither boto3 nor a region need to exist for
-    this module to import — the tests and any local run never reach here.
+    Delegates the "genuinely absent vs merely unreachable" classification to
+    `ssm.read_parameter` (issue #25) — see that module's docstring for why the
+    two cannot be collapsed into one `""`. Returns:
 
-    Every failure returns empty rather than propagating. A missing parameter is
-    the expected state of a deployment nobody has configured yet, and it is not
-    distinguishable from a transient SSM error in a way that would change what
-    the caller does: both mean "cannot mint a link right now", and both are
-    logged for whoever has to fix it.
+    - the value, trailing-slash stripped, when SSM answers.
+    - `""` when SSM confirms the parameter does not exist — safe to cache.
+    - `None` when the call itself failed — must NOT be cached; see
+      `public_base_url` for what the caller does with that.
     """
-    try:
-        import boto3
-
-        client = boto3.client("ssm")
-        value = client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"]
-        return str(value).strip().rstrip("/")
-    except Exception:
-        logger.warning("Could not read the public base URL from %s", parameter, exc_info=True)
-        return ""
+    value = ssm.read_parameter(parameter)
+    if value is None:
+        return None
+    return value.strip().rstrip("/")
 
 
 def reset_cache() -> None:

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -25,6 +25,8 @@ from typing import Protocol
 import httpx
 from aws_lambda_powertools import Logger
 
+from . import ssm
+
 logger = Logger(child=True)
 
 
@@ -158,7 +160,16 @@ _cached_api_key: str | None = None
 
 
 def _api_key() -> str:
-    """This deployment's image-provider API key, or ``""`` if unconfigured."""
+    """This deployment's image-provider API key, or ``""`` if unconfigured.
+
+    A call that could not even reach SSM (issue #25) also returns ``""`` for
+    THIS call only — `ssm.read_parameter` distinguishes that from a
+    confirmed-absent parameter, and only the latter gets cached. Without that
+    distinction, a single `ThrottlingException` on a cold start would be
+    remembered as "not configured" for the rest of that container's warm
+    life, and `generate_still` would keep telling an operator to fix a
+    deployment that was never broken.
+    """
     global _cached_api_key
 
     if _cached_api_key is not None:
@@ -174,17 +185,12 @@ def _api_key() -> str:
         _cached_api_key = ""
         return _cached_api_key
 
-    try:
-        import boto3
-
-        client = boto3.client("ssm")
-        value = client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"]
-        _cached_api_key = str(value).strip()
-    except Exception:
-        logger.warning(
-            "Could not read the image provider API key from %s", parameter, exc_info=True
-        )
-        _cached_api_key = ""
+    value = ssm.read_parameter(parameter)
+    if value is None:
+        # Could not ask — fail only this call. `_cached_api_key` stays `None`
+        # so the next call retries rather than repeating a non-answer.
+        return ""
+    _cached_api_key = value.strip()
     return _cached_api_key
 
 

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -194,6 +194,30 @@ def _api_key() -> str:
     return _cached_api_key
 
 
+def _no_api_key_message() -> str:
+    """Why `_api_key()` came back empty, stated as accurately as this module
+    can without re-deriving the SSM outcome (`ssm.read_parameter` already
+    logged the specific reason — genuinely absent, denied, or transient).
+
+    Distinguishes "nobody configured a source for this key at all" from "a
+    source IS configured and reading it did not work" — collapsing the two
+    into one fixed "are both unset" message (as this used to) is exactly the
+    class of misleading diagnosis issue #25 is about: telling an operator to
+    fix configuration that is not the problem.
+    """
+    parameter = os.environ.get(_PARAMETER_ENV, "").strip()
+    if not parameter:
+        return (
+            f"No image provider API key configured ({_DIRECT_ENV} / "
+            f"{_PARAMETER_ENV} are both unset)."
+        )
+    return (
+        f"No image provider API key configured: {_DIRECT_ENV} is unset, and the configured "
+        f"parameter ({_PARAMETER_ENV}={parameter!r}) had no readable value — see the logs "
+        "for why (absent, denied, or a transient SSM error)."
+    )
+
+
 def reset_api_key_cache() -> None:
     """Forget the resolved key. For tests only."""
     global _cached_api_key
@@ -227,10 +251,7 @@ class OpenAIImageProvider:
     async def generate_still(self, *, prompt: str) -> GeneratedImage:
         api_key = _api_key()
         if not api_key:
-            raise ImageProviderError(
-                f"No image provider API key configured ({_DIRECT_ENV} / "
-                f"{_PARAMETER_ENV} are both unset)."
-            )
+            raise ImageProviderError(_no_api_key_message())
 
         async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
             try:
@@ -318,10 +339,7 @@ class OpenRouterImageProvider:
     async def generate_still(self, *, prompt: str) -> GeneratedImage:
         api_key = _api_key()
         if not api_key:
-            raise ImageProviderError(
-                f"No image provider API key configured ({_DIRECT_ENV} / "
-                f"{_PARAMETER_ENV} are both unset)."
-            )
+            raise ImageProviderError(_no_api_key_message())
 
         model = _openrouter_model()
 

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -185,7 +185,7 @@ def _api_key() -> str:
         _cached_api_key = ""
         return _cached_api_key
 
-    value = ssm.read_parameter(parameter)
+    value = ssm.read_parameter(parameter, purpose="image provider API key")
     if value is None:
         # Could not ask — fail only this call. `_cached_api_key` stays `None`
         # so the next call retries rather than repeating a non-answer.

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -190,9 +190,9 @@ def _core_error(exc: BiffoAPIError, *, not_found: str | None = None) -> HTTPExce
     return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=exc.detail)
 
 
-def _required_field(payload: dict[str, Any], key: str, *, context: str) -> Any:
+def _required_field(payload: Any, key: str, *, context: str) -> Any:
     """``payload[key]``, or a 502 naming what broke instead of a bare
-    `KeyError`.
+    `KeyError` (or worse, an unhandled `TypeError`).
 
     Absorbed from issue #26 (see issue #24's comments): every call site below
     reads this straight off a Core response with no guard, so a response-shape
@@ -201,10 +201,18 @@ def _required_field(payload: dict[str, Any], key: str, *, context: str) -> Any:
     already been paid (issue #24), so losing the message here would also
     swallow the evidence (a ledger/media id) the caller needs to avoid a blind
     retry.
+
+    ``payload`` is typed `Any`, not `dict[str, Any]`, and both `KeyError` and
+    `TypeError` are caught: the SDK's own `_parse_json` returns `None` for any
+    empty-body 2xx, and `None[key]` raises `TypeError`, not `KeyError` — a
+    `dict`-only guard would miss exactly the response-shape drift this
+    function exists to catch. Not currently reachable against Core's own
+    routes (they all declare a `response_model`, so an empty body cannot pass
+    validation), but nothing here should depend on that staying true.
     """
     try:
         return payload[key]
-    except KeyError as exc:
+    except (KeyError, TypeError) as exc:
         logger.error("%s response had no %r: %r", context, key, payload)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -212,22 +220,36 @@ def _required_field(payload: dict[str, Any], key: str, *, context: str) -> Any:
         ) from exc
 
 
-def _committed_note(**ids: str | None) -> str:
+def _committed_note(*, charged: bool = False, **ids: str | None) -> str:
     """A human-readable list of what already committed, appended to an error
     raised after the provider has been charged (issue #24) — so an operator
     reading the failure knows a blind retry would double the charge rather
     than merely retry a step that never touched money.
+
+    ``charged=True`` with no ``ids`` covers the one case where there is a
+    charge but nothing to name yet: the ledger POST succeeded but its `id`
+    could not be read out of the response. There is still no id to print, but
+    "nothing to report" would be worse than silence — it would read as though
+    the charge itself were still in doubt, when it is not.
     """
     parts = [f"{name} {value}" for name, value in ids.items() if value]
-    if not parts:
-        return ""
-    return " Already recorded: " + ", ".join(parts) + ". Do not regenerate blindly."
+    if parts:
+        return " Already recorded: " + ", ".join(parts) + ". Do not regenerate blindly."
+    if charged:
+        return (
+            " The provider call already succeeded and WAS charged — its ledger id could "
+            "not be read from Core's response, so check the media-generations ledger by "
+            "hand before regenerating."
+        )
+    return ""
 
 
-def _with_committed_note(exc: HTTPException, **ids: str | None) -> HTTPException:
+def _with_committed_note(
+    exc: HTTPException, *, charged: bool = False, **ids: str | None
+) -> HTTPException:
     """`exc`, with `_committed_note`'s context appended to its detail and its
     status code preserved."""
-    note = _committed_note(**ids)
+    note = _committed_note(charged=charged, **ids)
     if not note:
         return exc
     return HTTPException(status_code=exc.status_code, detail=f"{exc.detail}{note}")
@@ -263,11 +285,21 @@ async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[st
             ),
         )
 
+    # Every field read off `presigned` from here on is guarded the same way
+    # as `max_bytes` above — a response missing any of these is exactly the
+    # same class of Core response-shape drift, and by this point in the
+    # module docstring's ordering (issue #24) the ledger has already been
+    # written, so an unguarded `KeyError` here would still be a post-charge
+    # failure worth a diagnosable message.
+    presign_url = _required_field(presigned, "url", context="Presign")
+    presign_fields = _required_field(presigned, "fields", context="Presign")
+    presign_key = _required_field(presigned, "key", context="Presign")
+
     async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as upload_client:
         try:
             upload = await upload_client.post(
-                presigned["url"],
-                data=presigned["fields"],
+                presign_url,
+                data=presign_fields,
                 files={"file": (image.filename, image.content, image.content_type)},
             )
         except httpx.HTTPError as exc:
@@ -283,7 +315,7 @@ async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[st
         )
 
     try:
-        return await core_client.post(f"{_STORAGE_PATH}/confirm", json={"key": presigned["key"]})
+        return await core_client.post(f"{_STORAGE_PATH}/confirm", json={"key": presign_key})
     except BiffoAPIError as exc:
         raise _core_error(exc) from exc
 
@@ -372,14 +404,24 @@ async def generate_still_route(
         )
         raise _core_error(exc) from exc
 
-    ledger_id = _required_field(ledger, "id", context="Ledger")
+    # The charge is already durably recorded at this point — see the
+    # docstring above. Every failure from here on wraps its error with
+    # `_with_committed_note` so a caller reading it sees what already
+    # committed, never a bare failure that reads like nothing happened.
+    try:
+        ledger_id = _required_field(ledger, "id", context="Ledger")
+    except HTTPException as exc:
+        raise _with_committed_note(exc, charged=True) from exc
 
     try:
         media = await _upload(core_client, image)
     except HTTPException as exc:
         raise _with_committed_note(exc, ledger=ledger_id) from exc
 
-    media_id = _required_field(media, "id", context="Storage confirm")
+    try:
+        media_id = _required_field(media, "id", context="Storage confirm")
+    except HTTPException as exc:
+        raise _with_committed_note(exc, ledger=ledger_id) from exc
 
     try:
         asset = await campaign_client.post(
@@ -395,7 +437,10 @@ async def generate_still_route(
     except BiffoAPIError as exc:
         raise _with_committed_note(_core_error(exc), ledger=ledger_id, media=media_id) from exc
 
-    asset_id = asset.get("id")
+    try:
+        asset_id = _required_field(asset, "id", context="Asset")
+    except HTTPException as exc:
+        raise _with_committed_note(exc, ledger=ledger_id, media=media_id) from exc
 
     try:
         url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -220,6 +220,29 @@ def _required_field(payload: Any, key: str, *, context: str) -> Any:
         ) from exc
 
 
+def _required_number(payload: Any, key: str, *, context: str) -> float:
+    """`_required_field(payload, key, context=context)`, additionally
+    checked to actually be a number.
+
+    A response with the key present but the wrong type (`null`, a JSON
+    string) is the same class of Core response-shape drift `_required_field`
+    exists to catch — but comparing against a non-number (`len(...) >
+    None`) raises `TypeError` directly out of the comparison, not out of
+    `_required_field`, so it would slip past every `except HTTPException`
+    guard in `generate_still_route` as a bare 500 with no committed-state
+    note. Every field this route reads and then uses in arithmetic (only
+    `max_bytes`, currently) goes through this instead of `_required_field`.
+    """
+    value = _required_field(payload, key, context=context)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        logger.error("%s response's %r was not a number: %r", context, key, value)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"{context} response's '{key}' was not a number.",
+        )
+    return value
+
+
 def _committed_note(*, charged: bool = False, **ids: str | None) -> str:
     """A human-readable list of what already committed, appended to an error
     raised after the provider has been charged (issue #24) — so an operator
@@ -275,7 +298,7 @@ async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[st
     except BiffoAPIError as exc:
         raise _core_error(exc) from exc
 
-    max_bytes = _required_field(presigned, "max_bytes", context="Presign")
+    max_bytes = _required_number(presigned, "max_bytes", context="Presign")
     if len(image.content) > max_bytes:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -354,7 +377,7 @@ async def generate_still_route(
     That gap is logged loudly (see below) but not closed — closing it needs
     an idempotency key Core's `/internal/media-generations` route does not
     yet accept, which is a Core-side change, not something this route can
-    build around on its own.
+    build around on its own. Tracked as biffo-template#1515.
     """
     campaign_id = _validated_campaign_id(campaign_id)
 
@@ -437,10 +460,20 @@ async def generate_still_route(
     except BiffoAPIError as exc:
         raise _with_committed_note(_core_error(exc), ledger=ledger_id, media=media_id) from exc
 
-    try:
-        asset_id = _required_field(asset, "id", context="Asset")
-    except HTTPException as exc:
-        raise _with_committed_note(exc, ledger=ledger_id, media=media_id) from exc
+    # Unlike ledger_id/media_id above, a missing asset id does not block
+    # anything: the asset row has already committed, `asset` (whatever shape
+    # it has) is returned to the caller either way, and `asset_id` below is
+    # used only to enrich a LATER failure's committed-state note — never to
+    # build a request. Hard-failing an otherwise fully successful generation
+    # over a field that is cosmetic at this point would be worse than the
+    # gap it closes, so this logs the drift rather than raising on it.
+    asset_id = asset.get("id") if isinstance(asset, dict) else None
+    if not isinstance(asset_id, str):
+        logger.warning(
+            "Asset response had no usable 'id' — later error context (if any) will not name it: %r",
+            asset,
+        )
+        asset_id = None
 
     try:
         url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -5,15 +5,24 @@ that file concurrently, and `admin_app.py` gains exactly one line — the
 `include_router` call below wires this in, ahead of its `StaticFiles` mount
 (which must stay last — see `admin_app`'s module docstring).
 
-The flow, in the order issue #5 asks for it:
+The flow:
 
 1. `image_provider.ImageProvider.generate_still` — behind the port, so a
    provider swap never touches the route, the storage upload, or the
    ledger-write payload below (issue #5's requirement 3). The one place this
    file is *meant* to know a choice exists is `get_image_provider()`, whose
    body is entirely `image_provider.create_image_provider()` — it names no
-   vendor itself, only the generic call that resolves one (issue #63).
-2. Store the bytes via Core's plugin object-storage capability
+   vendor itself, only the generic call that resolves one (issue #63). **This
+   is the only irreversible, billable step in this handler** — the provider
+   has been paid before this function has written anything at all.
+2. Record the generation in Core's media ledger (biffo-template#1439) —
+   **immediately**, before storage or the asset row. Issue #24: every step
+   after the charge is local bookkeeping Core can retry or reconcile, but the
+   ledger row is the only durable evidence the charge happened, so it is
+   written as early as it can be rather than last. See
+   `generate_still_route`'s own docstring for exactly what this guarantees
+   and what it does not.
+3. Store the bytes via Core's plugin object-storage capability
    (biffo-template#1437): presign, upload, confirm with `head_object`. The
    documented flow is "browser PUT" because the capability's usual caller is
    a user uploading a file — there is no browser in a machine-generated
@@ -22,8 +31,6 @@ The flow, in the order issue #5 asks for it:
    still never pass through **Core's** Lambda, which only signs and later
    verifies with `head_object` — the property the precondition actually
    promises.
-3. Record the generation in Core's media ledger (biffo-template#1439): a
-   cost, or visibly `unpriced` — never silently zero.
 
 Then a `marketing_asset` row is created with `is_source=True`: the ONE
 approved creative placements are later rendered from (`render.py`, M5) —
@@ -48,6 +55,7 @@ import uuid
 from typing import Any
 
 import httpx
+from aws_lambda_powertools import Logger
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -60,6 +68,8 @@ from .image_provider import (
     ImageProviderError,
     create_image_provider,
 )
+
+logger = Logger(child=True)
 
 require_admin = require_group("admin")
 
@@ -180,12 +190,60 @@ def _core_error(exc: BiffoAPIError, *, not_found: str | None = None) -> HTTPExce
     return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=exc.detail)
 
 
+def _required_field(payload: dict[str, Any], key: str, *, context: str) -> Any:
+    """``payload[key]``, or a 502 naming what broke instead of a bare
+    `KeyError`.
+
+    Absorbed from issue #26 (see issue #24's comments): every call site below
+    reads this straight off a Core response with no guard, so a response-shape
+    drift becomes an unhandled 500 rather than a diagnosable error — and on
+    this route, every one of these reads happens **after** the provider has
+    already been paid (issue #24), so losing the message here would also
+    swallow the evidence (a ledger/media id) the caller needs to avoid a blind
+    retry.
+    """
+    try:
+        return payload[key]
+    except KeyError as exc:
+        logger.error("%s response had no %r: %r", context, key, payload)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"{context} response had no '{key}'.",
+        ) from exc
+
+
+def _committed_note(**ids: str | None) -> str:
+    """A human-readable list of what already committed, appended to an error
+    raised after the provider has been charged (issue #24) — so an operator
+    reading the failure knows a blind retry would double the charge rather
+    than merely retry a step that never touched money.
+    """
+    parts = [f"{name} {value}" for name, value in ids.items() if value]
+    if not parts:
+        return ""
+    return " Already recorded: " + ", ".join(parts) + ". Do not regenerate blindly."
+
+
+def _with_committed_note(exc: HTTPException, **ids: str | None) -> HTTPException:
+    """`exc`, with `_committed_note`'s context appended to its detail and its
+    status code preserved."""
+    note = _committed_note(**ids)
+    if not note:
+        return exc
+    return HTTPException(status_code=exc.status_code, detail=f"{exc.detail}{note}")
+
+
 async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[str, Any]:
     """presign -> direct upload -> confirm.
 
     This Lambda plays the role a browser plays for a user-supplied file (see
     the module docstring): the presigned POST Core mints is just an HTTP
     request, and nothing about it requires a browser to send it.
+
+    Called *after* the ledger write (issue #24) — every failure raised here
+    happens after the provider has already been paid and the charge is
+    already durably recorded, so callers wrap what this raises with
+    `_with_committed_note` rather than surfacing it bare.
     """
     try:
         presigned = await core_client.post(
@@ -195,12 +253,13 @@ async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[st
     except BiffoAPIError as exc:
         raise _core_error(exc) from exc
 
-    if len(image.content) > presigned["max_bytes"]:
+    max_bytes = _required_field(presigned, "max_bytes", context="Presign")
+    if len(image.content) > max_bytes:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=(
                 f"Generated image is {len(image.content)} bytes, over this "
-                f"deployment's {presigned['max_bytes']}-byte ceiling."
+                f"deployment's {max_bytes}-byte ceiling."
             ),
         )
 
@@ -237,8 +296,33 @@ async def generate_still_route(
     core_client: BiffoAPIClient = Depends(get_core_client),
     campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
 ) -> GenerateStillResponse:
-    """Generate one still, store it, ledger its cost (or its absence), and
-    record it as this campaign's approved source creative.
+    """Generate one still, ledger its cost, store it, and record it as this
+    campaign's approved source creative.
+
+    **Ordering is the fix for issue #24.** `provider.generate_still` is the
+    only irreversible, billable step here — money has moved before this
+    function has written anything at all. Everything after it (storage
+    upload, the asset row) is local bookkeeping Core can retry or reconcile.
+    The ledger write is the one exception: it is the only durable evidence
+    the charge happened, so it is made **immediately** after the charge,
+    before upload or the asset row — not last, as it was before this fix.
+
+    **What this guarantees:** once the provider call succeeds, the very next
+    thing this handler does is ledger it. If upload or asset creation then
+    fails, the failure is raised with the ledger id (and the media id, once
+    storage has succeeded) named in its detail, so an operator reading the
+    error knows a blind retry would double the charge rather than merely
+    retry a step that never touched money.
+
+    **What this does NOT guarantee:** this is not exactly-once. Core's ledger
+    route has no idempotency key, so a failure of the ledger POST *itself*
+    (the one write that must happen first, and the one write nothing here can
+    move earlier) still leaves a charge with no queryable record short of a
+    log line, and a subsequent retry of the whole request would charge again.
+    That gap is logged loudly (see below) but not closed — closing it needs
+    an idempotency key Core's `/internal/media-generations` route does not
+    yet accept, which is a Core-side change, not something this route can
+    build around on its own.
     """
     campaign_id = _validated_campaign_id(campaign_id)
 
@@ -252,8 +336,9 @@ async def generate_still_route(
     except ImageProviderError as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
 
-    media = await _upload(core_client, image)
-
+    # The provider has now been paid. Ledger it before anything else — see
+    # the docstring above for why this cannot wait until after upload/asset
+    # creation.
     try:
         ledger = await core_client.post(
             _LEDGER_PATH,
@@ -268,7 +353,33 @@ async def generate_still_route(
             },
         )
     except BiffoAPIError as exc:
+        # This is the one gap this fix cannot close (see the docstring): the
+        # charge happened and could not even be ledgered. Log every field a
+        # human would need to reconcile it by hand, since a log line is the
+        # only record that will exist.
+        logger.error(
+            "Provider %s/%s charged campaign %s (units=%s unit_kind=%s cost_usd=%s "
+            "causation_id=%s) but the ledger write failed: %s. A retry WILL double-bill "
+            "unless this is reconciled by hand.",
+            image.provider,
+            image.model,
+            campaign_id,
+            image.units,
+            image.unit_kind,
+            image.cost_usd,
+            body.causation_id,
+            exc.detail,
+        )
         raise _core_error(exc) from exc
+
+    ledger_id = _required_field(ledger, "id", context="Ledger")
+
+    try:
+        media = await _upload(core_client, image)
+    except HTTPException as exc:
+        raise _with_committed_note(exc, ledger=ledger_id) from exc
+
+    media_id = _required_field(media, "id", context="Storage confirm")
 
     try:
         asset = await campaign_client.post(
@@ -277,24 +388,37 @@ async def generate_still_route(
                 "campaign_id": campaign_id,
                 "media_kind": "image",
                 "placement": None,
-                "media_id": media["id"],
+                "media_id": media_id,
                 "is_source": True,
             },
         )
     except BiffoAPIError as exc:
-        raise _core_error(exc) from exc
+        raise _with_committed_note(_core_error(exc), ledger=ledger_id, media=media_id) from exc
+
+    asset_id = asset.get("id")
 
     try:
-        url_resp = await core_client.get(f"{_STORAGE_PATH}/{media['id']}/url")
+        url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")
     except BiffoAPIError as exc:
-        raise _core_error(exc) from exc
+        raise _with_committed_note(
+            _core_error(exc), ledger=ledger_id, media=media_id, asset=asset_id
+        ) from exc
+
+    # Everything up to and including the asset row has committed by this
+    # point — a failure minting the signed URL below is the one failure mode
+    # left that touches nothing billable or durable; it is always safe to
+    # retry on its own, never a reason to regenerate.
+    try:
+        url = _required_field(url_resp, "url", context="Signed URL")
+    except HTTPException as exc:
+        raise _with_committed_note(exc, ledger=ledger_id, media=media_id, asset=asset_id) from exc
 
     return GenerateStillResponse(
         asset=asset,
         media=media,
-        url=url_resp["url"],
+        url=url,
         ledger={
-            "id": ledger["id"],
+            "id": ledger_id,
             "cost_usd": image.cost_usd,
             "unpriced": image.cost_usd is None,
         },

--- a/src/marketing/ssm.py
+++ b/src/marketing/ssm.py
@@ -10,13 +10,25 @@ they are "written to the same pattern deliberately".
 Both had the same gap. Neither could tell a **genuinely absent** parameter
 (``ParameterNotFound`` — SSM answered, and the answer is no) from an SSM call
 that simply **could not be completed** (a `ThrottlingException`, a network
-blip, a missing region, a denied grant — SSM never answered at all). Both
-caught every exception the same way and cached ``""`` regardless, so a single
-transient error on a cold start read as "not configured" for that container's
-entire warm life, and the resulting error told an operator to fix a deployment
-that was not broken.
+blip, a missing region — SSM never answered at all). Both caught every
+exception the same way and cached ``""`` regardless, so a single transient
+error on a cold start read as "not configured" for that container's entire
+warm life, and the resulting error told an operator to fix a deployment that
+was not broken.
 
-This module is the one place that draws that line, so a future caller that
+There is a third state, and collapsing it into either of the first two is
+also wrong: a **denied** grant (``AccessDeniedException``) is not "SSM
+answered no" — the parameter may well exist — but it is also not the kind of
+transient failure a retry fixes. An IAM grant does not repair itself between
+one request and the next the way a throttle clears, so treating it as
+"could not ask, try again" would mean paying a fresh `boto3.client` and a
+full SSM round trip on **every request, forever**, for a condition that only
+a human (fixing the grant) can end. It is therefore grouped with
+`ParameterNotFound` below: both are final answers for this container's
+life, and both are safe to cache, precisely because neither will change
+without external action this process cannot detect anyway.
+
+This module is the one place that draws these lines, so a future caller that
 wants to cache an SSM value does not have to relearn the distinction a third
 time. `config._from_ssm` and `image_provider._api_key` each keep their own
 `_cached` global and their own precedence over a direct env var — only the
@@ -29,28 +41,47 @@ from aws_lambda_powertools import Logger
 
 logger = Logger(child=True)
 
+#: `ClientError` codes that are a FINAL answer for this container's life —
+#: not "we could not ask", but "we asked, and this will not change without a
+#: human acting outside this process" (a `put-parameter`, or an IAM grant).
+#: Safe to cache, unlike everything else `read_parameter` catches.
+_PARAMETER_ABSENT = "ParameterNotFound"
+_ACCESS_DENIED = "AccessDeniedException"
 
-def read_parameter(parameter: str) -> str | None:
+
+def read_parameter(parameter: str, *, purpose: str) -> str | None:
     """Read `parameter` from SSM, with decryption.
+
+    `purpose` is a short, human-readable description of what this parameter
+    is for (e.g. ``"public base URL"``, ``"image provider API key"``) —
+    included in every log line so an operator triaging a throttle from a
+    shared module can tell which of a deployment's several cached values
+    failed, without that context living in the module that no longer knows
+    it (see the module docstring on why the classification itself is
+    shared while the caching stays per-caller).
 
     Returns:
 
     - the value SSM returned, verbatim (not stripped — callers normalise as
       they each already did before this module existed).
-    - ``""`` when SSM affirmatively answers "nothing is there"
-      (`ParameterNotFound`) — a genuinely unconfigured deployment. Safe for a
-      caller to cache: asking again would get the same answer.
+    - ``""`` when SSM gives a final answer that is not the value: the
+      parameter genuinely does not exist (`ParameterNotFound`), or this
+      caller is not authorised to read it (`AccessDeniedException`). Both
+      need a human to change and neither self-heals mid-request, so both
+      are safe for a caller to cache.
     - ``None`` when the call itself could not be completed: a transport or
-      throttling error, a missing region, denied credentials, or anything
-      else that means "we could not ask" rather than "we asked and the
-      answer is no". **A caller must never cache this** — the next call
-      should try again, not repeat a non-answer forever.
+      throttling error, a missing region, or anything else that means "we
+      could not ask" rather than "we got a final answer". **A caller must
+      never cache this** — the next call should try again, not repeat a
+      non-answer forever.
     """
     try:
         import boto3
         from botocore.exceptions import ClientError
     except Exception:
-        logger.warning("boto3 unavailable; cannot read %s from SSM", parameter, exc_info=True)
+        logger.warning(
+            "%s: boto3 unavailable; cannot read %s from SSM", purpose, parameter, exc_info=True
+        )
         return None
 
     try:
@@ -58,11 +89,20 @@ def read_parameter(parameter: str) -> str | None:
         return str(client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"])
     except ClientError as exc:
         code = exc.response.get("Error", {}).get("Code", "")
-        if code == "ParameterNotFound":
-            logger.warning("No SSM parameter at %s", parameter)
+        if code == _PARAMETER_ABSENT:
+            logger.warning("%s: no SSM parameter at %s", purpose, parameter)
+            return ""
+        if code == _ACCESS_DENIED:
+            logger.warning(
+                "%s: SSM denied reading %s — this needs an IAM grant, not a retry; "
+                "caching as unavailable for this container",
+                purpose,
+                parameter,
+            )
             return ""
         logger.warning(
-            "Transient SSM error reading %s (%s); will retry rather than caching as absent",
+            "%s: transient SSM error reading %s (%s); will retry rather than caching as absent",
+            purpose,
             parameter,
             code,
             exc_info=True,
@@ -70,7 +110,8 @@ def read_parameter(parameter: str) -> str | None:
         return None
     except Exception:
         logger.warning(
-            "Could not read %s from SSM; will retry rather than caching as absent",
+            "%s: could not read %s from SSM; will retry rather than caching as absent",
+            purpose,
             parameter,
             exc_info=True,
         )

--- a/src/marketing/ssm.py
+++ b/src/marketing/ssm.py
@@ -75,6 +75,12 @@ def read_parameter(parameter: str, *, purpose: str) -> str | None:
       never cache this** — the next call should try again, not repeat a
       non-answer forever.
     """
+    # Imported inside the function, not at module level: neither boto3 nor a
+    # region needs to exist for `marketing.ssm` itself to import, matching
+    # the deferred-import discipline `config._from_ssm` and
+    # `image_provider._api_key` each used before this module existed. Tests
+    # and any local run should never need AWS reachable just to import this
+    # file — only calling `read_parameter` should.
     try:
         import boto3
         from botocore.exceptions import ClientError

--- a/src/marketing/ssm.py
+++ b/src/marketing/ssm.py
@@ -1,0 +1,77 @@
+"""Shared, tested classification of an SSM ``get_parameter`` failure (issue #25).
+
+`config.public_base_url` and `image_provider._api_key` each resolve one SSM
+parameter once per warm Lambda container: ``None`` means "not yet looked up",
+distinct from ``""`` meaning "looked up, and there is nothing there" — without
+that distinction an unconfigured deployment would re-query SSM (and pay its
+latency) on every single request. Both modules say, in their own words, that
+they are "written to the same pattern deliberately".
+
+Both had the same gap. Neither could tell a **genuinely absent** parameter
+(``ParameterNotFound`` — SSM answered, and the answer is no) from an SSM call
+that simply **could not be completed** (a `ThrottlingException`, a network
+blip, a missing region, a denied grant — SSM never answered at all). Both
+caught every exception the same way and cached ``""`` regardless, so a single
+transient error on a cold start read as "not configured" for that container's
+entire warm life, and the resulting error told an operator to fix a deployment
+that was not broken.
+
+This module is the one place that draws that line, so a future caller that
+wants to cache an SSM value does not have to relearn the distinction a third
+time. `config._from_ssm` and `image_provider._api_key` each keep their own
+`_cached` global and their own precedence over a direct env var — only the
+"what does this failure mean" classification lives here.
+"""
+
+from __future__ import annotations
+
+from aws_lambda_powertools import Logger
+
+logger = Logger(child=True)
+
+
+def read_parameter(parameter: str) -> str | None:
+    """Read `parameter` from SSM, with decryption.
+
+    Returns:
+
+    - the value SSM returned, verbatim (not stripped — callers normalise as
+      they each already did before this module existed).
+    - ``""`` when SSM affirmatively answers "nothing is there"
+      (`ParameterNotFound`) — a genuinely unconfigured deployment. Safe for a
+      caller to cache: asking again would get the same answer.
+    - ``None`` when the call itself could not be completed: a transport or
+      throttling error, a missing region, denied credentials, or anything
+      else that means "we could not ask" rather than "we asked and the
+      answer is no". **A caller must never cache this** — the next call
+      should try again, not repeat a non-answer forever.
+    """
+    try:
+        import boto3
+        from botocore.exceptions import ClientError
+    except Exception:
+        logger.warning("boto3 unavailable; cannot read %s from SSM", parameter, exc_info=True)
+        return None
+
+    try:
+        client = boto3.client("ssm")
+        return str(client.get_parameter(Name=parameter, WithDecryption=True)["Parameter"]["Value"])
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code == "ParameterNotFound":
+            logger.warning("No SSM parameter at %s", parameter)
+            return ""
+        logger.warning(
+            "Transient SSM error reading %s (%s); will retry rather than caching as absent",
+            parameter,
+            code,
+            exc_info=True,
+        )
+        return None
+    except Exception:
+        logger.warning(
+            "Could not read %s from SSM; will retry rather than caching as absent",
+            parameter,
+            exc_info=True,
+        )
+        return None

--- a/tests/test_marketing_config.py
+++ b/tests/test_marketing_config.py
@@ -62,18 +62,55 @@ def test_nothing_configured_is_empty_rather_than_an_exception(
     assert config.public_base_url() == ""
 
 
-def test_an_unreadable_parameter_is_empty_rather_than_an_exception(
+def test_a_genuinely_missing_parameter_is_empty_and_cached(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A missing parameter, a denied grant and an SSM outage all mean the same
-    thing to the caller: no link can be minted right now. All are logged."""
+    """A confirmed-absent parameter (`ssm.read_parameter` returning `""`) is
+    the expected state of a deployment nobody has configured yet — `""`, and
+    safe to cache (see the transient-failure test below for the contrast)."""
+    monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL_PARAMETER", "/tabsii/dev/marketing/public-base-url")
+    monkeypatch.setattr(config.ssm, "read_parameter", lambda parameter: "")
+
+    assert config._from_ssm("/tabsii/dev/marketing/public-base-url") == ""
+    assert config.public_base_url() == ""
+    assert config._cached == ""
+
+
+def test_a_transient_ssm_failure_does_not_poison_the_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #25. `ssm.read_parameter` returning `None` means "could not ask"
+    — a `ThrottlingException`, a network blip, a missing region — and must
+    NOT be cached as "asked and got nothing", or one bad cold start disables
+    link minting for that container's entire warm life.
+
+    Fails before the fix: the old `_from_ssm` caught every exception the same
+    way and always cached `""`, so the second call below never re-consulted
+    SSM and stayed wrong for a value that was there all along.
+    """
     monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
     monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL_PARAMETER", "/tabsii/dev/marketing/public-base-url")
 
-    # _from_ssm swallows every failure and returns "" — exercised here through
-    # the real function, with boto3 absent/unreachable in the test environment.
-    assert config._from_ssm("/tabsii/dev/marketing/public-base-url") == ""
+    responses: list[str | None] = [None, "https://dev.tabsii.com"]
+    calls: list[str] = []
+
+    def _flaky_then_fine(parameter: str) -> str | None:
+        calls.append(parameter)
+        return responses.pop(0)
+
+    monkeypatch.setattr(config.ssm, "read_parameter", _flaky_then_fine)
+
+    # First call: SSM could not be reached. This call reports "not
+    # configured"...
     assert config.public_base_url() == ""
+    # ...but that must not have been cached as the answer.
+    assert config._cached is None
+
+    # A later call — the same warm container, no redeploy — retries and
+    # gets the real value, because nothing poisoned the cache.
+    assert config.public_base_url() == "https://dev.tabsii.com"
+    assert len(calls) == 2
 
 
 def test_an_unconfigured_deployment_does_not_re_query_on_every_request(

--- a/tests/test_marketing_config.py
+++ b/tests/test_marketing_config.py
@@ -6,9 +6,32 @@ when nothing is configured, which is the state every deployment starts in.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
+from botocore.exceptions import ClientError
 
 from marketing import config
+
+
+class _FakeSSMClient:
+    """Stands in for `boto3.client("ssm")` at the lowest layer this module
+    reaches — used only by the two "real wiring" tests below, which exist so
+    `config._from_ssm` -> `ssm.read_parameter` is exercised through the
+    actual call, not just against a `config.ssm.read_parameter` monkeypatch
+    that would keep passing even if the two modules' contract drifted apart
+    (a renamed kwarg, a moved function)."""
+
+    def __init__(self, *, value: str | None = None, error_code: str | None = None) -> None:
+        self._value = value
+        self._error_code = error_code
+
+    def get_parameter(self, Name: str, WithDecryption: bool) -> dict[str, Any]:  # noqa: N803
+        if self._error_code is not None:
+            raise ClientError(
+                {"Error": {"Code": self._error_code, "Message": "synthetic"}}, "GetParameter"
+            )
+        return {"Parameter": {"Value": self._value}}
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +93,7 @@ def test_a_genuinely_missing_parameter_is_empty_and_cached(
     safe to cache (see the transient-failure test below for the contrast)."""
     monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
     monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL_PARAMETER", "/tabsii/dev/marketing/public-base-url")
-    monkeypatch.setattr(config.ssm, "read_parameter", lambda parameter: "")
+    monkeypatch.setattr(config.ssm, "read_parameter", lambda parameter, *, purpose: "")
 
     assert config._from_ssm("/tabsii/dev/marketing/public-base-url") == ""
     assert config.public_base_url() == ""
@@ -95,7 +118,7 @@ def test_a_transient_ssm_failure_does_not_poison_the_cache(
     responses: list[str | None] = [None, "https://dev.tabsii.com"]
     calls: list[str] = []
 
-    def _flaky_then_fine(parameter: str) -> str | None:
+    def _flaky_then_fine(parameter: str, *, purpose: str) -> str | None:
         calls.append(parameter)
         return responses.pop(0)
 
@@ -111,6 +134,45 @@ def test_a_transient_ssm_failure_does_not_poison_the_cache(
     # gets the real value, because nothing poisoned the cache.
     assert config.public_base_url() == "https://dev.tabsii.com"
     assert len(calls) == 2
+
+
+def test_the_real_ssm_wiring_reports_a_confirmed_absence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Integration test, through the real call chain: `config._from_ssm` ->
+    `ssm.read_parameter` -> `boto3`, with only `boto3.client` stubbed —
+    everything above it is the actual production code, unlike every other
+    test in this file, which monkeypatches `config.ssm.read_parameter` or
+    `config._from_ssm` directly and would not notice if the two modules'
+    contract drifted apart."""
+    monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL_PARAMETER", "/tabsii/dev/marketing/public-base-url")
+    monkeypatch.setattr(
+        "boto3.client", lambda service: _FakeSSMClient(error_code="ParameterNotFound")
+    )
+
+    assert config._from_ssm("/tabsii/dev/marketing/public-base-url") == ""
+    assert config.public_base_url() == ""
+    assert config._cached == ""
+
+
+def test_the_real_ssm_wiring_does_not_cache_a_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """As above, but through the real chain for the #25 contract itself: a
+    throttle must not be cached, and a later call must retry and succeed."""
+    monkeypatch.delenv("BIFFO_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setenv("BIFFO_PUBLIC_BASE_URL_PARAMETER", "/tabsii/dev/marketing/public-base-url")
+
+    clients = iter(
+        [
+            _FakeSSMClient(error_code="ThrottlingException"),
+            _FakeSSMClient(value="https://dev.tabsii.com"),
+        ]
+    )
+    monkeypatch.setattr("boto3.client", lambda service: next(clients))
+
+    assert config.public_base_url() == ""
+    assert config._cached is None
+    assert config.public_base_url() == "https://dev.tabsii.com"
 
 
 def test_an_unconfigured_deployment_does_not_re_query_on_every_request(

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -9,15 +9,36 @@ from __future__ import annotations
 
 import base64
 import json
+from typing import Any
 
 import httpx
 import pytest
+from botocore.exceptions import ClientError
 
 import marketing.image_provider as image_provider
 from marketing.image_provider import GeneratedImage, ImageProviderError, OpenAIImageProvider
 
 _PNG_BYTES = b"\x89PNG\r\n\x1a\nnot a real png but bytes are bytes"
 _PNG_B64 = base64.b64encode(_PNG_BYTES).decode()
+
+
+class _FakeSSMClient:
+    """Stands in for `boto3.client("ssm")` at the lowest layer this module
+    reaches — used only by the "real wiring" test below, which exercises
+    `_api_key` -> `ssm.read_parameter` through the actual call rather than a
+    `image_provider.ssm.read_parameter` monkeypatch that would keep passing
+    even if the two modules' contract drifted apart."""
+
+    def __init__(self, *, value: str | None = None, error_code: str | None = None) -> None:
+        self._value = value
+        self._error_code = error_code
+
+    def get_parameter(self, Name: str, WithDecryption: bool) -> dict[str, Any]:  # noqa: N803
+        if self._error_code is not None:
+            raise ClientError(
+                {"Error": {"Code": self._error_code, "Message": "synthetic"}}, "GetParameter"
+            )
+        return {"Parameter": {"Value": self._value}}
 
 
 @pytest.fixture(autouse=True)
@@ -125,7 +146,7 @@ def test_a_transient_ssm_failure_does_not_poison_the_api_key_cache(
     responses: list[str | None] = [None, "sk-live-real-key"]
     calls: list[str] = []
 
-    def _flaky_then_fine(parameter: str) -> str | None:
+    def _flaky_then_fine(parameter: str, *, purpose: str) -> str | None:
         calls.append(parameter)
         return responses.pop(0)
 
@@ -140,3 +161,42 @@ def test_a_transient_ssm_failure_does_not_poison_the_api_key_cache(
     # A later call — same warm container — retries and gets the real key.
     assert image_provider._api_key() == "sk-live-real-key"
     assert len(calls) == 2
+
+
+def test_the_real_ssm_wiring_does_not_cache_a_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration test, through the real call chain: `_api_key` ->
+    `ssm.read_parameter` -> `boto3`, with only `boto3.client` stubbed —
+    everything above it is the actual production code, unlike the test
+    above, which monkeypatches `image_provider.ssm.read_parameter` directly
+    and would not notice if the two modules' contract drifted apart."""
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", "/marketing/image-key")
+    image_provider.reset_api_key_cache()
+
+    clients = iter(
+        [
+            _FakeSSMClient(error_code="ThrottlingException"),
+            _FakeSSMClient(value="sk-live-real-key"),
+        ]
+    )
+    monkeypatch.setattr("boto3.client", lambda service: next(clients))
+
+    assert image_provider._api_key() == ""
+    assert image_provider._cached_api_key is None
+    assert image_provider._api_key() == "sk-live-real-key"
+
+
+def test_the_real_ssm_wiring_reports_a_confirmed_absence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """As above, for the other half of the contract: a genuinely-absent
+    parameter through the real chain, not a mocked `ssm.read_parameter`."""
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", "/marketing/image-key")
+    image_provider.reset_api_key_cache()
+    monkeypatch.setattr(
+        "boto3.client", lambda service: _FakeSSMClient(error_code="ParameterNotFound")
+    )
+
+    assert image_provider._api_key() == ""
+    assert image_provider._cached_api_key == ""

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -127,6 +127,24 @@ async def test_generate_still_raises_without_a_configured_key(
         await _provider(handler).generate_still(prompt="anything")
 
 
+def test_the_no_key_message_does_not_claim_the_parameter_is_unset_when_it_is_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_api_key()` returning `""` is not always "nobody configured
+    anything" — a parameter CAN be configured and still fail to read (denied,
+    throttled, genuinely absent). The old fixed message ("are both unset")
+    was false in every one of those cases; this checks both branches of the
+    corrected one."""
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", raising=False)
+    assert "are both unset" in image_provider._no_api_key_message()
+
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", "/marketing/image-key")
+    message = image_provider._no_api_key_message()
+    assert "are both unset" not in message
+    assert "/marketing/image-key" in message
+
+
 def test_a_transient_ssm_failure_does_not_poison_the_api_key_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -104,3 +104,39 @@ async def test_generate_still_raises_without_a_configured_key(
 
     with pytest.raises(ImageProviderError, match="No image provider API key"):
         await _provider(handler).generate_still(prompt="anything")
+
+
+def test_a_transient_ssm_failure_does_not_poison_the_api_key_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #25. A `ThrottlingException` on a cold start's key lookup must
+    not be remembered as "not configured" for the rest of that warm
+    container's life — the fake `_provider(handler)` fixture above proves the
+    request-time symptom; this proves the caching contract that causes it.
+
+    Fails before the fix: the old `_api_key` caught every SSM failure the
+    same way and always cached `""`, so the second call below never
+    re-consulted SSM and stayed wrong for a key that was there all along.
+    """
+    monkeypatch.delenv("MARKETING_IMAGE_PROVIDER_API_KEY", raising=False)
+    monkeypatch.setenv("MARKETING_IMAGE_PROVIDER_API_KEY_PARAMETER", "/marketing/image-key")
+    image_provider.reset_api_key_cache()
+
+    responses: list[str | None] = [None, "sk-live-real-key"]
+    calls: list[str] = []
+
+    def _flaky_then_fine(parameter: str) -> str | None:
+        calls.append(parameter)
+        return responses.pop(0)
+
+    monkeypatch.setattr(image_provider.ssm, "read_parameter", _flaky_then_fine)
+
+    # First call: SSM could not be reached. Reports unconfigured for THIS
+    # call only...
+    assert image_provider._api_key() == ""
+    # ...but that must not have been cached as the answer.
+    assert image_provider._cached_api_key is None
+
+    # A later call — same warm container — retries and gets the real key.
+    assert image_provider._api_key() == "sk-live-real-key"
+    assert len(calls) == 2

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -69,7 +69,7 @@ class _FakeCoreClient:
     def __init__(
         self,
         *,
-        max_bytes: int = 10_000_000,
+        max_bytes: Any = 10_000_000,
         presign_status: int | None = None,
         ledger_status: int | None = None,
         ledger_missing_id: bool = False,
@@ -131,9 +131,16 @@ class _FakeCampaignClient:
     the plugin's own generated-CRUD tables (`marketing_campaign`,
     `marketing_asset`) — Core's internal, per-plugin mount, per issue #27."""
 
-    def __init__(self, *, exists: bool = True, fail_asset_creation: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        exists: bool = True,
+        fail_asset_creation: bool = False,
+        asset_missing_id: bool = False,
+    ) -> None:
         self.exists = exists
         self.fail_asset_creation = fail_asset_creation
+        self.asset_missing_id = asset_missing_id
         self.created_assets: list[dict[str, Any]] = []
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
@@ -147,7 +154,9 @@ class _FakeCampaignClient:
         if path == f"{image_routes._INTERNAL_PREFIX}/assets":
             if self.fail_asset_creation:
                 raise BiffoAPIError(502, "asset service unavailable")
-            row = {**(json or {}), "id": f"asset-{len(self.created_assets) + 1}"}
+            row = {**(json or {})}
+            if not self.asset_missing_id:
+                row["id"] = f"asset-{len(self.created_assets) + 1}"
             self.created_assets.append(row)
             return row
         raise AssertionError(f"unexpected POST {path}")
@@ -541,6 +550,54 @@ def test_a_malformed_confirm_response_names_the_ledger(_s3_upload_ok) -> None:
     assert resp.status_code == 502
     detail = resp.json()["detail"]
     assert _LEDGER_ID in detail, f"the error must name the ledger entry: {detail!r}"
+
+
+def test_a_non_numeric_max_bytes_is_a_diagnosable_502_not_a_crash() -> None:
+    """`presigned["max_bytes"]` is read straight into a numeric comparison
+    (`len(image.content) > max_bytes`). If Core's response carries the key
+    but with the wrong type — `null`, a JSON string — a bare `TypeError`
+    would raise straight out of that comparison, past every `except
+    HTTPException` guard in the route, as an unstyled 500 with no
+    committed-state note — even though the charge has already happened by
+    this point (issue #24).
+
+    Fails before this round's fix: `max_bytes` was read via `_required_field`
+    alone, which only guards presence, not type.
+    """
+    core = _FakeCoreClient(max_bytes="not-a-number")
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert "max_bytes" in detail
+    assert _LEDGER_ID in detail, f"the error must name the ledger entry: {detail!r}"
+
+
+def test_a_malformed_asset_response_does_not_fail_an_otherwise_successful_generation(
+    _s3_upload_ok,
+) -> None:
+    """A missing `id` on the asset response is Core response-shape drift,
+    but by the time it is read the charge, the upload AND the asset row have
+    all already committed — `asset_id` from here on is used only to enrich a
+    LATER failure's error message, never to build a request. Hard-failing an
+    otherwise fully successful generation over a field that is purely
+    cosmetic at this point would be worse than the gap it closes, so this
+    must still return 201.
+    """
+    core = _FakeCoreClient()
+    campaign = _FakeCampaignClient(asset_missing_id=True)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=campaign)
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 201
+    assert "id" not in resp.json()["asset"]
 
 
 def test_rejects_an_empty_prompt() -> None:

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -72,17 +72,23 @@ class _FakeCoreClient:
         max_bytes: int = 10_000_000,
         presign_status: int | None = None,
         ledger_status: int | None = None,
+        ledger_missing_id: bool = False,
+        confirm_missing_id: bool = False,
     ) -> None:
         self.calls: list[tuple[str, str, Any]] = []
         self._max_bytes = max_bytes
         self._presign_status = presign_status
         self._ledger_status = ledger_status
+        self._ledger_missing_id = ledger_missing_id
+        self._confirm_missing_id = confirm_missing_id
 
     async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
         self.calls.append(("POST", path, json))
         if path == image_routes._LEDGER_PATH:
             if self._ledger_status is not None:
                 raise BiffoAPIError(self._ledger_status, "ledger unavailable")
+            if self._ledger_missing_id:
+                return {"created_at": "2026-08-10T00:00:00Z"}
             return {"id": _LEDGER_ID, "created_at": "2026-08-10T00:00:00Z"}
         if path == f"{image_routes._STORAGE_PATH}/presign":
             if self._presign_status is not None:
@@ -95,6 +101,14 @@ class _FakeCoreClient:
                 "expires_in": 900,
             }
         if path == f"{image_routes._STORAGE_PATH}/confirm":
+            if self._confirm_missing_id:
+                return {
+                    "owner_plugin": "system:marketing",
+                    "storage_key": (json or {})["key"],
+                    "filename": "generated.png",
+                    "mime_type": "image/png",
+                    "size_bytes": len(b"fake-bytes"),
+                }
             return {
                 "id": _MEDIA_ID,
                 "owner_plugin": "system:marketing",
@@ -482,6 +496,51 @@ def test_a_ledger_failure_is_loud_even_though_it_cannot_be_prevented(
 
     assert resp.status_code == 502
     assert any("double-bill" in record.message for record in caplog.records)
+
+
+def test_a_malformed_ledger_response_still_reports_the_charge() -> None:
+    """The ledger POST can succeed (the charge IS recorded) while its
+    response is missing `id` — Core response-shape drift, not a failed
+    write. The 502 that follows must still say a charge happened, even
+    though there is no id left to name.
+
+    Fails before this round's fix: `ledger_id = _required_field(...)` was
+    not wrapped in `_with_committed_note`, so this case raised a bare
+    "Ledger response had no 'id'." with no mention that money had already
+    moved — the exact blind-retry risk issue #24 exists to prevent, at the
+    point closest to the charge.
+    """
+    core = _FakeCoreClient(ledger_missing_id=True)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert "charged" in detail.lower(), f"the error must say a charge already happened: {detail!r}"
+
+
+def test_a_malformed_confirm_response_names_the_ledger(_s3_upload_ok) -> None:
+    """As above, one step later: storage confirms the upload but its
+    response is missing `id`. The ledger is already known at this point, so
+    the error must name it.
+
+    Fails before this round's fix: `media_id = _required_field(...)` was not
+    wrapped in `_with_committed_note`, so this case's 502 said nothing about
+    the ledger entry that already existed.
+    """
+    core = _FakeCoreClient(confirm_missing_id=True)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail, f"the error must name the ledger entry: {detail!r}"
 
 
 def test_rejects_an_empty_prompt() -> None:

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -66,13 +66,24 @@ class _FakeCoreClient:
     """Stands in for the SigV4-signed internal client: storage presign/
     confirm/url and the media-generations ledger."""
 
-    def __init__(self, *, max_bytes: int = 10_000_000, presign_status: int | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        max_bytes: int = 10_000_000,
+        presign_status: int | None = None,
+        ledger_status: int | None = None,
+    ) -> None:
         self.calls: list[tuple[str, str, Any]] = []
         self._max_bytes = max_bytes
         self._presign_status = presign_status
+        self._ledger_status = ledger_status
 
     async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
         self.calls.append(("POST", path, json))
+        if path == image_routes._LEDGER_PATH:
+            if self._ledger_status is not None:
+                raise BiffoAPIError(self._ledger_status, "ledger unavailable")
+            return {"id": _LEDGER_ID, "created_at": "2026-08-10T00:00:00Z"}
         if path == f"{image_routes._STORAGE_PATH}/presign":
             if self._presign_status is not None:
                 raise BiffoAPIError(self._presign_status, "storage unavailable")
@@ -92,8 +103,6 @@ class _FakeCoreClient:
                 "mime_type": "image/png",
                 "size_bytes": len(b"fake-bytes"),
             }
-        if path == image_routes._LEDGER_PATH:
-            return {"id": _LEDGER_ID, "created_at": "2026-08-10T00:00:00Z"}
         raise AssertionError(f"unexpected POST {path}")
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
@@ -108,8 +117,9 @@ class _FakeCampaignClient:
     the plugin's own generated-CRUD tables (`marketing_campaign`,
     `marketing_asset`) — Core's internal, per-plugin mount, per issue #27."""
 
-    def __init__(self, *, exists: bool = True) -> None:
+    def __init__(self, *, exists: bool = True, fail_asset_creation: bool = False) -> None:
         self.exists = exists
+        self.fail_asset_creation = fail_asset_creation
         self.created_assets: list[dict[str, Any]] = []
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
@@ -121,6 +131,8 @@ class _FakeCampaignClient:
 
     async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
         if path == f"{image_routes._INTERNAL_PREFIX}/assets":
+            if self.fail_asset_creation:
+                raise BiffoAPIError(502, "asset service unavailable")
             row = {**(json or {}), "id": f"asset-{len(self.created_assets) + 1}"}
             self.created_assets.append(row)
             return row
@@ -374,6 +386,102 @@ def test_storage_unavailable_passes_through_as_503() -> None:
     resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
 
     assert resp.status_code == 503
+
+
+# ── issue #24: a partial failure must not orphan a billed generation ────────
+
+
+def test_the_charge_is_ledgered_before_upload_is_even_attempted(_s3_upload_ok) -> None:
+    """The core of the fix: the ledger POST is the very next Core call after
+    the provider is paid, ahead of storage — not last, as it was before.
+
+    Fails before the fix: the old handler called `_upload` first, so the
+    ledger path would not appear before the presign path in `core.calls`.
+    """
+    core = _FakeCoreClient()
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 201
+    post_paths = [path for method, path, _ in core.calls if method == "POST"]
+    ledger_index = post_paths.index(image_routes._LEDGER_PATH)
+    presign_index = post_paths.index(f"{image_routes._STORAGE_PATH}/presign")
+    assert ledger_index < presign_index, f"ledger must precede presign, got {post_paths}"
+
+
+def test_the_charge_survives_an_upload_failure_and_the_error_names_the_ledger(
+    _s3_upload_failing,
+) -> None:
+    """Issue #24's central claim: a failure between the provider call and the
+    asset row must not orphan the charge, and the resulting error must let a
+    caller tell this apart from a first attempt.
+
+    Fails before the fix: the old handler ledgered *after* upload, so an
+    upload failure meant no ledger row was ever written — `core.calls` would
+    contain no POST to `_LEDGER_PATH` at all, and the 502 would say nothing
+    about a charge having already happened.
+    """
+    core = _FakeCoreClient()
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    ledger_calls = [c for c in core.calls if c[1] == image_routes._LEDGER_PATH]
+    assert len(ledger_calls) == 1, "the charge must be ledgered even though upload failed"
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail, (
+        f"the error must name the ledger entry so a retry is not blind: {detail!r}"
+    )
+
+
+def test_the_charge_and_media_survive_an_asset_failure_and_the_error_names_both(
+    _s3_upload_ok,
+) -> None:
+    """A failure creating the `marketing_asset` row must not discard the
+    evidence that the charge AND the upload already happened."""
+    core = _FakeCoreClient()
+    campaign = _FakeCampaignClient(fail_asset_creation=True)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=campaign)
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    ledger_calls = [c for c in core.calls if c[1] == image_routes._LEDGER_PATH]
+    confirm_calls = [c for c in core.calls if c[1] == f"{image_routes._STORAGE_PATH}/confirm"]
+    assert len(ledger_calls) == 1
+    assert len(confirm_calls) == 1
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail
+    assert _MEDIA_ID in detail
+
+
+def test_a_ledger_failure_is_loud_even_though_it_cannot_be_prevented(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The one gap the fix does not close (see the route's own docstring): if
+    the ledger write itself fails, there is nothing to name in the error
+    response, because nothing durable was written. That case must at least
+    be loud in the logs, with everything a human needs to reconcile it by
+    hand — not silently swallowed the way it would be by a bare `_core_error`
+    mapping."""
+    core = _FakeCoreClient(ledger_status=502)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    with caplog.at_level("ERROR"):
+        resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    assert any("double-bill" in record.message for record in caplog.records)
 
 
 def test_rejects_an_empty_prompt() -> None:

--- a/tests/test_marketing_ssm.py
+++ b/tests/test_marketing_ssm.py
@@ -1,0 +1,77 @@
+"""`ssm.read_parameter` (issue #25) — the one place that classifies an SSM
+failure as either "genuinely absent" or "could not ask".
+
+Both callers (`config._from_ssm`, `image_provider._api_key`) cache this
+module's `""` forever and never cache its `None`. This file proves the
+classification itself; `test_marketing_config.py` and
+`test_marketing_image_provider*.py` prove each caller respects it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from marketing import ssm
+
+
+class _FakeSSMClient:
+    """Stands in for `boto3.client("ssm")` — either returns a parameter value
+    or raises exactly the `ClientError` a real `get_parameter` call would."""
+
+    def __init__(self, *, value: str | None = None, error_code: str | None = None) -> None:
+        self._value = value
+        self._error_code = error_code
+
+    def get_parameter(self, Name: str, WithDecryption: bool) -> dict[str, Any]:  # noqa: N803
+        if self._error_code is not None:
+            raise ClientError(
+                {"Error": {"Code": self._error_code, "Message": "synthetic"}}, "GetParameter"
+            )
+        return {"Parameter": {"Value": self._value}}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client: Any) -> None:
+    monkeypatch.setattr("boto3.client", lambda service: client)
+
+
+def test_returns_the_value_when_ssm_answers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _FakeSSMClient(value="sk-live-abc123"))
+    assert ssm.read_parameter("/some/parameter") == "sk-live-abc123"
+
+
+def test_a_genuinely_absent_parameter_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`ParameterNotFound` is SSM affirmatively answering "nothing is
+    there" — the one case safe for a caller to cache."""
+    _patch_client(monkeypatch, _FakeSSMClient(error_code="ParameterNotFound"))
+    assert ssm.read_parameter("/some/parameter") == ""
+
+
+def test_a_throttling_error_is_none_not_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exact shape issue #25 reports: a momentary throttle must not read
+    the same as a confirmed-absent parameter."""
+    _patch_client(monkeypatch, _FakeSSMClient(error_code="ThrottlingException"))
+    assert ssm.read_parameter("/some/parameter") is None
+
+
+def test_an_access_denied_error_is_none_not_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A permissions problem is something to fix, but it is not "this
+    parameter does not exist" — collapsing the two would send an operator
+    hunting for a missing `put-parameter` that was never the issue."""
+    _patch_client(monkeypatch, _FakeSSMClient(error_code="AccessDeniedException"))
+    assert ssm.read_parameter("/some/parameter") is None
+
+
+def test_a_non_client_transport_error_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raw connection failure (no region, network unreachable, ...) never
+    even reaches a `ClientError` — it must still classify as "could not
+    ask", not "asked and got nothing"."""
+
+    class _Exploding:
+        def get_parameter(self, Name: str, WithDecryption: bool) -> dict[str, Any]:  # noqa: N803
+            raise OSError("network is unreachable")
+
+    _patch_client(monkeypatch, _Exploding())
+    assert ssm.read_parameter("/some/parameter") is None

--- a/tests/test_marketing_ssm.py
+++ b/tests/test_marketing_ssm.py
@@ -1,5 +1,7 @@
 """`ssm.read_parameter` (issue #25) — the one place that classifies an SSM
-failure as either "genuinely absent" or "could not ask".
+failure as one of three things: a final "no" (safe to cache), a final
+"denied" (also safe to cache — see below), or "could not ask at all" (must
+never be cached).
 
 Both callers (`config._from_ssm`, `image_provider._api_key`) cache this
 module's `""` forever and never cache its `None`. This file proves the
@@ -15,6 +17,8 @@ import pytest
 from botocore.exceptions import ClientError
 
 from marketing import ssm
+
+_PURPOSE = "test parameter"
 
 
 class _FakeSSMClient:
@@ -39,39 +43,64 @@ def _patch_client(monkeypatch: pytest.MonkeyPatch, client: Any) -> None:
 
 def test_returns_the_value_when_ssm_answers(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_client(monkeypatch, _FakeSSMClient(value="sk-live-abc123"))
-    assert ssm.read_parameter("/some/parameter") == "sk-live-abc123"
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) == "sk-live-abc123"
 
 
 def test_a_genuinely_absent_parameter_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """`ParameterNotFound` is SSM affirmatively answering "nothing is
-    there" — the one case safe for a caller to cache."""
+    there" — safe for a caller to cache."""
     _patch_client(monkeypatch, _FakeSSMClient(error_code="ParameterNotFound"))
-    assert ssm.read_parameter("/some/parameter") == ""
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) == ""
 
 
 def test_a_throttling_error_is_none_not_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """The exact shape issue #25 reports: a momentary throttle must not read
-    the same as a confirmed-absent parameter."""
+    the same as a confirmed-absent parameter — it self-heals, so it must
+    not be cached."""
     _patch_client(monkeypatch, _FakeSSMClient(error_code="ThrottlingException"))
-    assert ssm.read_parameter("/some/parameter") is None
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) is None
 
 
-def test_an_access_denied_error_is_none_not_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A permissions problem is something to fix, but it is not "this
-    parameter does not exist" — collapsing the two would send an operator
-    hunting for a missing `put-parameter` that was never the issue."""
+def test_an_access_denied_error_is_cached_as_a_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`AccessDeniedException` is a THIRD state, distinct from both a
+    confirmed-absent parameter and a transient failure — the parameter may
+    well exist, but this caller is not, and will not become, authorised to
+    read it before this container recycles. An IAM grant does not repair
+    itself between one request and the next the way a throttle clears, so
+    treating this as "could not ask, retry" would pay a fresh
+    `boto3.client()` and a full SSM round trip on every request forever for
+    a condition only a human can fix. It is grouped with `ParameterNotFound`
+    instead: both are final for this container's life, and both are safe to
+    cache."""
     _patch_client(monkeypatch, _FakeSSMClient(error_code="AccessDeniedException"))
-    assert ssm.read_parameter("/some/parameter") is None
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) == ""
 
 
 def test_a_non_client_transport_error_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """A raw connection failure (no region, network unreachable, ...) never
     even reaches a `ClientError` — it must still classify as "could not
-    ask", not "asked and got nothing"."""
+    ask", not a final answer."""
 
     class _Exploding:
         def get_parameter(self, Name: str, WithDecryption: bool) -> dict[str, Any]:  # noqa: N803
             raise OSError("network is unreachable")
 
     _patch_client(monkeypatch, _Exploding())
-    assert ssm.read_parameter("/some/parameter") is None
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) is None
+
+
+def test_the_purpose_reaches_the_log_line(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Both callers share this module's classification but not its context —
+    `purpose` is what lets an operator triaging a throttle tell which of a
+    deployment's cached values failed, from a log line the shared module
+    itself has no other way to make specific."""
+    _patch_client(monkeypatch, _FakeSSMClient(error_code="ThrottlingException"))
+
+    with caplog.at_level("WARNING"):
+        ssm.read_parameter("/some/parameter", purpose="a very specific purpose")
+
+    assert any("a very specific purpose" in record.message for record in caplog.records)


### PR DESCRIPTION
## What changed

**#24 — a partial failure orphans a billed generation, and retry double-bills**

`generate_still_route` billed the provider, then wrote to storage, then
wrote the ledger row, then created the asset row. A failure anywhere after
the charge (upload, asset creation) left a paid-for generation with no
ledger record at all, and a retry re-billed the same prompt with no way to
tell the attempts apart.

The provider call is the only irreversible step in this handler; everything
after it is Core bookkeeping that can be retried. The fix moves the ledger
write to immediately after the charge, before upload or the asset row.
Every later failure's error names what already committed (ledger id, media
id, asset id where available), so an operator reading it knows a blind
retry would double the charge.

**What this guarantees:** once `provider.generate_still` succeeds, the very
next thing the handler does is ledger it, so the charge is durably recorded
as early as it is possible to record it.

**What this does NOT guarantee:** this is not exactly-once. Core's
`/internal/media-generations` route has no idempotency key, so a failure of
the ledger POST itself — the one write that must happen first, and the one
write nothing here can move earlier — still leaves a charge with no
queryable record short of a log line, and a genuine retry of the whole
request after that specific failure would still double-bill. That gap is
logged loudly (every field needed to reconcile it by hand) but not closed;
closing it needs a Core-side change, filed as
[biffo-template#1515](https://github.com/keiranholloway/biffo-template/issues/1515).

Also absorbs the two related findings from #26 that fire on this same
post-charge path: unguarded dict/type reads off Core responses
(`presigned["max_bytes"]`, `media["id"]`, `ledger["id"]`, `url_resp["url"]`,
and `presigned["url"]`/`["fields"]`/`["key"]`) now raise a diagnosable 502
instead of a bare `KeyError`/`TypeError` -> 500, which on this route would
have swallowed the committed-state evidence above. One exception: `asset`'s
`id` is guarded but deliberately soft (logged, not raised) — by the time
it's read, the charge, upload and asset row have all already committed, and
that id is used only to enrich a *later* failure's message, never to build
a request, so failing an otherwise-successful 201 over it would be worse
than the gap it closes. The `BIFFO_CORE_API_URL` guard and the 502-vs-503
status code for a missing credential (the rest of #26) are left out of
scope: the former lives in `biffo-plugin-sdk`, not this repo.

**#25 — a transient SSM failure caches "unconfigured" for the life of the
warm container**

`image_provider._api_key()` and `config.public_base_url()` each caught
every SSM failure the same way and cached `""` regardless — so a single
`ThrottlingException` on a cold start read as "not configured" for that
container's entire warm life, and the resulting error told an operator to
fix a deployment that was never broken.

New shared module `src/marketing/ssm.py` (`read_parameter`) distinguishes
three states: SSM affirmatively answering "nothing there"
(`ParameterNotFound`), a **permanent** denial (`AccessDeniedException` — the
parameter may exist, but this caller will not become authorised to read it
without a human fixing the grant, so retrying every request forever would
just waste a round trip for a condition that cannot self-heal), and a
**transient** failure (throttling, transport, missing region) that must
never be cached. The first two are cached; the third is not. Both callers
now leave their cache unset on a transient failure, so the next call
retries instead of repeating a non-answer forever. The error message
raised when no key is available no longer claims both env vars are unset
when the parameter env *is* set and the read simply failed for another
reason — that was a real, if pre-existing, instance of the exact
misdiagnosis issue #25 is about.

## Cross-cutting

`cost_usd is None` (no price returned) is untouched by this change and
still never becomes `0.0` anywhere in the modified paths — verified by the
existing unpriced/priced ledger tests, both still green.

## Verification

Unit-tested against fakes only (the image provider, the internal Core
client, and a mocked SSM/boto3 client) — no network, per this repo's
convention. Every test that reverts to demonstrate a real failure was
proven fail-first: reverted against the pre-fix code, confirmed red for the
actual reason, then restored to green.

Coverage highlights:
- `test_marketing_image_routes.py`: the ledger write precedes the storage
  presign call; the charge survives an upload/asset-creation/malformed-
  response failure and the error names what already committed; a
  ledger-write failure itself is logged loudly; a non-numeric `max_bytes`
  is a diagnosable 502, not a crash; a malformed asset response does not
  fail an otherwise-successful 201.
- `test_marketing_ssm.py` (new), plus additions to `test_marketing_config.py`
  / `test_marketing_image_provider.py`: `ParameterNotFound` and
  `AccessDeniedException` are both cached; throttling/transport errors are
  not; a transient failure does not poison later calls in the same
  (simulated) warm container. Each caller also carries one integration test
  that exercises the real `_from_ssm`/`_api_key` -> `ssm.read_parameter` ->
  `boto3` chain with only `boto3.client` stubbed, not `ssm.read_parameter`
  itself — so a contract drift between the shared module and its callers
  would be caught rather than passing a suite where every other test mocks
  the module boundary.

**Image generation cannot be verified against a live deployment.** The
shared plugin host still cannot reach this plugin's credential (#69,
unresolved), so nothing here has been exercised end-to-end on dev — only
against fakes.

Local gates (ruff, ruff format, pyright, pytest — 425 passed, web-admin
lint/typecheck/test) all pass, including the repo's own pre-push `verify`
gate.

Closes #24
Closes #25
