### PR TITLE
fix(schema): require the synthesis findings key, so the model cannot skip it

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -151,7 +151,31 @@ class ResearchSynthesis(BaseModel):
     reconcile into, and what is stored as the ``research`` artefact's body."""
 
     summary: str = Field(description="The research findings, reconciled into a few paragraphs.")
-    findings: list[ResearchFinding] = Field(default_factory=list)
+
+    #: A REQUIRED KEY that may legitimately be empty. This was
+    #: `default_factory=list`,
+    #: which made it optional in the generated tool schema — `"required":
+    #: ["summary"]` — so the model returned a summary and nothing else, every
+    #: time. Measured on dev 2026-08-12: both research agents cited correctly
+    #: (3 and 8 real sources), the synthesis run's tool call contained the
+    #: single key `summary`, and the citation guard then failed the run for
+    #: having no sources. The model was complying exactly with the contract it
+    #: was given; the contract did not ask for what the guard demands.
+    #:
+    #: Deliberately NOT `min_length=1`. `ResearchFinding.sources` is already
+    #: `min_length=1`, so demanding at least one finding would mean a valid
+    #: synthesis always carries a source — making the citation guard
+    #: unreachable, and forcing the model to invent a finding when retrieval
+    #: genuinely found nothing. That is the fabrication the guard exists to
+    #: prevent. An empty list is an honest answer; an absent key is not,
+    #: because it lets the model skip the question entirely.
+    findings: list[ResearchFinding] = Field(
+        description=(
+            "Every finding worth carrying forward, each with the sources that "
+            "support it. Carry sources through from the research you were given "
+            "— do not drop them and do not invent new ones."
+        ),
+    )
 
 
 class Segment(BaseModel):


### PR DESCRIPTION
## The root cause, measured

Read directly off the agent runs on dev:

```
marketing-research-audience     3 findings,  3 real sources,  5 annotations  ✓
marketing-research-competitive  3 findings,  8 real sources,  5 annotations  ✓
marketing-research-synthesis    tool call keys: ["summary"]                  ✗
```

**Both research agents cited perfectly. Synthesis dropped all 11 sources.**

`ResearchSynthesis.findings` was `default_factory=list`, which makes it **optional** in the generated tool schema — `"required": ["summary"]`. The model returned the one field it was asked for and omitted the rest. It was complying exactly with its contract; the contract never asked for findings.

The citation guard then failed the run for having no sources, which is why this looked for two days like a retrieval problem when retrieval was working the whole time.

## Deliberately not `min_length=1`

The obvious fix — demand at least one finding — is wrong, and I made it first before catching it.

`ResearchFinding.sources` is **already** `min_length=1`. So requiring at least one finding would mean a valid synthesis *always* carries a source, which:

- makes `NoCitationsError` **unreachable** for this stage, undoing the diagnosability just built in #88/#91, and
- **forces the model to invent a finding** when retrieval genuinely found nothing — the exact fabrication the guard exists to prevent.

Required key, possibly empty, is the correct contract. An empty list is an honest answer; an absent key is not, because it lets the model skip the question entirely.

## This does not take effect on deploy alone

The fan-in workflow **froze `output_tools` into its `action_config` when it was seeded**, so the new schema does not reach the model until the workflow is re-seeded with `--replace`. Same trap recorded in #62 for the model constant.

Deploying this without re-seeding changes nothing observable.

## Verification

447 tests pass. The proof that matters is a real run producing a cited synthesis artefact, which follows deploy **and** re-seed — and which I will report either way.

Refs #82, #90, #92
