### PR TITLE
fix(marketing): surface validation-error detail on mint, and pick channels from the taxonomy

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -144,11 +144,22 @@ def _validated_campaign_id(campaign_id: str) -> str:
 
 
 class MintRequest(BaseModel):
-    """One link to mint: a channel, optionally a variant, organic or paid."""
+    """One link to mint: a channel key, and optionally a variant.
+
+    No ``is_paid`` here (#84). It used to be a caller-supplied flag,
+    independent of ``channel`` — which meant an operator could tick "Paid
+    placement" for a channel whose own taxonomy row already says
+    ``motion: organic``, or leave it unticked for one that is inherently
+    paid, and nothing reconciled the two. Motion now lives on the channel
+    (#76 increment 2), so ``mint_links`` derives ``is_paid`` from the
+    selected channel's own ``motion`` and this model does not accept a
+    second, independently-wrong answer to the same question. A legacy
+    caller that still sends ``is_paid`` is not rejected for it — pydantic
+    ignores unknown fields by default — it is simply not consulted.
+    """
 
     channel: str = Field(min_length=1, max_length=64)
     variant: str | None = Field(default=None, max_length=64)
-    is_paid: bool = False
 
 
 class MintBody(BaseModel):
@@ -205,8 +216,30 @@ async def mint_links(
             detail="This campaign has no destination_url, so its links would lead nowhere.",
         )
 
+    # #84: `marketing_link.channel` now holds taxonomy keys everywhere else
+    # (`pack_routes._ensure_links`) — this was the one path still writing
+    # whatever an operator typed. Validated here, against this tenant's own
+    # `marketing_channel` rows, not against a hardcoded list: an
+    # instance-added channel must mint exactly as well as a seeded one.
+    channel_motions = await _channel_motions(admin.token)
+    unrecognised = sorted(
+        {spec.channel for spec in body.links if spec.channel not in channel_motions}
+    )
+    if unrecognised:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Not a recognised channel key: {', '.join(unrecognised)}. "
+                f"Valid channel keys: {', '.join(sorted(channel_motions))}."
+            ),
+        )
+
     minted: list[dict[str, Any]] = []
     for spec in body.links:
+        # Derived from the channel's own taxonomy row, not from anything the
+        # caller sent (#84) — see `MintRequest`'s docstring for why there is
+        # no independent `is_paid` on the request any more.
+        is_paid = channel_motions[spec.channel] == "paid"
         token = mint_token()
         created = await _core(
             "POST",
@@ -217,7 +250,7 @@ async def mint_links(
                 "token": token,
                 "channel": spec.channel,
                 "variant": spec.variant,
-                "is_paid": spec.is_paid,
+                "is_paid": is_paid,
                 # Resolved HERE, once, and stored. The public redirect sends the
                 # caller to exactly what is stored, so editing the campaign
                 # tomorrow cannot rewrite a link published today.
@@ -226,7 +259,7 @@ async def mint_links(
                     campaign_id=campaign_id,
                     channel=spec.channel,
                     variant=spec.variant,
-                    is_paid=spec.is_paid,
+                    is_paid=is_paid,
                 ),
             },
         )
@@ -237,12 +270,27 @@ async def mint_links(
                 "id": row.get("id"),
                 "channel": spec.channel,
                 "variant": spec.variant,
-                "is_paid": spec.is_paid,
+                "is_paid": is_paid,
                 "url": tracked_url(base_url, token),
             }
         )
 
     return {"campaign_id": campaign_id, "links": minted}
+
+
+async def _channel_motions(admin_token: str) -> dict[str, str]:
+    """``{channel_key: motion}`` for this tenant's channel taxonomy — what
+    `mint_links` validates a requested channel against, and derives `is_paid`
+    from (#84). Mirrors `paid_pack_routes._channel_ad_platforms`, which fetches
+    the same table for the same reason on the pack side; kept as two small
+    functions rather than one shared helper because the two callers want
+    different projections of the same rows (`ad_platform` there, `motion`
+    here) and a single "give me the taxonomy" helper would just push the
+    projection back onto each call site anyway."""
+    resp = await _core("GET", f"{_INTERNAL_PREFIX}/channels", admin_token)
+    resp.raise_for_status()
+    rows = resp.json() or []
+    return {row["key"]: row["motion"] for row in rows}
 
 
 async def _core(method: str, path: str, token: str, **kw: Any) -> httpx.Response:

--- a/tests/test_marketing_dual_auth_wiring.py
+++ b/tests/test_marketing_dual_auth_wiring.py
@@ -70,9 +70,18 @@ class _FakeSignedCoreClient:
                 "extra_signed_headers": extra_signed_headers,
             }
         )
-        # A generically-shaped 2xx JSON body: every route this file drives
-        # only needs SOME campaign/artefact/asset-looking dict back, not a
-        # specific one — the assertions below are about what was SENT.
+        # `mint_links` (#84) now also fetches the channel taxonomy to
+        # validate against and derive `is_paid` from — a LIST, unlike every
+        # other call this file drives, which all want a campaign/artefact/
+        # asset-looking dict. Branching on path is the minimum needed to keep
+        # that call from being handed a dict and blowing up on `for row in
+        # rows: row["key"]`; the assertions below remain about what was SENT.
+        if path.endswith("/channels"):
+            return (
+                200,
+                b'[{"key": "linkedin_organic", "motion": "organic"}]',
+                ("application/json"),
+            )
         return (
             200,
             b'{"id": "x", "destination_url": "https://tabsii.com/intake/demo"}',
@@ -106,11 +115,11 @@ def test_mint_links_forwards_the_real_admins_token_through_core(
     )()
 
     resp = TestClient(app).post(
-        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]}
+        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_organic"}]}
     )
 
     assert resp.status_code == 201
-    assert len(fake_signed_client.calls) == 2  # GET campaign, POST links
+    assert len(fake_signed_client.calls) == 3  # GET campaign, GET channels, POST links
     for call in fake_signed_client.calls:
         assert call["extra_signed_headers"] == {
             principal_client.FORWARDED_USER_HEADER: _REAL_ADMIN_TOKEN
@@ -131,11 +140,14 @@ def test_mint_links_calls_the_real_internal_paths_not_the_token(
         "U", (), {"sub": "admin", "groups": ["admin"], "token": _REAL_ADMIN_TOKEN}
     )()
 
-    TestClient(app).post(f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]})
+    TestClient(app).post(
+        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_organic"}]}
+    )
 
     paths = {call["path"] for call in fake_signed_client.calls}
     assert paths == {
         f"{admin_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}",
+        f"{admin_app._INTERNAL_PREFIX}/channels",
         f"{admin_app._INTERNAL_PREFIX}/links",
     }
     assert _REAL_ADMIN_TOKEN not in paths

