### PR TITLE
test(marketing): lock in pack views surfacing the server's reason (#85)

### DIFF
--- a/web-admin/src/components/DistributionPack.test.tsx
+++ b/web-admin/src/components/DistributionPack.test.tsx
@@ -101,7 +101,14 @@ describe('DistributionPack', () => {
     expect(await screen.findByText(/no public base url configured/i)).toBeInTheDocument()
   })
 
-  it('reports a load failure with the server reason, not a raw body', async () => {
+  // The three distinct 4xx branches `pack_routes.get_pack_route` actually
+  // raises (issue #85) — each asserts the operator-facing wording the server
+  // sent, not the status code, and not the response's raw JSON. The fixture
+  // `detail` strings are copied verbatim from `pack_routes.py` rather than
+  // invented, per the issue's own warning that a fixture built from what the
+  // author expects, rather than what the server produces, is the recurring
+  // defect here.
+  it('says there is no copy yet, not just "(404)"', async () => {
     stubSession()
     const user = userEvent.setup()
     vi.stubGlobal(
@@ -109,14 +116,57 @@ describe('DistributionPack', () => {
       vi.fn().mockResolvedValue({
         ok: false,
         status: 404,
-        json: async () => ({ detail: 'No approved source creative for this campaign yet.' }),
+        json: async () => ({ detail: 'No copy artefact for this campaign yet.' }),
       }),
     )
 
     render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
-    expect(await screen.findByText(/no approved source creative/i)).toBeInTheDocument()
+    expect(await screen.findByText(/no copy artefact for this campaign yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the distribution pack \(404\)$/i)).not.toBeInTheDocument()
+  })
+
+  it('says the campaign was not found, not just "(404)"', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Campaign not found.' }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    expect(await screen.findByText(/^campaign not found\./i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the distribution pack \(404\)$/i)).not.toBeInTheDocument()
+  })
+
+  it('says the copy needs approving on a 409 — one click from resolved, not a bare status', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          detail: 'The copy artefact must be approved before this can proceed (status: proposed).',
+        }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    expect(await screen.findByText(/copy artefact must be approved before this can proceed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the distribution pack \(409\)$/i)).not.toBeInTheDocument()
+    // No raw JSON — only the string `detail` field, never the object itself.
+    expect(screen.queryByText(/"detail"/)).not.toBeInTheDocument()
   })
 
   it('marks a channel_key with no taxonomy row as unrecognised rather than blank', async () => {

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -75,4 +75,68 @@ describe('PaidPack', () => {
     expect(screen.getByText(/1 paid channel\(s\)/)).toBeInTheDocument()
     expect(screen.getByText(/not measurable — no route reachable/i)).toBeInTheDocument()
   })
+
+  // The three distinct 4xx branches `paid_pack_routes.get_paid_pack_route`
+  // actually raises (issue #85), mirroring `pack_routes.py`'s own wording —
+  // asserting the operator-facing text the server sent, not the status code.
+  // `detail` strings are copied verbatim from `paid_pack_routes.py`.
+  it('says there is no copy yet, not just "(404)"', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'No copy artefact for this campaign yet.' }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/no copy artefact for this campaign yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the paid pack \(404\)$/i)).not.toBeInTheDocument()
+  })
+
+  it('says the campaign was not found, not just "(404)"', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Campaign not found.' }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/^campaign not found\./i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the paid pack \(404\)$/i)).not.toBeInTheDocument()
+  })
+
+  it('says the copy needs approving on a 409 — one click from resolved, not a bare status', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          detail: 'The copy artefact must be approved before this can proceed (status: proposed).',
+        }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/copy artefact must be approved before this can proceed/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^could not load the paid pack \(409\)$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/"detail"/)).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## What this is

Issue #85 asked to check whether `api.ts`'s shared error path was the cause
of pack views showing `(404)` instead of the server's reason, and to fix it
there once if so — with a warning not to overcorrect into rendering raw
response bodies.

## What I found

The shared path is **not** the cause, and never has been for these two
routes. `createRequest`'s `onError` default branch (`api.ts`) already
extracts `detail` and includes it in the thrown message for every status —
404, 409, 403 — and only when `detail` is actually a string, so a validation
error's list-shaped `detail` or an HTML error page still falls back to a
plain status message rather than `[object Object]` or raw JSON. That
extraction has been present since the pack routes were first built
(`feat(marketing): admin UI ... #53`) via `throwForResponse`, and #59's
migration onto the distributed `api-core` request core carried it over
byte-for-byte as the `onError` default branch.

I proved this by temporarily forcing the default branch to skip detail
extraction (reproducing the exact `could not load the distribution/paid pack
(404)`/`(409)` wording the issue quotes), watched the new tests below fail on
that wording, then reverted the temporary change and watched them pass.

**No production code changed.** `web-admin/src/lib/api.ts`,
`DistributionPack.tsx`, and `PaidPack.tsx` are untouched by this PR.

## What changed

Only test coverage, closing the gap against the issue's own "Done when"
checklist:

- `DistributionPack.test.tsx`: replaced one test asserting a 404 message
  (`"No approved source creative..."`) that `pack_routes.py` no longer
  produces (removed by #64) with three tests against the routes' real 4xx
  branches — no copy yet (404), campaign not found (404), copy awaiting
  approval (409) — using `detail` strings copied verbatim from
  `pack_routes.py`.
- `PaidPack.test.tsx`: had **zero** error-path tests before this PR. Added
  the same three branches, mirroring `paid_pack_routes.py`'s identical
  wording.

Each test asserts the operator-facing text is shown, that the raw
`could not load the ... pack (<status>)` fallback is absent, and (on the 409
case) that no raw `"detail"` JSON reaches the page.

## For the caller — sequencing note

This PR does **not** touch `api.ts`. A concurrent agent fixing #83/#84 in
`MintLinks.tsx` may still need to touch `api.ts`'s `onError` (its `'mint
links'` case is the one branch that genuinely does discard `detail` for
unhandled statuses) — that is a disjoint, real bug in a different branch of
the same switch statement. Nothing here should conflict with that PR, but
flagging since both PRs touch files under `web-admin/src/lib`/`components`
in the same plugin.

## Is the 409 distinguishable from the 404s?

Yes — it already was, and now it's covered: the 409 renders
`"The copy artefact must be approved before this can proceed (status:
proposed)."`, not `(409)`.

Refs #85
