### PR TITLE
fix(pipeline): ground the citation guard in the research runs' annotations, not the synthesis run's

### DIFF
--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -573,6 +573,54 @@ async def start_research(
     return chain_id, research_run_ids
 
 
+def _aggregate_research_annotations(
+    views: list[AgentRunView | None],
+) -> list[dict[str, Any]] | None:
+    """Aggregate ``annotations`` across the runs that actually performed
+    retrieval — the **research** runs, not the synthesis run (issue #90).
+
+    ``DEFAULT_RESEARCH_MODEL`` is ``:online``; ``DEFAULT_SYNTHESIS_MODEL`` is
+    not. The synthesis run fans in over the research runs' output and never
+    grounds itself, so its own ``.annotations`` can never be anything but the
+    "not a grounded run" state — reading it, as :func:`advance_research` used
+    to, makes the zero-citations guard structurally blind to what retrieval
+    actually found. The research runs named in ``research_run_ids`` are the
+    ones that retrieved, so they are the ones this aggregates over.
+
+    Three-way result, matching :class:`AgentRunView.annotations`'s own
+    tri-state so the guard's existing None/[]/non-empty branches keep their
+    meaning one level up:
+
+    - **Union, if any run has non-empty annotations.** A chain where one
+      research angle retrieved and the other found nothing is not treated as
+      a distinct case from one where both retrieved: either way, retrieval
+      demonstrably happened somewhere in the chain, so the guard's "retrieval
+      succeeded but wasn't transcribed" message is the right one, and its
+      wording already just reports a total count — it does not claim every
+      angle succeeded.
+    - **``None``, if no run has non-empty annotations and at least one is
+      unresolved** — either the view itself is missing (a vanished run) or
+      its ``annotations`` is ``None`` (predates the column, or somehow
+      wasn't a grounded run). The aggregate must not assert a proven
+      zero-URL retrieval when part of the chain's status is unknown.
+    - **``[]``, only when every run resolved and every one reported ``[]``.**
+      This is the one case where "retrieval genuinely found nothing" is true
+      of the whole chain, not just the run the guard used to look at.
+    """
+    saw_unknown = False
+    union: list[dict[str, Any]] = []
+    for view in views:
+        if view is None or view.annotations is None:
+            saw_unknown = True
+        elif view.annotations:
+            union.extend(view.annotations)
+    if union:
+        return union
+    if saw_unknown:
+        return None
+    return []
+
+
 async def advance_research(
     gateway: AgentGateway,
     *,
@@ -593,6 +641,12 @@ async def advance_research(
     result. ``synthesis_model`` is accepted for parity with the other stage
     starters even though this stage never *starts* a run — the engine does —
     so callers have one place to read every model this pipeline can use.
+
+    The citation guard is grounded in the **research** runs' annotations
+    (:func:`_aggregate_research_annotations`), not the synthesis run's own —
+    issue #90: the synthesis run is never a grounded (``:online``) run, so its
+    ``.annotations`` can never answer "did retrieval find anything"; the two
+    research runs named in ``research_run_ids`` are the ones that retrieved.
     """
     del synthesis_model  # the engine chooses the synthesis run's model, not us
 
@@ -604,8 +658,10 @@ async def advance_research(
             return None  # synthesis is running; nothing to do yet
         if not synthesis_run.succeeded:
             raise RunNotSucceededError("The research-synthesis run did not complete successfully.")
+        research_views = [await gateway.get_agent_run(run_id=rid) for rid in research_run_ids]
         return extract_research_synthesis(
-            synthesis_run.messages, annotations=synthesis_run.annotations
+            synthesis_run.messages,
+            annotations=_aggregate_research_annotations(research_views),
         )
 
     # No synthesis run yet: either research is still in flight (the normal

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -212,36 +212,49 @@ async def test_advance_research_raises_when_every_research_agent_failed() -> Non
         await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
 
 
+def _empty_synthesis_call() -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "submit_research_synthesis",
+                        "arguments": {"summary": "Nothing usable.", "findings": []},
+                    }
+                }
+            ],
+        }
+    ]
+
+
 @pytest.mark.asyncio
-async def test_advance_research_propagates_the_synthesis_runs_annotations_into_the_error() -> None:
-    """Issue #82: `advance_research` must read `annotations` off the
-    engine-fired synthesis run itself (`AgentRunView.annotations`), not just
-    its `messages`, and pass it all the way into the citation guard. A
-    synthesis run that cited nothing in its tool call but WAS given retrieval
-    evidence must fail with the "transcription failure" message, not the
-    "fetched zero URLs" one — proven here through the real orchestration
-    function, not just the extractor directly."""
+async def test_advance_research_reads_annotations_from_research_runs_not_synthesis_run() -> None:
+    """Issue #90: the synthesis run is never `:online`
+    (`DEFAULT_SYNTHESIS_MODEL` has no `:online` suffix) — only the two
+    research runs actually retrieve. The guard must be grounded in THEIR
+    annotations, not the synthesis run's own.
+
+    Proven adversarially: the synthesis run here is given `annotations=[]`
+    (the value the old, buggy code read) while the research runs are given
+    real, non-empty annotations. If `advance_research` were still reading the
+    synthesis run's own annotations — the pre-#90-fix code, and exactly the
+    shape issue #90 was filed against — this would see `[]` and raise the
+    unconditional "fetched zero URLs" message. It must not: the research
+    runs retrieved, so the failure must read as a transcription failure."""
     gateway = _FakeGateway()
     chain_id, run_ids = await pipeline.start_research(gateway, brief={})
     for run_id in run_ids:
-        gateway.complete(run_id, status="completed")
+        gateway.complete(
+            run_id,
+            status="completed",
+            annotations=[{"type": "url_citation", "url": "https://example.com/z", "title": "Z"}],
+        )
     gateway.fire_chain_run(
         chain_id=chain_id,
         agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
-        messages=[
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "function": {
-                            "name": "submit_research_synthesis",
-                            "arguments": {"summary": "Nothing usable.", "findings": []},
-                        }
-                    }
-                ],
-            }
-        ],
-        annotations=[{"type": "url_citation", "url": "https://example.com/z", "title": "Z"}],
+        messages=_empty_synthesis_call(),
+        annotations=[],  # what the synthesis run itself reports — must be ignored
     )
 
     with pytest.raises(pipeline.NoCitationsError) as excinfo:
@@ -250,6 +263,99 @@ async def test_advance_research_propagates_the_synthesis_runs_annotations_into_t
     detail = str(excinfo.value)
     assert "fetched zero URLs" not in detail
     assert "transcription failure" in detail
+
+
+@pytest.mark.asyncio
+async def test_advance_research_unions_annotations_when_only_one_research_angle_retrieved() -> None:
+    """Decision (issue #90): a chain where one research angle retrieved and
+    the other found nothing is not distinguished from "both retrieved" — the
+    aggregate is a union, and any non-empty result reads as "retrieval
+    succeeded somewhere in the chain", which is what the message already
+    says (a total count, not a per-angle claim)."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed", annotations=[])
+    gateway.complete(
+        run_ids[1],
+        status="completed",
+        annotations=[{"type": "url_citation", "url": "https://example.com/only-one", "title": "Z"}],
+    )
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_empty_synthesis_call(),
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    detail = str(excinfo.value)
+    assert "transcription failure" in detail
+    assert "1 source" in detail
+
+
+@pytest.mark.asyncio
+async def test_advance_research_reports_genuine_zero_only_when_every_research_run_is_empty() -> (
+    None
+):
+    """The base "fetched zero URLs" message is only honest when EVERY
+    research run resolved and reported `[]` — the one case in the aggregate
+    that actually matches what the message asserts."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    for run_id in run_ids:
+        gateway.complete(run_id, status="completed", annotations=[])
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_empty_synthesis_call(),
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    detail = str(excinfo.value)
+    assert detail == (
+        "The research run fetched zero URLs. Nothing was found to cite, so no "
+        "artefact was produced — try running research again."
+    )
+
+
+@pytest.mark.asyncio
+async def test_advance_research_treats_mixed_none_and_empty_chain_as_unknown_not_proven_zero() -> (
+    None
+):
+    """Decision (issue #90): if one research run predates the annotations
+    column (or was otherwise never graded) and reports `None`, while the
+    other reports a genuine `[]`, the aggregate must not claim a proven
+    zero-URL retrieval — part of the chain's status is simply not known."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed", annotations=None)
+    gateway.complete(run_ids[1], status="completed", annotations=[])
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_empty_synthesis_call(),
+        # Deliberately the opposite of the correct aggregate (`None`): if
+        # `advance_research` were still reading the synthesis run's own
+        # annotations instead of the research runs', this `[]` would produce
+        # the bare "fetched zero URLs" message with no disclaimer — the wrong
+        # answer, and a different string from the one asserted below.
+        annotations=[],
+    )
+
+    with pytest.raises(pipeline.NoCitationsError) as excinfo:
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    detail = str(excinfo.value)
+    assert detail == (
+        "The research run fetched zero URLs. Nothing was found to cite, so no "
+        "artefact was produced — try running research again. (This run predates "
+        "citation tracking, or was not a grounded run, so whether retrieval itself "
+        "found anything is not known — do not read this as a proven zero-URL "
+        "retrieval.)"
+    )
 
 
 # ── start_positioning / advance_positioning ──────────────────────────────────


### PR DESCRIPTION
fix(pipeline): ground the citation guard in the research runs' annotations, not the synthesis run's

Closes #90

## What was broken

`advance_research` read `synthesis_run.annotations` to feed the zero-citation
guard (#88). But `DEFAULT_SYNTHESIS_MODEL` has no `:online` suffix — only the
two research runs (`DEFAULT_RESEARCH_MODEL`) retrieve. The synthesis run fans
in over their output and never grounds itself, so its own `.annotations` is
structurally always the "not a grounded run" state. #88's guard therefore saw
`[]` on every single research attempt, forever, and reported "the research run
fetched zero URLs" regardless of what the research agents actually found —
observed live on dev immediately after #88 deployed.

## The fix

`_aggregate_research_annotations` in `pipeline.py` aggregates `annotations`
across the research runs named in `research_run_ids` — the runs that actually
retrieved — instead of reading the synthesis run's own field.

## Decisions taken (as asked)

**1. Union or per-run?** Union. A chain where one research angle retrieved
and the other found nothing is not given a distinct message from "both
retrieved": either way retrieval demonstrably happened somewhere in the
chain, and `_no_citations_message`'s "retrieval succeeded — N sources were
found" wording already reports a total, not a per-angle claim, so a partial
retrieval reads correctly as the same transient "retry the stage" case.

**2. `None` vs `[]` across a chain.** `None` (unknown) contaminates: if any
research run's view is missing or its `annotations` is `None`, the aggregate
is `None` unless another run's annotations are non-empty (which wins
regardless, per decision 1). Only when *every* run resolved and reported
`[]` is the aggregate `[]`. This is the only rule that keeps the "fetched
zero URLs" message honest — it is now true of the whole chain, not just the
one run the guard used to look at.

**3. The other three stages.** Checked, not assumed. `DEFAULT_POSITIONING_MODEL`,
`DEFAULT_CHANNEL_PLAN_MODEL` and `DEFAULT_COPY_MODEL` are all
`anthropic/claude-opus-4.8` — also not `:online`. But they do **not** share
this defect: unlike research/synthesis, each of these stages reads
`view.annotations` off its **own single run** — there is no separate upstream
retrieval run for the guard to be misdirected away from. Their agent
instructions are explicit ("You do not have web access and must not claim
to.") — these stages are designed to transcribe citations already present in
an approved upstream artefact, never to retrieve. Their own `_no_citations_message`
text never asserts "fetched zero URLs" either (it says "cited nothing from
the approved research/positioning"), so nothing is falsely claimed. The
"retrieval succeeded but not transcribed" branch is permanently dead for
these three, but that's a correct reflection of what they do (no retrieval),
not the #90 bug shape. Not a fifth/sixth/seventh bug — three bugs ruled out
by reading the code and the agent instructions.

## Tests

`tests/test_marketing_pipeline_orchestration.py`:

- Replaced the #88 test that fabricated `annotations` directly on the
  synthesis run (`gateway.fire_chain_run(..., annotations=[...])`) — the
  exact fixture shape #90 diagnoses as the gap that let this ship: the
  production path can never put annotations on that run. It now proves the
  fix adversarially: the synthesis run is given `annotations=[]` (what the
  buggy code read) while the research runs are given real annotations, and
  asserts the guard's message reflects the research runs, not the synthesis
  run's decoy value.
- Added: union case (one research run empty, one non-empty), genuine-zero
  case (every research run resolves to `[]`), and the `None`-contamination
  case (one research run `None`, one `[]`) — each asserting the exact
  message text.

Fail-first, proven: `git stash push -- src/marketing/pipeline.py`, ran the new
tests against the unfixed code — 4 failed for the diagnosed reason (three
read the synthesis run's decoy/absent annotations instead of the research
runs'; the fourth passed by coincidence on first pass because the synthesis
run's own annotations happened to be `None` too, so it was rewritten to give
the synthesis run an adversarial `[]` and re-verified red). Restored the fix;
all 447 tests pass, `ruff check`/`ruff format --check`/`pyright` clean.

## Not done here / not verified

Not verified against a live dev run — this is a fixture/unit-level proof
against the real chain shape (two research runs + a synthesis run), not an
end-to-end OpenRouter call. The deployed-artifact confirmation this issue's
predecessors relied on is left to whoever verifies the merge.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