--- a/tests/test_marketing_mint_route.py
+++ b/tests/test_marketing_mint_route.py
@@ -24,11 +24,27 @@ _ATTACKER_TOKEN = "attacker-chosen"  # noqa: S105
 _BASE = "https://dev.tabsii.com"
 
 
+#: A small slice of the real seeded taxonomy (scripts/seed_marketing_channels.py)
+#: — enough to exercise organic vs paid and an unrecognised key, without
+#: reproducing all 31 rows in every test.
+_TAXONOMY = [
+    {"key": "linkedin_organic", "label": "LinkedIn — organic", "motion": "organic"},
+    {"key": "linkedin_paid", "label": "LinkedIn ads", "motion": "paid"},
+    {"key": "instagram_organic", "label": "Instagram — organic", "motion": "organic"},
+]
+
+
 class _FakeCore:
     """Records what the plugin asked Core to do, and answers plausibly."""
 
-    def __init__(self, *, destination: str | None = "https://tabsii.com/intake/demo") -> None:
+    def __init__(
+        self,
+        *,
+        destination: str | None = "https://tabsii.com/intake/demo",
+        channels: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.destination = destination
+        self.channels = _TAXONOMY if channels is None else channels
         self.created: list[dict[str, Any]] = []
 
     async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
@@ -41,6 +57,8 @@ class _FakeCore:
                 json={"id": _CAMPAIGN, "destination_url": self.destination},
                 request=request,
             )
+        if method == "GET" and path == f"{admin_app._INTERNAL_PREFIX}/channels":
+            return httpx.Response(200, json=self.channels, request=request)
         if method == "POST" and path == f"{admin_app._INTERNAL_PREFIX}/links":
             body = kw["json"]
             self.created.append(body)
@@ -69,7 +87,12 @@ def test_minting_returns_a_publishable_url_per_link(ctx) -> None:
     client, _ = ctx
     resp = client.post(
         f"/campaigns/{_CAMPAIGN}/links",
-        json={"links": [{"channel": "linkedin"}, {"channel": "instagram", "variant": "b"}]},
+        json={
+            "links": [
+                {"channel": "linkedin_organic"},
+                {"channel": "instagram_organic", "variant": "b"},
+            ]
+        },
     )
 
     assert resp.status_code == 201
@@ -84,7 +107,7 @@ def test_each_link_gets_its_own_token(ctx) -> None:
     client, core = ctx
     client.post(
         f"/campaigns/{_CAMPAIGN}/links",
-        json={"links": [{"channel": "linkedin"}, {"channel": "instagram"}]},
+        json={"links": [{"channel": "linkedin_organic"}, {"channel": "instagram_organic"}]},
     )
 
     tokens = {row["token"] for row in core.created}
@@ -94,7 +117,7 @@ def test_each_link_gets_its_own_token(ctx) -> None:
 def test_the_stored_destination_carries_the_campaign_id(ctx) -> None:
     """The whole milestone, asserted at the row that actually gets written."""
     client, core = ctx
-    client.post(f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]})
+    client.post(f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_organic"}]})
 
     stored = core.created[0]["destination_url"]
     assert parse_qs(urlsplit(stored).query)["utm_campaign"] == [_CAMPAIGN]
@@ -113,7 +136,7 @@ def test_the_caller_cannot_supply_the_destination_or_the_token(ctx) -> None:
         json={
             "links": [
                 {
-                    "channel": "linkedin",
+                    "channel": "linkedin_organic",
                     "token": _ATTACKER_TOKEN,
                     "destination_url": "https://evil.example/",
                 }
@@ -124,6 +147,50 @@ def test_the_caller_cannot_supply_the_destination_or_the_token(ctx) -> None:
     stored = core.created[0]
     assert stored["token"] != _ATTACKER_TOKEN
     assert stored["destination_url"].startswith("https://tabsii.com/intake/demo")
+
+
+def test_channel_is_validated_against_the_tenants_own_taxonomy(ctx) -> None:
+    """#84: `marketing_link.channel` now holds taxonomy keys everywhere else
+    (`pack_routes._ensure_links`) — free text minted here would be the one
+    path still writing whatever an operator typed, and would never group with
+    the same channel minted through the pipeline."""
+    client, core = ctx
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/links",
+        json={"links": [{"channel": "totally made up channel"}]},
+    )
+
+    assert resp.status_code == 422
+    # Naming what IS valid, not just that this value wasn't — an operator
+    # calling the API directly (not through the picker) needs to see the
+    # actual keys, not guess at them.
+    assert "totally made up channel" in resp.json()["detail"]
+    assert "linkedin_organic" in resp.json()["detail"]
+    assert core.created == [], "nothing should have been written"
+
+
+def test_is_paid_is_derived_from_the_channels_own_motion_not_the_caller(ctx) -> None:
+    """#84: motion lives on the channel now. A caller-supplied `is_paid` used
+    to be a second, independent answer to the same question — sending one
+    that disagrees with the channel's own taxonomy row must not reach
+    storage, because nothing downstream (`_platform_for_channel`, results
+    grouping) trusts anything else."""
+    client, core = ctx
+    client.post(
+        f"/campaigns/{_CAMPAIGN}/links",
+        # `linkedin_organic` is organic in `_TAXONOMY`; an attacker (or a
+        # stale client) claiming `is_paid: true` must be overruled.
+        json={"links": [{"channel": "linkedin_organic", "is_paid": True}]},
+    )
+
+    assert core.created[0]["is_paid"] is False
+
+
+def test_is_paid_true_for_a_paid_channel_even_with_no_flag_sent(ctx) -> None:
+    client, core = ctx
+    client.post(f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_paid"}]})
+
+    assert core.created[0]["is_paid"] is True
 
 
 def test_a_campaign_with_no_destination_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,7 +209,7 @@ def test_a_campaign_with_no_destination_is_refused(monkeypatch: pytest.MonkeyPat
     )()
 
     resp = TestClient(app).post(
-        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]}
+        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_organic"}]}
     )
 
     assert resp.status_code == 422
@@ -161,7 +228,7 @@ def test_an_unconfigured_deployment_says_so_rather_than_minting_a_broken_url(
     )()
 
     resp = TestClient(app).post(
-        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin"}]}
+        f"/campaigns/{_CAMPAIGN}/links", json={"links": [{"channel": "linkedin_organic"}]}
     )
     assert resp.status_code == 503
 
@@ -220,7 +287,7 @@ def test_a_valid_uuid_is_re_rendered_canonically(ctx) -> None:
     """Even a value that parses is rewritten, so no caller formatting survives."""
     client, core = ctx
     upper = _CAMPAIGN.upper()
-    client.post(f"/campaigns/{upper}/links", json={"links": [{"channel": "linkedin"}]})
+    client.post(f"/campaigns/{upper}/links", json={"links": [{"channel": "linkedin_organic"}]})
 
     assert core.created, "a valid campaign_id should still mint"
     assert core.created[0]["campaign_id"] == _CAMPAIGN, "the id should be canonical lowercase"

--- a/web-admin/src/App.test.tsx
+++ b/web-admin/src/App.test.tsx
@@ -14,13 +14,22 @@ describe('App', () => {
   })
 
   it('lists campaigns it receives', async () => {
+    // Routed by URL, not a single blanket response — `App` now also fetches
+    // `/channels` (`useChannelTaxonomy`, #84), and a campaign row is not a
+    // `ChannelTaxonomyEntry`: reusing the campaigns array for both used to
+    // hand `MintLinks` a list of `{key: undefined}` "channels".
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => [
-          { id: '1', name: 'Spring demo push', status: 'draft', destination_url: null },
-        ],
+      vi.fn((url: string) => {
+        if (typeof url === 'string' && url.endsWith('/channels')) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { id: '1', name: 'Spring demo push', status: 'draft', destination_url: null },
+          ],
+        })
       }),
     )
     render(<App />)
