### PR TITLE
fix(pipeline): ground the citation guard in the run's annotations, not just the model's tool call

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -428,7 +428,16 @@ class _CoreAgentGateway:
                 return None
             raise
         return pipeline.AgentRunView(
-            id=run["id"], status=run["status"], messages=run.get("messages") or []
+            id=run["id"],
+            status=run["status"],
+            messages=run.get("messages") or [],
+            # Core's `AgentRunResponse.annotations` (biffo-template#1528/#1530):
+            # `run.get(...)` alone would collapse a genuinely absent key to the
+            # same `None` as an explicit JSON `null`, which is exactly right
+            # here — both mean "not known", never "confirmed zero". Do NOT
+            # coerce to `[]`: that would make an unknown run read as a proven
+            # empty retrieval, which is the exact ambiguity #82 exists to remove.
+            annotations=run.get("annotations"),
         )
 
 

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -81,13 +81,28 @@ class PipelineError(Exception):
 
 
 class NoCitationsError(PipelineError):
-    """A research or positioning run produced content with zero citations.
+    """A research or positioning run produced content with zero citations —
+    zero *in the model's structured output*, i.e. ``sources`` across the
+    artefact. That is a fact about what the model transcribed, not about what
+    retrieval actually returned, and issue #82 is precisely the gap between
+    the two: a model can be shown real search results and simply not retype
+    them into its tool call.
 
