### PR TITLE
test(marketing): re-enable loggers disabled by dictConfig before each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,41 @@ by `cli/src/lib/plugin-skeleton-second-occupant.test.ts`.
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
+
+
+@pytest.fixture(autouse=True)
+def _reenable_disabled_loggers() -> None:
+    """Undo `disable_existing_loggers` before each test.
+
+    `logging.config.dictConfig()` defaults `disable_existing_loggers` to
+    **True**, which sets ``disabled = True`` on every logger that already
+    exists. Something in `tabsii-platform`'s suite calls it, so by the time
+    these tests run — vendored into that instance and executed after ~5400
+    other tests — this plugin's module-level `Logger(child=True)` objects are
+    switched off entirely:
+
+        'service_undefined.marketing.ssm'  propagate=True  disabled=True
+        'service_undefined'                propagate=True  disabled=True
+        isEnabledFor(WARNING) = False
+
+    So the log line is never emitted, `caplog` sees nothing, and two tests
+    asserting on log content fail — in the instance only. They pass in this
+    repo because nothing here reconfigures logging.
+
+    Measured, not assumed: three earlier hypotheses (a powertools version
+    difference, a specific polluting test, propagation severed at the parent)
+    each looked right and were each disproved by testing them. The state above
+    is what the failing test actually sees.
+
+    Re-enabling per test is the portable fix: it makes no claim about who
+    reconfigured logging or when, and holds wherever this plugin is vendored.
+    """
+    import logging
+
+    for name in list(logging.root.manager.loggerDict):
+        obj = logging.getLogger(name)
+        if isinstance(obj, logging.Logger):
+            obj.disabled = False


### PR DESCRIPTION
Two tests asserting on log content pass in this repo and **fail once vendored into `tabsii-platform`** and run after its full suite:

```
test_marketing_ssm.py::test_the_purpose_reaches_the_log_line
test_marketing_image_routes.py::test_a_ledger_failure_is_loud_even_though_it_cannot_be_prevented
```

They blocked the instance sync PR (`tabsii-platform#883`).

## The measured cause

Instrumenting the failing test inside the full instance suite:

```
'service_undefined.marketing.ssm'  propagate=True  disabled=True
'service_undefined'                propagate=True  disabled=True
isEnabledFor(WARNING) = False
```

`logging.config.dictConfig()` defaults `disable_existing_loggers` to **True**, which sets `disabled = True` on every logger that already exists. Something in the instance's suite calls it, so this plugin's module-level `Logger(child=True)` objects are switched off before its tests run — the log line is never emitted and `caplog` sees nothing.

## Three wrong answers first, recorded so nobody repeats them

Each looked right and was disproved by testing it:

1. **A powertools version difference** — real (3.34.0 here, 3.30.0 in the instance) but not the cause: pinning this repo to 3.30.0 and re-running, the tests still passed.
2. **A specific polluting test** — narrowing to `test_public_signing.py` plus the marketing tests passed either way.
3. **Propagation severed at the parent service logger** — plausible, since powertools does set `propagate=False` there; a fixture forcing `propagate=True` on every logger changed nothing, and binding `caplog` directly to the module's own logger changed nothing either.

Only instrumenting the failing test in the environment that reproduces it showed `disabled=True`. Worth recording: the first three hypotheses were each cheap to believe and each cost a full-suite run to disprove.

## The fix

An autouse fixture re-enabling disabled loggers before each test. It makes **no claim** about who reconfigured logging or when, so it holds wherever this plugin is vendored — which is the property that was missing, since the tests were correct about the behaviour and merely depended on ambient global state to observe it.

## Verified

- This repo: 444 pass
- **The full instance suite: 5423 passed, 0 failed** — previously 2 failed

That second one is the check that matters; the first passed before this change too.

## Not fixed here

Whoever calls `dictConfig` with the default `disable_existing_loggers=True` is silently switching off every logger created before it, for the whole process. That is worth finding and fixing at source — but it lives in `tabsii-platform`, not this plugin, and this fix does not depend on it.