@@ -36,17 +45,24 @@ describe('App', () => {
 
 describe('creating a campaign', () => {
   it('submits the form and refreshes the list', async () => {
+    // Dispatched by URL/method, not call order (`CampaignDetail.test.tsx`'s
+    // own pattern): `App` now also fetches `/channels` via
+    // `useChannelTaxonomy` (#84), whose effect can fire before or after
+    // `load()`'s — a fixed three-call queue silently mis-fed the taxonomy
+    // fetch a `Campaign` and vice versa the moment a second concurrent
+    // caller was added.
+    let campaigns: unknown[] = []
     const user = userEvent.setup()
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: '1' }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          { id: '1', name: 'Spring', status: 'draft', destination_url: 'https://x/demo' },
-        ],
-      })
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.endsWith('/channels')) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      if (typeof url === 'string' && url.endsWith('/campaigns') && init?.method === 'POST') {
+        campaigns = [{ id: '1', name: 'Spring', status: 'draft', destination_url: 'https://x/demo' }]
+        return Promise.resolve({ ok: true, json: async () => ({ id: '1' }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => campaigns })
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     render(<App />)
@@ -68,11 +84,16 @@ describe('creating a campaign', () => {
 
 describe('opening a campaign studio', () => {
   it('switches to the campaign detail view, and back again', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => [
-        { id: '1', name: 'Spring demo push', status: 'draft', destination_url: null, brief: null },
-      ],
+    const fetchMock = vi.fn((url: string) => {
+      if (typeof url === 'string' && url.endsWith('/channels')) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: '1', name: 'Spring demo push', status: 'draft', destination_url: null, brief: null },
+        ],
+      })
     })
     vi.stubGlobal('fetch', fetchMock)
 

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { CampaignDetail } from './components/CampaignDetail'
 import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
+import { useChannelTaxonomy } from './lib/useChannelTaxonomy'
 
 /** The campaign studio's admin surface.
  *
@@ -22,6 +23,11 @@ export default function App() {
   const [destination, setDestination] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Fetched once here, not once per row's `MintLinks` (#84) — the same
+  // one-fetch-per-view sharing `CampaignDetail` already does for
+  // `Pipeline`/`DistributionPack` via this same hook.
+  const channelLookup = useChannelTaxonomy()
 
   function load() {
     listCampaigns()
@@ -125,7 +131,7 @@ export default function App() {
                 <td>{c.status}</td>
                 <td>{c.destination_url ?? '—'}</td>
                 <td>
-                  <MintLinks campaignId={c.id} />
+                  <MintLinks campaignId={c.id} channelLookup={channelLookup} />
                 </td>
                 <td>
                   <button type="button" onClick={() => setSelected(c)}>

--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -16,7 +16,7 @@ import {
  * shape it produces. */
 function makeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
   const byKey = new Map(entries.map((e) => [e.key, e]))
-  return { get: (key) => byKey.get(key), loading }
+  return { get: (key) => byKey.get(key), entries, loading }
 }
 
 describe('SourceList', () => {

--- a/web-admin/src/components/ChannelName.test.tsx
+++ b/web-admin/src/components/ChannelName.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { ChannelTaxonomyEntry } from '../lib/api'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+import { ChannelName } from './ChannelName'
+
+const LINKEDIN_PAID: ChannelTaxonomyEntry = {
+  key: 'linkedin_paid',
+  label: 'LinkedIn ads',
+  motion: 'paid',
+  category: 'social',
+  ad_platform: 'linkedin',
+}
+
+function fakeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
+  const byKey = new Map(entries.map((e) => [e.key, e]))
+  return { get: (key) => byKey.get(key), entries, loading }
+}
+
+describe('ChannelName', () => {
+  it('renders the taxonomy label for a resolved key, never the raw key', () => {
+    render(<ChannelName channelKey="linkedin_paid" suggestedLabel={null} lookup={fakeLookup([LINKEDIN_PAID])} />)
+
+    expect(screen.getByText('LinkedIn ads')).toBeInTheDocument()
+    expect(screen.queryByText('linkedin_paid')).not.toBeInTheDocument()
+  })
+
+  it('shows a neutral placeholder while the taxonomy is still loading, not the bare key', () => {
+    render(<ChannelName channelKey="linkedin_paid" suggestedLabel={null} lookup={fakeLookup([], true)} />)
+
+    expect(screen.getByText(/loading channel/i)).toBeInTheDocument()
+    expect(screen.queryByText('linkedin_paid')).not.toBeInTheDocument()
+  })
+
+  it('marks a proposal (no channel_key yet) as outside the selection, using its suggested label', () => {
+    render(<ChannelName channelKey={null} suggestedLabel="Community meetups" lookup={fakeLookup([])} />)
+
+    expect(screen.getByText('Community meetups')).toBeInTheDocument()
+    expect(screen.getByText(/outside selection/i)).toBeInTheDocument()
+  })
+
+  /** #84/#85's decision on existing free-text rows: minted before the
+   * picker existed (e.g. `"totally made up channel"`, minted on dev during
+   * #84's own repro), these have no taxonomy row and are NOT migrated or
+   * deleted — they are left exactly as this test asserts: visibly marked
+   * unrecognised, never silently dropped from grouping and never rendered
+   * as if the raw value were a real label. Every renderer that shows a
+   * channel goes through this component, so the decision is enforced here
+   * once rather than at each call site. */
+  it('renders a legacy free-text channel as visibly unrecognised, never blank and never as if it were a label', () => {
+    render(
+      <ChannelName
+        channelKey="totally made up channel"
+        suggestedLabel={null}
+        lookup={fakeLookup([LINKEDIN_PAID])}
+      />,
+    )
+
+    expect(screen.getByText('totally made up channel')).toBeInTheDocument()
+    expect(screen.getByText(/unrecognised channel/i)).toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/DistributionPack.test.tsx
+++ b/web-admin/src/components/DistributionPack.test.tsx
@@ -23,7 +23,7 @@ function stubSession(jwt = 'test-jwt') {
  * these tests only need this stub, not a second mocked response. */
 function makeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
   const byKey = new Map(entries.map((e) => [e.key, e]))
-  return { get: (key) => byKey.get(key), loading }
+  return { get: (key) => byKey.get(key), entries, loading }
 }
 
 const LINKEDIN: ChannelTaxonomyEntry = {

--- a/web-admin/src/components/MintLinks.test.tsx
+++ b/web-admin/src/components/MintLinks.test.tsx
@@ -2,7 +2,9 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChannelTaxonomyEntry } from '../lib/api'
 import * as auth from '../lib/auth'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import { MintLinks } from './MintLinks'
 
 afterEach(() => {
@@ -18,6 +20,41 @@ function stubSession(jwt = 'test-jwt') {
 
 const CAMPAIGN = 'b3f1c0de-0000-4000-8000-0000000000ab'
 
+const LINKEDIN_ORGANIC: ChannelTaxonomyEntry = {
+  key: 'linkedin_organic',
+  label: 'LinkedIn — organic',
+  motion: 'organic',
+  category: 'social',
+  ad_platform: null,
+}
+const LINKEDIN_PAID: ChannelTaxonomyEntry = {
+  key: 'linkedin_paid',
+  label: 'LinkedIn ads',
+  motion: 'paid',
+  category: 'social',
+  ad_platform: 'linkedin',
+}
+
+/** A stub taxonomy lookup, matching the shape `useChannelTaxonomy` produces
+ * (`ArtefactBody.test.tsx`/`DistributionPack.test.tsx` use the identical
+ * helper) — `App.tsx` fetches this once and threads it down, so `MintLinks`
+ * itself never calls `listChannels`. */
+function fakeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
+  const byKey = new Map(entries.map((e) => [e.key, e]))
+  return { get: (key) => byKey.get(key), entries, loading }
+}
+
+//: The exact 121-character channel name that overflowed `marketing_link.channel`
+//: on dev (#75, #83's own repro) — kept as the realistic long value for the
+//: variant-overflow test below, rather than a short hand-typed placeholder.
+//: The channel itself can no longer carry a value this long (#84 turned it
+//: into a picker over the taxonomy's short keys), but `variant` is still free
+//: text up to 64 characters, so the exact same shape of 422 — a FastAPI
+//: validation error, `detail` as a list — is still a live, reachable path
+//: through this form.
+const REALISTIC_OVERLONG_VALUE =
+  "Google Search ads (non-brand: terms like 'franchise management software UK', 'franchise operations pricing per location')"
+
 describe('MintLinks', () => {
   it('mints a link and shows the URL to publish', async () => {
     stubSession()
@@ -30,7 +67,7 @@ describe('MintLinks', () => {
           links: [
             {
               id: 'l1',
-              channel: 'linkedin',
+              channel: 'linkedin_organic',
               variant: null,
               is_paid: false,
               url: 'https://dev.tabsii.com/c/tok',
@@ -40,48 +77,134 @@ describe('MintLinks', () => {
       }),
     )
 
-    render(<MintLinks campaignId={CAMPAIGN} />)
-    await user.type(screen.getByLabelText('Channel'), 'linkedin')
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([LINKEDIN_ORGANIC])} />)
+    await user.selectOptions(screen.getByLabelText('Channel'), 'linkedin_organic')
     await user.click(screen.getByRole('button', { name: /mint link/i }))
 
     expect(await screen.findByText('https://dev.tabsii.com/c/tok')).toBeInTheDocument()
   })
 
-  it('posts to the admin app, not generated CRUD, and sends only the channel', async () => {
+  it('posts to the admin app, not generated CRUD, and sends only the selected key', async () => {
     // The token and the destination (carrying utm_campaign) are DERIVED
     // server-side. A caller that could supply either would put back the
-    // hand-typed utm_campaign this whole feature exists to remove.
+    // hand-typed utm_campaign this whole feature exists to remove. Nor does
+    // it send `is_paid` any more (#84) — the server derives it from the
+    // channel's own taxonomy row.
     stubSession()
     const user = userEvent.setup()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ links: [] }) })
     vi.stubGlobal('fetch', fetchMock)
 
-    render(<MintLinks campaignId={CAMPAIGN} />)
-    await user.type(screen.getByLabelText('Channel'), 'instagram')
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([LINKEDIN_ORGANIC])} />)
+    await user.selectOptions(screen.getByLabelText('Channel'), 'linkedin_organic')
     await user.click(screen.getByRole('button', { name: /mint link/i }))
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe(`/api/v1/plugins/marketing/admin/campaigns/${CAMPAIGN}/links`)
     const sent = JSON.parse(init.body as string).links[0]
-    expect(sent).toEqual({ channel: 'instagram', is_paid: false })
+    expect(sent).toEqual({ channel: 'linkedin_organic' })
+    expect(sent.is_paid).toBeUndefined()
     expect(sent.token).toBeUndefined()
     expect(sent.destination_url).toBeUndefined()
   })
 
-  it('explains a 422 as the campaign having no destination', async () => {
+  it('only offers channels from the taxonomy — a non-key value cannot be typed or submitted', async () => {
+    stubSession()
+    render(
+      <MintLinks
+        campaignId={CAMPAIGN}
+        channelLookup={fakeLookup([LINKEDIN_ORGANIC, LINKEDIN_PAID])}
+      />,
+    )
+
+    const select = screen.getByLabelText('Channel') as HTMLSelectElement
+    // A blank placeholder plus exactly the two taxonomy entries — no free-text
+    // input exists on this form for #84's "totally made up channel" to go into.
+    const options = Array.from(select.options).map((o) => o.value)
+    expect(options).toEqual(['', 'linkedin_organic', 'linkedin_paid'])
+  })
+
+  it("shows the channel's own motion, and offers no separate paid checkbox", async () => {
+    // #84: motion lives on the channel now — picking `linkedin_paid` already
+    // says the link is paid, so a second "Paid placement" control would be a
+    // second, independently-wrong answer to the same question.
+    stubSession()
+    const user = userEvent.setup()
+    render(
+      <MintLinks
+        campaignId={CAMPAIGN}
+        channelLookup={fakeLookup([LINKEDIN_ORGANIC, LINKEDIN_PAID])}
+      />,
+    )
+
+    expect(screen.queryByText(/paid placement/i)).not.toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('Channel'), 'linkedin_paid')
+    expect(screen.getByText(/^paid/i)).toBeInTheDocument()
+  })
+
+  it('explains a 422 as the campaign having no destination when nothing else is readable', async () => {
+    // The pre-#83 behaviour, still correct when the body genuinely carries
+    // nothing usable — never silence, but a named fallback rather than a
+    // guess at unstructured text.
     stubSession()
     const user = userEvent.setup()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 422 }))
 
-    render(<MintLinks campaignId={CAMPAIGN} />)
-    await user.type(screen.getByLabelText('Channel'), 'linkedin')
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([LINKEDIN_ORGANIC])} />)
+    await user.selectOptions(screen.getByLabelText('Channel'), 'linkedin_organic')
     await user.click(screen.getByRole('button', { name: /mint link/i }))
 
     expect(await screen.findByText(/no destination URL/i)).toBeInTheDocument()
   })
 
-  it('cannot be submitted without a channel', () => {
-    render(<MintLinks campaignId={CAMPAIGN} />)
+  it('names the field and the constraint on a real FastAPI validation 422, rather than showing nothing (#83)', async () => {
+    // This is the actual defect: a `Field` constraint 422 (here, `variant`
+    // over its 64-character ceiling) has `detail` as a LIST of pydantic
+    // error objects, not the hand-authored string the UI used to assume.
+    // Before the fix this rendered no error at all — not the wrong text,
+    // nothing, which is why the button looked unresponsive.
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: [
+            {
+              type: 'string_too_long',
+              loc: ['body', 'links', 0, 'variant'],
+              msg: 'String should have at most 64 characters',
+            },
+          ],
+        }),
+      }),
+    )
+
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([LINKEDIN_ORGANIC])} />)
+    await user.selectOptions(screen.getByLabelText('Channel'), 'linkedin_organic')
+    await user.type(screen.getByLabelText('Variant (optional)'), REALISTIC_OVERLONG_VALUE)
+    await user.click(screen.getByRole('button', { name: /mint link/i }))
+
+    // Matched on the constraint text alone — "variant" also appears in the
+    // field's own <label>, so a regex naming just the field would ambiguously
+    // match both.
+    const error = await screen.findByText(/64 characters/)
+    expect(error.textContent).toMatch(/variant/i)
+  })
+
+  it('cannot be submitted without a channel selected', () => {
+    stubSession()
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([LINKEDIN_ORGANIC])} />)
     expect(screen.getByRole('button', { name: /mint link/i })).toBeDisabled()