-    The milestone's guard. A research or positioning agent whose live web
-    results (or whose grounding research) is unavailable does not error — it
-    fabricates a plausible, confident, well-structured document with nothing
-    behind it. A run that names zero URLs across its **entire** output fails
-    outright rather than being proposed to a human as if it were evidenced.
+    The milestone's guard is still right to fail in that case — an artefact
+    with no per-claim attribution is not something a human should be shown as
+    evidenced, whatever retrieval found — but the message now grounds itself
+    in ``AgentRunView.annotations`` (the runtime's own record of what
+    retrieval returned, biffo-template#1528/#1530) so the three distinguishable
+    causes read as different problems needing different responses:
+
+    - ``sources`` empty, ``annotations`` non-empty — retrieval worked, the
+      model didn't transcribe it. Transient; retrying the stage is likely to
+      produce a citable result without anything else changing.
+    - ``sources`` empty, ``annotations == []`` — retrieval genuinely found
+      nothing. Retrying will not help; the brief needs to change.
+    - ``sources`` empty, ``annotations is None`` — this run predates the
+      annotations column or was never ``:online``, so whether retrieval
+      happened at all is simply not known. Said plainly rather than guessed.
     """
 
 
@@ -167,23 +182,65 @@ def _total_citations(*source_lists: list[Source]) -> int:
     return sum(len(sources) for sources in source_lists)
 
 
+def _no_citations_message(
+    *, base_message: str, retry_hint: str, annotations: list[dict[str, Any]] | None
+) -> str:
+    """Ground :class:`NoCitationsError`'s message in what the run's
+    ``annotations`` (issue #82) say about retrieval, so the three cases in
+    that class's docstring read as distinguishable problems rather than the
+    identical, and for one of them false, "fetched zero URLs" sentence.
+
+    ``base_message`` is the case-specific "cited nothing" sentence each
+    caller already had — unchanged wording, and still the correct message
+    for the ``annotations == []`` case, since that IS a genuine zero-URL
+    retrieval. The other two cases replace it entirely rather than append to
+    it: appending "but retrieval actually succeeded" after a sentence that
+    opens by asserting the opposite reads as contradictory, not corrective.
+    """
+    if annotations:
+        # Deliberately NOT salvaged into `sources` here or anywhere upstream
+        # (see this module's own docstring / the PR that added this check):
+        # an annotation carries no claim mapping, so attaching one to a
+        # finding/segment/channel would fabricate the very attribution this
+        # guard exists to guarantee. The only honest response to "retrieval
+        # worked, the model didn't transcribe it" is to fail and say so.
+        n = len(annotations)
+        return (
+            f"Retrieval succeeded — {n} source{'s' if n != 1 else ''} were found — but "
+            f"the model did not cite any of them in its output. This is a transcription "
+            f"failure, not a failed search: try running {retry_hint} again."
+        )
+    if annotations is None:
+        return (
+            f"{base_message} (This run predates citation tracking, or was not a "
+            "grounded run, so whether retrieval itself found anything is not known — "
+            "do not read this as a proven zero-URL retrieval.)"
+        )
+    return base_message  # annotations == []: retrieval genuinely found nothing
+
+
 def _extract_cited_artefact[T: BaseModel](
     messages: list[dict[str, Any]],
     *,
+    annotations: list[dict[str, Any]] | None,
     tool_name: str,
     model_cls: type[T],
     citation_groups: Callable[[T], list[list[Source]]],
     malformed_message: str,
     no_citations_message: str,
+    retry_hint: str,
 ) -> T:
     """The shared skeleton behind :func:`extract_research_synthesis`,
-    :func:`extract_positioning` and :func:`extract_channel_plan`: fetch the
-    last call to ``tool_name``, validate it against ``model_cls``, and
-    enforce the zero-citation guard over ``citation_groups(result)``.
+    :func:`extract_positioning`, :func:`extract_channel_plan` and
+    :func:`extract_copy`: fetch the last call to ``tool_name``, validate it
+    against ``model_cls``, and enforce the zero-citation guard over
+    ``citation_groups(result)`` — grounded in ``annotations``, the run's own
+    record of what retrieval returned (issue #82), not just what the model's
+    tool call repeated of it.
 
-    Kept as one implementation rather than three near-identical copies
+    Kept as one implementation rather than four near-identical copies
     precisely because the guard is "the milestone, not a detail" (this
-    module's docstring) — three copies is three places a change to the guard
+    module's docstring) — four copies is four places a change to the guard
     itself (or a fix to it) can drift out of step.
     """
     data = _tool_call_arguments(messages, tool_name)
@@ -196,11 +253,17 @@ def _extract_cited_artefact[T: BaseModel](
 
     total = _total_citations(*citation_groups(result))
     if total == 0:
-        raise NoCitationsError(no_citations_message)
+        raise NoCitationsError(
+            _no_citations_message(
+                base_message=no_citations_message, retry_hint=retry_hint, annotations=annotations
+            )
+        )
     return result
 
 
-def extract_research_synthesis(messages: list[dict[str, Any]]) -> ResearchSynthesis:
+def extract_research_synthesis(
+    messages: list[dict[str, Any]], *, annotations: list[dict[str, Any]] | None = None
+) -> ResearchSynthesis:
     """The research-synthesis agent's output, or a hard failure.
 
     Raises :class:`MalformedOutputError` when the tool call is missing or
@@ -208,9 +271,15 @@ def extract_research_synthesis(messages: list[dict[str, Any]]) -> ResearchSynthe
     is well-formed but cites nothing at all. Unlike a single research angle
     finding little, there is no redundancy at the synthesis step: nothing else
     produces the ``research`` artefact, so there is nothing to degrade to.
+
+    ``annotations`` is the run's own record of what retrieval returned
+    (:attr:`AgentRunView.annotations`, issue #82) — defaulted to ``None`` so
+    a direct call (as every existing test makes) still works, reading as "not
+    known" rather than "definitely nothing", which is the correct default.
     """
     return _extract_cited_artefact(
         messages,
+        annotations=annotations,
         tool_name=RESEARCH_SYNTHESIS_TOOL_NAME,
         model_cls=ResearchSynthesis,
         citation_groups=lambda r: [f.sources for f in r.findings],
@@ -221,16 +290,21 @@ def extract_research_synthesis(messages: list[dict[str, Any]]) -> ResearchSynthe
             "The research run fetched zero URLs. Nothing was found to cite, so no "
             "artefact was produced — try running research again."
         ),
+        retry_hint="research",
     )
 
 
-def extract_positioning(messages: list[dict[str, Any]]) -> Positioning:
+def extract_positioning(
+    messages: list[dict[str, Any]], *, annotations: list[dict[str, Any]] | None = None
+) -> Positioning:
     """The positioning agent's output, or a hard failure — the same two
     failure modes as :func:`extract_research_synthesis`, for the same reason:
     a positioning claim is exactly as fabricable as a research finding, and an
-    operator reviewing it needs the same guarantee."""
+    operator reviewing it needs the same guarantee. ``annotations`` — see
+    :func:`extract_research_synthesis`."""
     return _extract_cited_artefact(
         messages,
+        annotations=annotations,
         tool_name=POSITIONING_TOOL_NAME,
         model_cls=Positioning,
         citation_groups=lambda r: [
@@ -243,18 +317,23 @@ def extract_positioning(messages: list[dict[str, Any]]) -> Positioning:
             "The positioning run cited nothing from the approved research. Nothing "
             "was produced — try running positioning again."
         ),
+        retry_hint="positioning",
     )
 
 
 def extract_channel_plan(
-    messages: list[dict[str, Any]], *, taxonomy: dict[str, Literal["organic", "paid"]]
+    messages: list[dict[str, Any]],
+    *,
+    taxonomy: dict[str, Literal["organic", "paid"]],
+    annotations: list[dict[str, Any]] | None = None,
 ) -> ChannelPlan:
     """The channel-plan agent's output, or a hard failure — the same two
     failure modes as :func:`extract_positioning`, for the same reason (M4,
     issue #3): a channel recommendation is exactly as fabricable as a
     positioning claim, and arguably the most confident-sounding one in the
     whole pipeline, because channel advice reads as generic wisdom whether or
-    not anyone researched it.
+    not anyone researched it. ``annotations`` — see
+    :func:`extract_research_synthesis`.
 
     ``taxonomy`` is ``{channel_key: motion}`` for exactly the taxonomy this
     run was shown (#76 increment 2) — stored on the artefact at start time,
@@ -268,6 +347,7 @@ def extract_channel_plan(
     """
     plan = _extract_cited_artefact(
         messages,
+        annotations=annotations,
         tool_name=CHANNEL_PLAN_TOOL_NAME,
         model_cls=ChannelPlan,
         citation_groups=lambda r: [c.sources for c in r.channels],
@@ -276,6 +356,7 @@ def extract_channel_plan(
             "The channel-plan run cited nothing from the approved positioning. Nothing "
             "was produced — try running channel planning again."
         ),
+        retry_hint="channel planning",
     )
     for recommendation in plan.channels:
         if recommendation.channel_key is None:
@@ -290,13 +371,17 @@ def extract_channel_plan(
 
 
 def extract_copy(
-    messages: list[dict[str, Any]], *, channel_plan_channels: dict[str, Literal["organic", "paid"]]
+    messages: list[dict[str, Any]],
+    *,
+    channel_plan_channels: dict[str, Literal["organic", "paid"]],
+    annotations: list[dict[str, Any]] | None = None,
 ) -> CopySet:
     """The copy agent's output, or a hard failure — the same two failure
     modes as :func:`extract_channel_plan` (M5, issue #4): copy is exactly as
     fabricable as a channel recommendation, and arguably the most
     publishable-looking one in the whole pipeline, since prose reads as
-    correct whether or not any pillar or CTA actually backs it.
+    correct whether or not any pillar or CTA actually backs it. ``annotations``
+    — see :func:`extract_research_synthesis`.
 
     ``channel_plan_channels`` is ``{channel_key: motion}`` for exactly the
     approved channel plan entries that themselves carried a ``channel_key``
@@ -310,6 +395,7 @@ def extract_copy(
     """
     result = _extract_cited_artefact(
         messages,
+        annotations=annotations,
         tool_name=COPY_TOOL_NAME,
         model_cls=CopySet,
         citation_groups=lambda r: [c.sources for c in r.channels],
@@ -318,6 +404,7 @@ def extract_copy(
             "The copy run cited nothing from the approved positioning. Nothing "
             "was produced — try running copy generation again."
         ),
+        retry_hint="copy generation",
     )
     for channel_copy in result.channels:
         if channel_copy.channel_key not in channel_plan_channels:
@@ -384,11 +471,28 @@ RUN_TERMINAL = frozenset({RUN_COMPLETED, RUN_FAILED})
 @dataclass(frozen=True)
 class AgentRunView:
     """A read of an async agent run — just what this pipeline needs to decide
-    whether it is done and to extract its output-tool call."""
+    whether it is done and to extract its output-tool call.
+
+    ``annotations`` is Core's ``AgentRunResponse.annotations`` (biffo-template
+    #1528/#1530): the ``:online`` grounding citations the *runtime* recorded on
+    the run, independent of whatever the model chose to retype into its
+    structured tool call. It is a fact about the run, not an inference from
+    ``messages`` — which is exactly why the citation guard (#82) reads it
+    instead of, or as well as, ``messages``. Three states, each meaning
+    something different and none collapsible into another:
+
+    - ``None`` — this run predates the annotations column, or was never an
+      ``:online`` run. Whether retrieval happened is simply not known.
+    - ``[]`` — the run WAS asked to ground, and retrieval genuinely returned
+      nothing to cite.
+    - non-empty — retrieval succeeded; the run has evidence, whatever the
+      model's tool call did or didn't repeat of it.
+    """
 
     id: str
     status: str
     messages: list[dict[str, Any]] = field(default_factory=list)
+    annotations: list[dict[str, Any]] | None = None
 
     @property
     def is_terminal(self) -> bool:
@@ -500,7 +604,9 @@ async def advance_research(
             return None  # synthesis is running; nothing to do yet
         if not synthesis_run.succeeded:
             raise RunNotSucceededError("The research-synthesis run did not complete successfully.")
-        return extract_research_synthesis(synthesis_run.messages)
+        return extract_research_synthesis(
+            synthesis_run.messages, annotations=synthesis_run.annotations
+        )
 
     # No synthesis run yet: either research is still in flight (the normal
     # case), or every research run has already failed and the engine correctly
@@ -563,7 +669,7 @@ async def advance_positioning(gateway: AgentGateway, *, run_id: str) -> Position
         return None
     if not view.succeeded:
         raise RunNotSucceededError("The positioning run did not complete successfully.")
-    return extract_positioning(view.messages)
+    return extract_positioning(view.messages, annotations=view.annotations)
 
 
 async def start_channel_plan(
@@ -617,7 +723,7 @@ async def advance_channel_plan(
         return None
     if not view.succeeded:
         raise RunNotSucceededError("The channel-plan run did not complete successfully.")
-    return extract_channel_plan(view.messages, taxonomy=taxonomy)
+    return extract_channel_plan(view.messages, taxonomy=taxonomy, annotations=view.annotations)
 
 
 async def start_copy(
@@ -662,7 +768,9 @@ async def advance_copy(
         return None
     if not view.succeeded:
         raise RunNotSucceededError("The copy run did not complete successfully.")
-    return extract_copy(view.messages, channel_plan_channels=channel_plan_channels)
+    return extract_copy(
+        view.messages, channel_plan_channels=channel_plan_channels, annotations=view.annotations
+    )
 
 
 def channel_plan_channel_map(

--- a/tests/test_marketing_agent_gateway.py
+++ b/tests/test_marketing_agent_gateway.py
@@ -1,0 +1,110 @@
+"""`_CoreAgentGateway` — the seam between Core's raw `AgentRunResponse` JSON
+and `pipeline.AgentRunView` (issue #82).
+
+The citation guard's fix is only real if the field it reads actually arrives
+here: `pipeline.py`'s `AgentRunView.annotations` is inert unless whatever
+builds a view from a Core response carries it across. This is that boundary,
+and until this issue it had no dedicated test at all — every existing
+route-level test overrides `get_agent_gateway` with a fake `AgentGateway`
+(`test_marketing_pipeline_routes.py`), which bypasses `_CoreAgentGateway`
+entirely.
+
+A minimal duck-typed fake client is enough: `_CoreAgentGateway` only ever
+calls `.get`/`.post` on it (`admin_app.py`'s own comment on `_CoreAgentGateway
+.__init__`), so it does not need to be a real `BiffoAPIClient` at runtime —
+`_CoreAgentGateway.__init__` is typed against the concrete class regardless
+(so callers get its actual `.get`/`.post` signatures), which is why each
+construction below carries `# type: ignore[arg-type]` rather than widening
+that signature for one test file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from marketing import admin_app
+
+
+class _FakeClient:
+    """Records nothing; just returns whatever `Any` response is queued,
+    mirroring `BiffoAPIClient.get`'s return type (parsed JSON, untyped)."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        del path, params
+        return self._response
+
+
+_BASE_RUN: dict[str, Any] = {
+    "id": "run-1",
+    "status": "completed",
+    "messages": [{"role": "assistant", "content": "..."}],
+}
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_carries_non_empty_annotations_onto_the_view() -> None:
+    """The shape Core actually sends — `AgentRunResponse.annotations`
+    (biffo-template#1528/#1530) is `list[dict[str, Any]] | None`, and a
+    non-empty entry has exactly the `Annotation.to_dict()` shape
+    (`agent_runtime/openrouter.py`): `type`/`url`/`title`, nothing else."""
+    run = {
+        **_BASE_RUN,
+        "annotations": [
+            {"type": "url_citation", "url": "https://example.com/a", "title": "A"},
+            {"type": "url_citation", "url": "https://example.com/b", "title": "B"},
+        ],
+    }
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.annotations == run["annotations"]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_carries_an_explicit_empty_annotations_list() -> None:
+    """`[]` — the run WAS `:online` and retrieval genuinely found nothing.
+    Must arrive on the view as `[]`, not be coerced to `None` (which would
+    make a proven-empty retrieval read as merely unknown)."""
+    run = {**_BASE_RUN, "annotations": []}
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.annotations == []
+    assert view.annotations is not None
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_carries_null_annotations_as_none() -> None:
+    """An explicit JSON `null` — Core sends this for a pre-#1528 run or one
+    that was never `:online`. Must read as `None` ("not known")."""
+    run = {**_BASE_RUN, "annotations": None}
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.annotations is None
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_defaults_a_missing_annotations_key_to_none() -> None:
+    """An older Core build's response predating the `annotations` field
+    entirely (the key is simply absent, not `null`) must read identically to
+    an explicit `null` — both mean "not known", never "confirmed zero"."""
+    run = dict(_BASE_RUN)
+    assert "annotations" not in run
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.annotations is None

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -90,6 +90,157 @@ def test_copy_with_no_channels_raises_no_citations() -> None:
         extract_copy(messages, channel_plan_channels={})
 
 
+# ── The guard's message is grounded in `annotations`, not just `sources`
+# (issue #82) ─────────────────────────────────────────────────────────────────
+#
+# OpenRouter returns `:online` grounding citations out of band, on
+# `message.annotations` (biffo-template#1528/#1530) — a fact about the RUN,
+# independent of whatever the model chose to retype into its structured tool
+# call. Before this, a run that genuinely retrieved evidence and a run that
+# never retrieved anything were indistinguishable the moment the model failed
+# to transcribe: both produced empty `sources` and the identical "fetched
+# zero URLs" message, which is false for the first. `annotations` is what
+# makes the two tell apart. `extract_research_synthesis` stands in for all
+# four `_extract_cited_artefact` callers below since they share one
+# implementation — proven directly on it, then spot-checked on the other
+# three so a change to any one extractor's wiring cannot silently drop the
+# `annotations` argument.
+
+_A_URL_CITATION = {"type": "url_citation", "url": "https://example.com/found", "title": "Found"}
+
+
+def test_empty_sources_with_null_annotations_reads_as_not_known_not_as_zero() -> None:
+    """`annotations=None` — this run predates the annotations column, or was
+    never a grounded (`:online`) run. The guard still fails (empty `sources`
+    is still empty `sources`; this is not a new pass condition), but the
+    message must not claim retrieval fetched zero URLs, because that is not
+    established. Deliberately the SAME failure as before this issue's fix —
+    a pre-upgrade artefact is not retroactively treated as a proven-zero
+    retrieval, only described honestly as an unknown one."""
+    messages = _tool_call(
+        "submit_research_synthesis", {"summary": "Nothing usable was found.", "findings": []}
+    )
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_research_synthesis(messages, annotations=None)
+
+    detail = str(excinfo.value)
+    assert "not known" in detail
+    assert "fetched zero URLs" in detail  # the base sentence is kept, not replaced
+
+
+def test_empty_sources_with_empty_annotations_is_a_genuine_zero_url_retrieval() -> None:
+    """`annotations=[]` — the run WAS asked to ground and retrieval genuinely
+    found nothing. This is the one case where the original "fetched zero
+    URLs, try again" message is fully accurate, so it is used unchanged, and
+    retrying is explicitly not promised to help."""
+    messages = _tool_call(
+        "submit_research_synthesis", {"summary": "Nothing usable was found.", "findings": []}
+    )
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_research_synthesis(messages, annotations=[])
+
+    detail = str(excinfo.value)
+    assert detail == (
+        "The research run fetched zero URLs. Nothing was found to cite, so no "
+        "artefact was produced — try running research again."
+    )
+
+
+def test_empty_sources_with_non_empty_annotations_is_a_transcription_not_a_dead_search() -> None:
+    """`annotations` non-empty, `sources` empty — the defect issue #82 reports:
+    retrieval worked, the model did not transcribe it. This must NOT read as
+    "fetched zero URLs" (false — it fetched some) and must be phrased as
+    transient, since retrying is likely to produce a citable result without
+    the brief changing at all."""
+    messages = _tool_call(
+        "submit_research_synthesis", {"summary": "Nothing usable was found.", "findings": []}
+    )
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_research_synthesis(messages, annotations=[_A_URL_CITATION])
+
+    detail = str(excinfo.value)
+    assert "fetched zero URLs" not in detail
+    assert "1 source" in detail
+    assert "transcription failure" in detail
+    assert "try running research again" in detail
+
+
+def test_the_three_annotation_cases_produce_three_different_messages() -> None:
+    """The whole point: an operator (or a log line) must be able to tell the
+    three cases apart without reading code. Guards against a future edit that
+    reconverges them onto one message string."""
+    messages = _tool_call(
+        "submit_research_synthesis", {"summary": "Nothing usable was found.", "findings": []}
+    )
+
+    def _message(annotations: list[dict[str, Any]] | None) -> str:
+        with pytest.raises(NoCitationsError) as excinfo:
+            extract_research_synthesis(messages, annotations=annotations)
+        return str(excinfo.value)
+
+    null_message = _message(None)
+    empty_message = _message([])
+    found_message = _message([_A_URL_CITATION])
+
+    assert len({null_message, empty_message, found_message}) == 3
+
+
+def test_non_empty_annotations_does_not_salvage_into_sources_and_still_fails() -> None:
+    """The decision this issue asks to be argued: salvaging `annotations` into
+    a finding's `sources` is tempting and wrong, because an annotation is not
+    attributed to any particular claim — attaching one to a finding would
+    fabricate the exact claim-to-evidence mapping the citation discipline
+    exists to guarantee. So a run with rich `annotations` but empty `sources`
+    still raises `NoCitationsError`; nothing manufactures a `Source` from an
+    annotation on its behalf."""
+    messages = _tool_call(
+        "submit_research_synthesis", {"summary": "Nothing usable was found.", "findings": []}
+    )
+
+    with pytest.raises(NoCitationsError):
+        extract_research_synthesis(
+            messages,
+            annotations=[
+                _A_URL_CITATION,
+                {"type": "url_citation", "url": "https://example.com/other", "title": "Other"},
+            ],
+        )
+
+
+def test_positioning_wires_annotations_into_its_message() -> None:
+    """Spot check on `extract_positioning`: the other three `_extract_cited_
+    artefact` callers share the same implementation as research-synthesis, but
+    a future refactor could drop the argument from one of them silently — this
+    proves it is actually wired, not just present in the signature."""
+    messages = _tool_call("submit_positioning", {"segments": [], "pillars": [], "ctas": []})
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_positioning(messages, annotations=[_A_URL_CITATION])
+
+    assert "transcription failure" in str(excinfo.value)
+
+
+def test_channel_plan_wires_annotations_into_its_message() -> None:
+    messages = _tool_call("submit_channel_plan", {"channels": []})
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_channel_plan(messages, taxonomy={}, annotations=[_A_URL_CITATION])
+
+    assert "transcription failure" in str(excinfo.value)
+
+
+def test_copy_wires_annotations_into_its_message() -> None:
+    messages = _tool_call("submit_copy", {"channels": []})
+
+    with pytest.raises(NoCitationsError) as excinfo:
+        extract_copy(messages, channel_plan_channels={}, annotations=[_A_URL_CITATION])
+
+    assert "transcription failure" in str(excinfo.value)
+
+
 # ── The guard does not fire on genuine content ───────────────────────────────
 
 

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -73,10 +73,15 @@ class _FakeGateway:
     # ── Test-only helpers, standing in for the runtime and the engine ────────
 
     def complete(
-        self, run_id: str, *, status: str = "completed", messages: list | None = None
+        self,
+        run_id: str,
+        *,
+        status: str = "completed",
+        messages: list | None = None,
+        annotations: list[dict[str, Any]] | None = None,
     ) -> None:
         self._runs[run_id] = pipeline.AgentRunView(
-            id=run_id, status=status, messages=messages or []
+            id=run_id, status=status, messages=messages or [], annotations=annotations
         )
 
     def fire_chain_run(
@@ -86,12 +91,13 @@ class _FakeGateway:
         agent_name: str,
         status: str = "completed",
         messages: list | None = None,
+        annotations: list[dict[str, Any]] | None = None,
     ) -> str:
         """Simulate the engine's `agent_fan_in` firing a joining agent."""
         self._next_id += 1
         run_id = f"run-{self._next_id}"
         self._runs[run_id] = pipeline.AgentRunView(
-            id=run_id, status=status, messages=messages or []
+            id=run_id, status=status, messages=messages or [], annotations=annotations
         )
         self._chain_runs[(chain_id, agent_name)] = run_id
         return run_id
@@ -206,6 +212,46 @@ async def test_advance_research_raises_when_every_research_agent_failed() -> Non
         await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
 
 
+@pytest.mark.asyncio
+async def test_advance_research_propagates_the_synthesis_runs_annotations_into_the_error() -> None:
+    """Issue #82: `advance_research` must read `annotations` off the
+    engine-fired synthesis run itself (`AgentRunView.annotations`), not just
+    its `messages`, and pass it all the way into the citation guard. A
+    synthesis run that cited nothing in its tool call but WAS given retrieval
+    evidence must fail with the "transcription failure" message, not the
+    "fetched zero URLs" one — proven here through the real orchestration
+    function, not just the extractor directly."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    for run_id in run_ids:
+        gateway.complete(run_id, status="completed")
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "submit_research_synthesis",
+                            "arguments": {"summary": "Nothing usable.", "findings": []},
+                        }
+                    }
+                ],
+            }
+        ],
+        annotations=[{"type": "url_citation", "url": "https://example.com/z", "title": "Z"}],
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    detail = str(excinfo.value)
+    assert "fetched zero URLs" not in detail
+    assert "transcription failure" in detail
+
+
 # ── start_positioning / advance_positioning ──────────────────────────────────
 
 
@@ -279,6 +325,40 @@ async def test_advance_positioning_raises_when_the_run_failed() -> None:
 
     with pytest.raises(pipeline.RunNotSucceededError):
         await pipeline.advance_positioning(gateway, run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_advance_positioning_propagates_the_runs_annotations_into_the_error() -> None:
+    """Issue #82, positioning half: a run whose retrieval genuinely found
+    nothing (`annotations=[]`) must keep the "retrying will not help" reading
+    — proven through `advance_positioning`, not the extractor directly."""
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_positioning(gateway, research_body={})
+    gateway.complete(
+        run_id,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "submit_positioning",
+                            "arguments": {"segments": [], "pillars": [], "ctas": []},
+                        }
+                    }
+                ],
+            }
+        ],
+        annotations=[],
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_positioning(gateway, run_id=run_id)
+
+    assert str(excinfo.value) == (
+        "The positioning run cited nothing from the approved research. Nothing "
+        "was produced — try running positioning again."
+    )
 
 
 # ── start_channel_plan / advance_channel_plan (M4) ───────────────────────────
@@ -370,6 +450,34 @@ async def test_advance_channel_plan_raises_when_the_run_failed() -> None:
         await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
 
 
+@pytest.mark.asyncio
+async def test_advance_channel_plan_propagates_null_annotations_into_the_error() -> None:
+    """Issue #82, channel-plan half: `annotations=None` (a pre-upgrade run, or
+    a non-`:online` model) must NOT be reported as a confirmed zero-URL
+    retrieval — proven through `advance_channel_plan`."""
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_channel_plan(
+        gateway, positioning_body={}, taxonomy=[]
+    )
+    gateway.complete(
+        run_id,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "submit_channel_plan", "arguments": {"channels": []}}}
+                ],
+            }
+        ],
+        annotations=None,
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
+
+    assert "not known" in str(excinfo.value)
+
+
 # ── start_copy / advance_copy (M5, issue #4) ─────────────────────────────────
 
 
@@ -458,6 +566,33 @@ async def test_advance_copy_raises_when_the_run_failed() -> None:
 
     with pytest.raises(pipeline.RunNotSucceededError):
         await pipeline.advance_copy(gateway, run_id=run_id, channel_plan_channels={})
+
+
+@pytest.mark.asyncio
+async def test_advance_copy_propagates_the_runs_annotations_into_the_error() -> None:
+    """Issue #82, copy half: retrieval succeeding while the model's tool call
+    cites nothing must read as transient — proven through `advance_copy`."""
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_copy(
+        gateway, positioning_body={}, channel_plan_body={}
+    )
+    gateway.complete(
+        run_id,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "submit_copy", "arguments": {"channels": []}}}
+                ],
+            }
+        ],
+        annotations=[{"type": "url_citation", "url": "https://example.com/z", "title": "Z"}],
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_copy(gateway, run_id=run_id, channel_plan_channels={})
+
+    assert "transcription failure" in str(excinfo.value)
 
 
 # ── require_approved ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #82

## What was broken

`NoCitationsError` counted `sources` inside the model's structured tool call
(`f.sources`/`s.sources`/`p.sources`/`c.sources`) — populated only if the
model chooses to retype URLs it was shown. So the guard detected "the model
did not report sources", not "the run fetched zero URLs", and its message
claimed the latter. Measured on dev: the identical brief produced richly
cited research one day and failed three consecutive times the next, with
retrieval succeeding every time.

## The fix

The agent runtime now records OpenRouter's `:online` grounding citations as
a fact about the *run*, independent of what the model transcribed
(`AgentRunResponse.annotations`, biffo-template#1528/#1530 — already merged,
deployed to tabsii dev). This PR reads it.

- `AgentRunView` (in `pipeline.py`) gains an `annotations: list[dict] | None`
  field, with the three-way meaning spelled out in its docstring
  (`None`/`[]`/non-empty).
- `admin_app._CoreAgentGateway.get_agent_run` carries `run.get("annotations")`
  from Core's raw response onto the view — the actual wiring point from
  Core's JSON to the pipeline's own type.
- Every `advance_*` function threads `view.annotations` (or
  `synthesis_run.annotations`) into its `extract_*` call.
- `_extract_cited_artefact`'s guard is unchanged in *when* it fires (still:
  `sources` empty ⇒ fail) — only the **message** now names which of three
  cases produced the failure.

## The three cases, and what an operator sees

| case | message says | because |
|---|---|---|
| `annotations` non-empty, `sources` empty | "Retrieval succeeded — N sources were found — but the model did not cite any of them... This is a transcription failure, not a failed search: try running `<stage>` again." | transient — retrying is likely to help without the brief changing |
| `annotations == []` | the original "fetched zero URLs... try running `<stage>` again" message, unchanged | this is the one case where that sentence is actually true |
| `annotations is None` | the original message, with "(This run predates citation tracking, or was not a grounded run, so whether retrieval itself found anything is not known — do not read this as a proven zero-URL retrieval.)" appended | pre-#1528 runs and non-`:online` runs must not be retroactively asserted as proven-zero |

## Decisions taken (as asked)

**1. Fail, retry, or salvage on `annotations` non-empty / `sources` empty?**
**Fail**, with a message that frames the failure as transient. **Not salvage**:
an `Annotation` (`type`/`url`/`title`) carries no claim mapping, so attaching
one to a specific finding/segment/channel would fabricate the exact
claim-to-evidence link the citation discipline exists to guarantee — the
guard would stop meaning what it says. **Not automatic retry**: nothing in
this pipeline retries anything today (every `PipelineError` maps to a 502 the
*operator* retries via the UI, per `admin_app._pipeline_error_to_http`'s own
docstring), and adding retry-on-annotations here would be new pipeline
behaviour beyond this issue's scope. "Transient" is communicated in the
message so the operator's next click is informed, not guessed.

**2. What happens on `NULL`?** Nothing new fails. This run already failed the
guard before this PR (`sources` was already empty), so a pre-upgrade artefact
is not newly broken by this change — only its message stops asserting a
zero-URL retrieval it cannot actually prove. Treating `NULL` as `[]` was
explicitly avoided for exactly the reason the issue names: it would read as
"retrieval definitely found nothing" for every artefact that predates the
annotations column.

## Was `AgentRunView` the right seam?

Yes. It already existed as the boundary between Core's raw
`AgentRunResponse` and the four `extract_*` functions — every one of them
already took an `AgentRunView`/its `.messages`, so `.annotations` is one more
field on an existing dataclass rather than a new abstraction. The one real
wiring point that needed a code change beyond `pipeline.py` was
`admin_app._CoreAgentGateway.get_agent_run`, exactly as the issue predicted.

## Tests

Fixtures use the *real* shape: `AgentRunResponse.annotations` is
`list[dict[str, Any]] | None`, and a populated entry is exactly
`Annotation.to_dict()`'s shape (`type`/`url`/`title`) from
biffo-template#1530's fixture and schema — not an authored guess (the
`biffo-template#1514` discipline).

- `tests/test_marketing_pipeline.py` — all three message cases on
  `extract_research_synthesis`, a "produces three distinct messages" guard,
  the no-salvage assertion, and a wiring spot-check on
  `extract_positioning`/`extract_channel_plan`/`extract_copy`.
- `tests/test_marketing_pipeline_orchestration.py` — one test per
  `advance_*` function proving `AgentRunView.annotations` actually reaches
  the raised error through the real orchestration path, not just the
  extractor directly.
- `tests/test_marketing_agent_gateway.py` (new) — `_CoreAgentGateway
  .get_agent_run`'s JSON→dataclass mapping for all four cases (non-empty,
  `[]`, explicit `null`, and the key simply absent), which had **no test
  coverage at all** before this PR — every existing route-level test
  overrides `get_agent_gateway` with a fake, bypassing this class entirely.

**Fail-first, proven**: reverted `src/marketing/{pipeline,admin_app}.py` via
`git stash` with the new tests in place, ran the suite — 26 tests failed with
`AttributeError: 'AgentRunView' object has no attribute 'annotations'`, the
same reason the guard was wrong (the field did not exist to read). Restored
the fix; all 444 tests pass, `ruff check`/`ruff format --check`/`pyright`
clean.

## Not done here

No UI change — the admin surface already forwards the server's `detail`
string verbatim (#86), so the new message text flows through with no other
change needed. Not verified against a live dev run (this plugin is frozen at
`23ea05b`, one change only); the fixture shapes are real but this PR's
behaviour has only been proven against the test suite, not a real
OpenRouter `:online` call.