+  })
+
+  it('disables the picker and says so while the taxonomy is still loading', () => {
+    stubSession()
+    render(<MintLinks campaignId={CAMPAIGN} channelLookup={fakeLookup([], true)} />)
+    expect(screen.getByLabelText('Channel')).toBeDisabled()
+    expect(screen.getByText(/loading channels/i)).toBeInTheDocument()
   })
 })

--- a/web-admin/src/components/MintLinks.tsx
+++ b/web-admin/src/components/MintLinks.tsx
@@ -1,23 +1,52 @@
 import { useState } from 'react'
 
 import { mintLinks, type MintedLink } from '../lib/api'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 
 /** Mint tracked links for one campaign, and show the URLs to publish.
  *
- * The operator supplies a channel and, optionally, a variant and whether the
- * link is paid. Everything that makes the link *trackable* — the token, and the
- * destination carrying `utm_campaign` — is derived server-side and deliberately
- * not offered here: a hand-typed `utm_campaign` is precisely what this feature
- * exists to remove.
+ * The operator picks a channel from the seeded taxonomy and, optionally,
+ * types a variant. Everything that makes the link *trackable* — the token,
+ * and the destination carrying `utm_campaign` — is derived server-side and
+ * deliberately not offered here: a hand-typed `utm_campaign` is precisely
+ * what this feature exists to remove.
+ *
+ * #84: this used to be a free-text channel input, so `"totally made up
+ * channel"` minted successfully into the same `marketing_link.channel`
+ * column `pack_routes._ensure_links` fills with taxonomy keys — splitting
+ * one column into two vocabularies written by two paths. A picker makes a
+ * non-key value structurally impossible to submit here, rather than
+ * rejecting one after the fact with nothing telling the operator what the
+ * valid values are (rejecting free text alone would still be a worse form
+ * than today's, per the issue: it would turn a working form into a failing
+ * one without saying what to type instead). `channelLookup` is fetched once
+ * by the caller (`App.tsx`) via `useChannelTaxonomy` and threaded down here
+ * — the same sharing `CampaignDetail` already does for `Pipeline`/
+ * `DistributionPack` — rather than this component fetching its own copy.
+ *
+ * No "Paid placement" checkbox any more, for the same reason: motion now
+ * lives on the channel (#76 increment 2), so picking `linkedin_paid` already
+ * says the link is paid. A second, independently-set checkbox was a second
+ * answer to the same question — `admin_app.mint_links` now derives `is_paid`
+ * from the selected channel's own taxonomy row and does not accept one from
+ * the request at all, so offering the checkbox here would just be a control
+ * the server silently ignores.
  */
-export function MintLinks({ campaignId }: { campaignId: string }) {
-  const [channel, setChannel] = useState('')
+export function MintLinks({
+  campaignId,
+  channelLookup,
+}: {
+  campaignId: string
+  channelLookup: ChannelLookup
+}) {
+  const [channelKey, setChannelKey] = useState('')
   const [variant, setVariant] = useState('')
-  const [isPaid, setIsPaid] = useState(false)
   const [minting, setMinting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [minted, setMinted] = useState<MintedLink[]>([])
   const [copied, setCopied] = useState<string | null>(null)
+
+  const selected = channelLookup.get(channelKey)
 
   async function submit(event: React.FormEvent) {
     event.preventDefault()
@@ -26,13 +55,12 @@ export function MintLinks({ campaignId }: { campaignId: string }) {
     try {
       const links = await mintLinks(campaignId, [
         {
-          channel: channel.trim(),
+          channel: channelKey,
           ...(variant.trim() !== '' ? { variant: variant.trim() } : {}),
-          is_paid: isPaid,
         },
       ])
       setMinted((prev) => [...prev, ...links])
-      setChannel('')
+      setChannelKey('')
       setVariant('')
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e))
@@ -58,12 +86,19 @@ export function MintLinks({ campaignId }: { campaignId: string }) {
     <div className="mint">
       <form onSubmit={submit} aria-label={`Mint a tracked link for ${campaignId}`}>
         <label htmlFor={`channel-${campaignId}`}>Channel</label>
-        <input
+        <select
           id={`channel-${campaignId}`}
-          value={channel}
-          onChange={(e) => setChannel(e.target.value)}
-          placeholder="linkedin"
-        />
+          value={channelKey}
+          onChange={(e) => setChannelKey(e.target.value)}
+          disabled={channelLookup.loading}
+        >
+          <option value="">{channelLookup.loading ? 'Loading channels…' : 'Select a channel'}</option>
+          {channelLookup.entries.map((entry) => (
+            <option key={entry.key} value={entry.key}>
+              {entry.label} ({entry.motion})
+            </option>
+          ))}
+        </select>
 
         <label htmlFor={`variant-${campaignId}`}>Variant (optional)</label>
         <input
@@ -73,12 +108,14 @@ export function MintLinks({ campaignId }: { campaignId: string }) {
           placeholder="a"
         />
 
-        <label className="checkbox">
-          <input type="checkbox" checked={isPaid} onChange={(e) => setIsPaid(e.target.checked)} />
-          Paid placement
-        </label>
+        {selected !== undefined && (
+          <p className="hint">
+            {selected.motion === 'paid' ? 'Paid' : 'Organic'} — set by the channel, not chosen
+            separately.
+          </p>
+        )}
 
-        <button type="submit" disabled={channel.trim() === '' || minting}>
+        <button type="submit" disabled={channelKey === '' || minting}>
           {minting ? 'Minting…' : 'Mint link'}
         </button>
       </form>

--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -23,7 +23,7 @@ const CAMPAIGN = 'c1'
 // itself is `CampaignDetail`'s concern, not `Pipeline`'s (see
 // `CampaignDetail.test.tsx` and `ArtefactBody.test.tsx` for that). An
 // already-resolved empty lookup is enough to satisfy the required prop.
-const EMPTY_LOOKUP: ChannelLookup = { get: () => undefined, loading: false }
+const EMPTY_LOOKUP: ChannelLookup = { get: () => undefined, entries: [], loading: false }
 
 /** A `fetch` stub that answers every stage's GET as "not started yet" (404)
  * unless `artefacts` supplies a row for that kind. */

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -9,6 +9,7 @@ import {
   getResults,
   listCampaigns,
   listChannels,
+  mintLinks,
   parseArtefactBody,
   startResearch,
   updateCampaign,
@@ -199,6 +200,70 @@ describe('pipeline artefacts', () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/plugins/marketing/admin/campaigns/c1/artefacts/channel_plan/approve')
     expect(init.method).toBe('POST')
+  })
+})
+
+describe('mintLinks', () => {
+  it('sends only the channel key (and variant, if given) — no is_paid (#84)', async () => {
+    stubSession('abc123')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ links: [] }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await mintLinks('c1', [{ channel: 'linkedin_organic' }])
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/plugins/marketing/admin/campaigns/c1/links')
+    expect(JSON.parse(init.body as string)).toEqual({ links: [{ channel: 'linkedin_organic' }] })
+  })
+
+  it('surfaces a FastAPI validation error verbatim from the real API shape (#83)', async () => {
+    // The exact response the API returns for an over-long channel (issue
+    // #83's own repro): `detail` is a LIST of pydantic error objects, not
+    // the hand-authored string every other endpoint returns. This is a
+    // direct API caller's route to the bug — the web-admin picker (#84)
+    // makes an over-long CHANNEL unreachable through the form, but this is
+    // the shape the whole plugin can return, which is why the fix lives in
+    // `detailMessage`/`onError`, not in one component.
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: [
+            {
+              type: 'string_too_long',
+              loc: ['body', 'links', 0, 'channel'],
+              msg: 'String should have at most 64 characters',
+              ctx: { max_length: 64 },
+            },
+          ],
+        }),
+      }),
+    )
+
+    await expect(mintLinks('c1', [{ channel: 'x'.repeat(80) }])).rejects.toThrow(
+      /channel: String should have at most 64 characters \(422\)/,
+    )
+  })
+
+  it('surfaces the hand-authored string detail for an unrecognised channel key (#84)', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: "Not a recognised channel key: totally made up channel. Valid channel keys: linkedin_organic.",
+        }),
+      }),
+    )
+
+    await expect(mintLinks('c1', [{ channel: 'totally made up channel' }])).rejects.toThrow(
+      /not a recognised channel key/i,
+    )
   })
 })
 

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -57,17 +57,56 @@ async function getIdToken(): Promise<string | null> {
   return session?.getIdToken().getJwtToken() ?? null
 }
 
+/** One entry of a FastAPI/pydantic validation-error list — the shape `detail`
+ * takes on a 422 raised by request-body validation itself (a `Field`
+ * constraint), rather than by a plugin's own `raise HTTPException(...)`. See
+ * {@link detailMessage}'s docstring for why this is a second shape `detail`
+ * takes, not a malformed instance of the string one. */
+interface ValidationErrorItem {
+  loc?: unknown[]
+  msg?: string
+}
+
+/** Turns a FastAPI validation-error list into one operator-readable line per
+ * error — the field name (the last, most specific segment of `loc`, e.g.
+ * `["body","links",0,"channel"]` → `channel`) and pydantic's own `msg`
+ * ("String should have at most 64 characters"), which between them are
+ * exactly "the field and the constraint" #83 asks the UI to show. `null`
+ * only if every item is unusable (missing `msg`), so the caller still has a
+ * status-coded fallback rather than an empty string. */
+function formatValidationErrors(items: unknown[]): string | null {
+  const lines = items
+    .map((item): string | null => {
+      if (item === null || typeof item !== 'object') return null
+      const { loc, msg } = item as ValidationErrorItem
+      if (typeof msg !== 'string') return null
+      const field = Array.isArray(loc) && loc.length > 0 ? String(loc[loc.length - 1]) : null
+      return field !== null ? `${field}: ${msg}` : msg
+    })
+    .filter((line): line is string => line !== null)
+  return lines.length > 0 ? lines.join('; ') : null
+}
+
+/** Extracts an operator-readable reason from a failed response's body, or
+ * `null` if there is nothing safe to show.
+ *
+ * `detail` takes TWO shapes here, both genuine, and conflating them is #83:
+ * a **string** for every `HTTPException` this plugin raises itself (hand-
+ * authored specifically to be read), and a **list** of
+ * {@link ValidationErrorItem} for a 422 FastAPI raises on its own, before a
+ * route body ever runs, when a `Field` constraint rejects the request (e.g.
+ * `channel: str = Field(max_length=64)` on a channel over that length). The
+ * first version of this function handled only the string case, so a
+ * validation 422 fell through silently — not a wrong message, no message,
+ * because nothing here recognised the shape at all.
+ */
 async function detailMessage(response: Response): Promise<string | null> {
   try {
     const body: unknown = await response.json()
-    if (
-      body !== null &&
-      typeof body === 'object' &&
-      'detail' in body &&
-      typeof (body as { detail?: unknown }).detail === 'string'
-    ) {
-      return (body as { detail: string }).detail
-    }
+    if (body === null || typeof body !== 'object' || !('detail' in body)) return null
+    const detail = (body as { detail?: unknown }).detail
+    if (typeof detail === 'string') return detail
+    if (Array.isArray(detail)) return formatValidationErrors(detail)
   } catch {
     // Not JSON, or an empty body — nothing safe to extract, fall through to a
     // generic message rather than guessing at unstructured text.
@@ -83,14 +122,21 @@ async function detailMessage(response: Response): Promise<string | null> {
  * behind the hook `api-core.ts` added specifically so they would not have to
  * collapse into a generic status message.
  *
- * `createCampaign`/`listCampaigns`/`mintLinks` hit Core's *generic* CRUD, whose
- * 403 text ("Administrator access required") is Core's own wording, not this
- * plugin's — the tests deliberately do not surface it verbatim, so those three
- * keep their own hand-authored messages rather than reading `detail`.
- * Everything else hits THIS plugin's own admin routes, whose `detail` text is
- * hand-authored specifically to be read by the operator — extracting and
- * showing it is the point (see the file-level comment below for the fuller
- * version of this split).
+ * `createCampaign`/`listCampaigns`/`mintLinks` hit Core's *generic* CRUD (or,
+ * for `mintLinks`, the host's own `group_gate` ahead of it), whose 403 text
+ * ("Administrator access required") is Core's own wording, not this plugin's
+ * — the tests deliberately do not surface it verbatim, so those three keep
+ * their own hand-authored 403 message rather than reading `detail`.
+ * `mintLinks`'s 422, unlike its 403, is NOT generic: it is either this
+ * plugin's own hand-authored `HTTPException` (`admin_app.mint_links`'s "no
+ * destination_url" and channel-taxonomy checks) or FastAPI's own validation
+ * error for a `Field` constraint on the request body (both plugin-specific —
+ * `MintRequest` is this plugin's own model), so it reads `detail` the same
+ * way the `default` branch below does (#83 — the earlier hardcoded 422
+ * message discarded both). Everything else hits THIS plugin's own admin
+ * routes, whose `detail` text is hand-authored specifically to be read by the
+ * operator — extracting and showing it is the point (see the file-level
+ * comment below for the fuller version of this split).
  */
 async function onError(response: Response, context: string | undefined): Promise<never> {
   if (response.status === 401) {
@@ -113,6 +159,18 @@ async function onError(response: Response, context: string | undefined): Promise
         throw new Error('you need the admin role to mint links (403)')
       }
       if (response.status === 422) {
+        // Reads `detail` rather than assuming what a 422 here means (#83):
+        // it is one of "no destination_url" (a hand-authored string), an
+        // unrecognised channel key (#84, also a string), or a `Field`
+        // constraint like `channel`'s 64-character ceiling (a validation
+        // list) — three different causes that used to render the same
+        // hardcoded sentence regardless of which one actually happened.
+        // Falls back to the pre-#83 wording only when nothing readable came
+        // back at all, so a genuinely bodyless 422 still says something.
+        const detail = await detailMessage(response)
+        if (detail !== null) {
+          throw new Error(`${detail} (422)`)
+        }
         throw new Error('this campaign has no destination URL, so its links would lead nowhere')
       }
       if (response.status === 503) {
@@ -171,14 +229,20 @@ export interface MintedLink {
 
 /** Mint tracked links for a campaign.
  *
- * The caller supplies only a channel (and optionally a variant, and whether it
- * is paid). The token and the destination — including `utm_campaign`, which is
- * the campaign's own id — are derived server-side and cannot be supplied. That
- * is the point of the whole milestone, so the form does not offer them.
+ * The caller supplies a channel **key** from the taxonomy (`listChannels`),
+ * and optionally a variant. The token and the destination — including
+ * `utm_campaign`, which is the campaign's own id — are derived server-side
+ * and cannot be supplied. That is the point of the whole milestone, so the
+ * form does not offer them.
+ *
+ * No `is_paid` parameter (#84): motion lives on the channel now, so the
+ * server derives `is_paid` from the selected channel's own taxonomy row
+ * rather than trusting a second, independently-settable flag that could
+ * disagree with it.
  */
 export async function mintLinks(
   campaignId: string,
-  links: { channel: string; variant?: string; is_paid?: boolean }[],
+  links: { channel: string; variant?: string }[],
 ): Promise<MintedLink[]> {
   const body = await request<{ links?: MintedLink[] }>(
     'POST',

--- a/web-admin/src/lib/useChannelTaxonomy.ts
+++ b/web-admin/src/lib/useChannelTaxonomy.ts
@@ -10,6 +10,13 @@ import { listChannels, type ChannelTaxonomyEntry } from './api'
  * fallback. */
 export interface ChannelLookup {
   get(key: string): ChannelTaxonomyEntry | undefined
+  /** Every seeded/instance-added row, for a component that needs to OFFER
+   * the taxonomy rather than just resolve one key already in hand — `Mint
+   * Links`' channel picker (#84) is the first such caller. Same array
+   * identity across renders that don't change `entries` (both come from the
+   * one `useMemo` below), so a picker can depend on it without re-rendering
+   * every time its parent does. */
+  entries: ChannelTaxonomyEntry[]
   loading: boolean
 }
 
@@ -43,13 +50,18 @@ export function useChannelTaxonomy(): ChannelLookup {
     }
   }, [])
 
-  const byKey = useMemo(() => new Map((entries ?? []).map((e) => [e.key, e])), [entries])
+  // One shared `[]` for the "not loaded yet" case, not a fresh literal per
+  // render — a picker keying off `entries` (e.g. in its own `useMemo`)
+  // would otherwise see a "changed" array every render while still loading.
+  const resolved = useMemo(() => entries ?? [], [entries])
+  const byKey = useMemo(() => new Map(resolved.map((e) => [e.key, e])), [resolved])
 
   return useMemo(
     () => ({
       get: (key: string) => byKey.get(key),
+      entries: resolved,
       loading: entries === null,
     }),
-    [byKey, entries],
+    [byKey, resolved, entries],
   )
 }


### PR DESCRIPTION
## What changed

Both issues live in `web-admin/src/components/MintLinks.tsx` and would have collided as separate PRs, so one PR here.

### #83 — mint form fails silently on a 422

`detailMessage` (`web-admin/src/lib/api.ts`) only handled a string `detail`. FastAPI's own validation errors (raised by a `Field` constraint, before the route body ever runs) put a **list** of `{loc, msg}` objects there instead — so any such 422 rendered nothing. Confirmed the cause before fixing: `mintLinks`'s `onError` branch didn't even call `detailMessage` for a 422, it hardcoded "this campaign has no destination_url" for **every** 422 regardless of cause.

Fixed in the shared error path, not the component:
- `detailMessage` now extracts a readable line per validation-error item (`field: message`), or the string as before.
- `mintLinks`'s 422 branch now reads `detail` like the `default` branch already did, falling back to the old hardcoded sentence only when nothing is readable at all (kept for a genuinely bodyless 422).

A too-long **channel** can no longer reach this path through the UI (see #84's picker below), but a too-long **variant** still can — the added component test exercises that live, realistic path with the real repro payload shape from the issue, and a fail-first check confirmed the old code rendered the wrong (misleading, not blank) fallback text for it.

**No other agent needed the shared helper** — I own `detailMessage`/`onError`/`throwForResponse` end to end in this PR; flagging per the dispatch brief in case #85's PR touches the same file, but I did not coordinate with another session since this PR was scoped, built and pushed as one unit.

### #84 — mint accepts arbitrary free text into a taxonomy column

Replaced the free-text channel `<input>` with a `<select>` over `useChannelTaxonomy` (already fetched once per view for the artefact renderers — reused here via `App.tsx`, not a second fetch path). A non-key value is now structurally impossible to submit through this form.

- `admin_app.mint_links` also validates server-side against the tenant's own `marketing_channel` rows (not a hardcoded list) and returns a 422 naming both the offending value and the valid keys — for a caller that bypasses the picker (e.g. a direct API call).
- **`is_paid` reconciled with `motion`, in favour of `motion`.** Picking `linkedin_paid` already says the link is paid; the old "Paid placement" checkbox was a second, independently-settable answer to the same question. Removed the checkbox. `MintRequest` no longer accepts `is_paid` from the client at all — `mint_links` derives it from the selected channel's own taxonomy row. A legacy caller that still sends `is_paid` is not rejected for it (pydantic ignores unknown fields), just not consulted; a test proves a caller claiming `is_paid: true` for an organic channel is overruled.
- **Existing free-text rows** (including `"totally made up channel"` from the issue's own repro) are left as-is — not migrated, not deleted. They already render through `ChannelName`'s existing "unrecognised channel" fallback wherever a channel is shown (results/pack views), which had **no test coverage at all** before this PR (`ChannelName.test.tsx` is new). I judged an automatic mapping too risky (nothing can reliably map arbitrary free text to a taxonomy key) and deleting tenant data out of scope for a satellite code change.

## Tests

- `tests/test_marketing_mint_route.py`: taxonomy validation (422 naming the value and the valid keys), `is_paid` derivation both directions (organic channel overrides a caller's `is_paid: true`; paid channel sets `is_paid: true` with no flag sent). Existing fixtures switched from free-text ("linkedin"/"instagram") to real seeded keys, since the route now rejects the former.
- `tests/test_marketing_dual_auth_wiring.py`: updated for the new `/channels` call `mint_links` now makes.
- `web-admin/src/lib/api.test.ts`: `mintLinks` unit coverage (didn't exist before) — the exact validation-error shape from #83's own repro, and the hand-authored unrecognised-channel string from #84.
- `web-admin/src/components/MintLinks.test.tsx`: picker submits a key and nothing else (no `is_paid`); taxonomy is the only source of options; motion hint replaces the checkbox; 422 fallback still works with no body; **realistic** 422 (list-shaped `detail`) on an over-long variant renders the field and constraint — proved fail-first (reverted the `api.ts` fix, watched this go red on the *old* hardcoded-nowhere-URL text rather than blank, restored the fix, green again).
- `web-admin/src/components/ChannelName.test.tsx`: new — all four render states, including the legacy/unrecognised-channel one #84 asks to be decided and tested.

Ran `uv run pytest` (428 passed), `uv run ruff format`/`check`, `pnpm typecheck`, `pnpm lint`, `pnpm vitest run` (85 passed), and `pnpm build` in `web-admin/`.

## Not verified

No deployed environment was exercised — this is a fresh worktree with local test/lint/build gates only, no click-through against dev. The pre-push `verify` gate (ruff, pyright, pytest, terraform-fmt, lint/typecheck/test for web-admin) passed.

Closes #83
Closes #84
