### PR TITLE
feat(results): read leads/conversions/cost from an instance-configured leads source

### DIFF
--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -25,15 +25,14 @@ this module adds is the part that is genuinely paid-only:
    no historical spend or performance data to optimise against, so this is a
    declared, fixed starting-point heuristic — not a bidding model — and says
    so in its own ``basis`` field.
-4. **Spend, reported as explicitly unmeasurable.** ``lead_source_costs``
-   (``tabsii.lead_source_costs``, DDL module 049) is not reachable from this
-   plugin today — no ``/api/v1/internal/*`` route is registered for it, and
-   it sits behind tabsii-CRM RBAC codes unrelated to this plugin's own admin
-   identity (issue #31, the exact gap ``results_routes.py`` already reports
-   leads/conversions/cost against). This module does not invent a call to a
-   route that does not exist; it reuses ``results_routes.UnmeasuredMetric``
-   verbatim so "no data" reads the same way here as it does on the results
-   dashboard, rather than a bespoke ``0``.
+4. **Spend, reported as explicitly unmeasurable.** Issue #31 closed the gap
+   for ``results_routes.py``'s leads/conversions/cost — those now go through
+   the instance-configured leads source — but this route asks a different
+   question (spend for one campaign, inside a paid brief pack) that contract
+   was never wired to answer, and still isn't. This module does not invent a
+   call to a route that does not exist; it reuses
+   ``results_routes.UnmeasuredMetric`` verbatim so "no data" reads the same
+   way here as it does on the results dashboard, rather than a bespoke ``0``.
 
 ## What this module deliberately does NOT do
 

--- a/src/marketing/results_routes.py
+++ b/src/marketing/results_routes.py
@@ -19,51 +19,69 @@ there is nothing this deployment could ever call to learn them. Nothing below
 renders a click, a mint, or a download count as if it said anything about
 who saw a post.
 
-## Clicks are measured; leads, conversions and cost are not — yet
+## Clicks are measured directly; leads, conversions and cost go through the
+## instance's own leads source (issue #31, option B)
 
 `marketing_click` and `marketing_link` are this plugin's own generated-CRUD
 tables (declared in `biffo.plugin.json`), reachable through the same
 internal, SigV4-signed mount every other route in this file uses
 (`admin_app._core`, `_INTERNAL_PREFIX`). Clicks per campaign, and the
 paid/organic split, are real numbers computed from real rows this plugin
-wrote itself.
+wrote itself, and stay that way regardless of anything below.
 
 Leads (`public.demo_requests`, tabsii-platform) and cost
-(`tabsii.lead_source_costs`, DDL module 049) are **not** reachable from here
-today, and this is a genuinely missing capability rather than an oversight in
-this module. Both surfaces exist and are queried in `tabsii-platform`, but
-neither is registered under `/api/v1/internal/*` — the only tree a
-SigV4-signed plugin call can reach at all (`services/api/src/api/main.py`'s
-full router-registration list has no `internal_*` router for either table).
-`demo_requests` sits behind Core's own `/api/v1/admin/demo-requests`, gated
-by `require_admin`, which is built on `require_auth`
-(`services/api/src/api/middleware/auth.py`) — bearer-`Authorization`-only,
-with no forwarded-token acceptance the way `require_principal` (the guard
-`require_principal_crud_permission` uses) has. `lead_source_costs` sits
-behind tabsii-CRM's `/api/v1/data/lead_source_costs` and
-`/api/v1/analytics/pipeline/*`, gated on RBAC permission codes
-(`leads.read`, `lead_source_costs.read`) that have nothing to do with the
-"admin" Cognito group this plugin's own admin surface authorises on. Even if
-either surface were reachable, `demo_requests.status` has no mutation path
-yet (`demo_requests_admin.py`'s own docstring: "there's no mutation surface
-yet"), so "conversion" has no signal to read regardless of transport.
+(`tabsii.lead_source_costs`, DDL module 049) are tabsii concepts this plugin
+must never import directly — a marketing plugin installed on biffo-platform
+has no such tables and never will. Issue #31's settled design (option B) is
+that **the plugin declares it needs a leads source, and the instance
+configures which endpoint answers it**: `MARKETING_LEADS_SOURCE_URL`
+(delivered via `plugin_host_environment`, biffo-template#1534). When set,
+this module calls
 
-So "no data" here is not a placeholder for effort not yet spent on a query —
-it is the honest, current state of a real transport gap, filed as issue #31.
-Until that closes, every campaign's leads, conversions and cost render as
-**unmeasurable**, never as zero: reporting zero would claim "we looked, and
-nothing happened," which is not a claim this plugin can make today.
+    GET <leads_source_url>?campaign_id=<uuid>&campaign_id=<uuid>...
+
+and expects back `{"campaigns": [{campaign_id, leads: {value, measurable[,
+reason]}, conversions: {...}, cost: {...}}]}` — see `_fetch_leads_source` and
+`_metric_from_raw`. tabsii's implementation of that endpoint is a grouped
+count over `demo_requests.utm_campaign`, `.status`, and a join to
+`lead_source_costs`; another platform answering the same three questions from
+entirely different tables is an equally valid implementation. None of that
+lives here — this file knows only the wire contract.
+
+**Unset is a first-class state, not an error.** A platform with no leads
+source configured (every platform other than tabsii, today) renders
+leads/conversions/cost as unmeasurable with the reason "no leads source is
+configured for this deployment" — the honest answer, not a failure.
+
+**The source failing must never take down results that already work.** A
+timeout, a non-200, or a malformed body degrades every campaign's
+leads/conversions/cost to unmeasurable-with-a-reason; clicks, computed
+locally, keep rendering regardless (`_fetch_leads_source` never raises).
+
+**A campaign the source doesn't know about is unmeasurable, not an error** —
+see the "unknown campaign id" handling in `_metrics_for_campaign`.
+
+**`measurable: false` is never rendered as a zero, and an upstream `reason`
+is always preserved verbatim** when the source gives one — see
+`_metric_from_raw`. A real zero (`value: 0, measurable: true`) stays
+distinguishable throughout.
 """
 
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from typing import Any
+from urllib.parse import urlencode
 
+import httpx
+from aws_lambda_powertools import Logger
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from . import admin_app
+
+logger = Logger(child=True)
 
 router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 
@@ -85,15 +103,43 @@ _INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
 #: silently under-count.
 _LIST_PAGE_SIZE = 200
 
-#: Why leads/conversions/cost cannot be computed from here today — see the
-#: module docstring for the full mechanism. Surfaced verbatim in the
-#: response so a caller reading only the JSON, not this file, still gets the
-#: real reason rather than a bare `false`.
-_UNMEASURABLE_REASON = (
-    "No route reachable from this plugin's internal Core transport exposes this yet "
-    "(tracked in issue #31) — 'unmeasurable' means the transport does not exist, "
-    "not that the count is zero."
-)
+#: issue #31's contract: the instance tells this plugin which endpoint
+#: answers "leads, conversions and cost for these campaign ids" by setting
+#: this environment variable (delivered via `plugin_host_environment`,
+#: biffo-template#1534). The value is the full path/URL to call — this
+#: module appends the `campaign_id` query params and calls it exactly as
+#: given, through the same dual-auth transport (`admin_app._core`) every
+#: other Core call in this file uses.
+_LEADS_SOURCE_URL_ENV = "MARKETING_LEADS_SOURCE_URL"
+
+#: A platform with no leads source configured is normal, not broken — every
+#: platform other than tabsii sees exactly this today. Verbatim text from
+#: issue #31's settled contract, since a caller reading only the JSON should
+#: get the same words this docstring does.
+_NOT_CONFIGURED_REASON = "no leads source is configured for this deployment"
+
+#: The URL is configured but the call itself did not produce a usable
+#: response — timeout, connection failure, or a non-200 status. Degrades to
+#: unmeasurable rather than a 500 on the whole dashboard; see
+#: `_fetch_leads_source`.
+_SOURCE_UNREACHABLE_REASON = "the configured leads source could not be reached"
+
+#: The URL answered, but the body wasn't the shape the contract promises
+#: (not JSON, no `campaigns` list, or a per-metric object missing the
+#: `value`/`measurable` the contract requires). Kept distinct from
+#: `_SOURCE_UNREACHABLE_REASON` so an operator reading the reason can tell
+#: "nothing answered" from "something answered wrong".
+_SOURCE_MALFORMED_REASON = "the configured leads source returned data this plugin could not parse"
+
+#: The call succeeded and the source is working — this specific campaign id
+#: simply wasn't in its response. Per the contract: "a campaign the source
+#: does not know about is simply unmeasurable, not a 500."
+_UNKNOWN_TO_SOURCE_REASON = "the configured leads source has no data for this campaign"
+
+#: `measurable: false` with no `reason` at all is itself a malformed
+#: response — the contract requires one — but still degrades to unmeasurable
+#: rather than failing the whole call. See `_metric_from_raw`.
+_NO_REASON_GIVEN = "the configured leads source marked this unmeasurable but gave no reason"
 
 
 class ClickBreakdown(BaseModel):
@@ -126,20 +172,50 @@ class UnmeasuredMetric(BaseModel):
     for a click-to-lead rate) when that population is itself known here;
     `None` when it isn't (e.g. a conversion rate's denominator is a lead
     count this plugin cannot see either).
+
+    Still used verbatim by `paid_pack_routes.py` for its own, still-genuinely
+    -unreachable `spend` field — unrelated to the leads/conversions/cost
+    metrics below, which now go through `Metric` instead.
     """
 
     measurable: bool = False
     denominator: int | None = None
-    reason: str = _UNMEASURABLE_REASON
+    reason: str = (
+        "No route reachable from this plugin's internal Core transport exposes this yet "
+        "(tracked in issue #31) — 'unmeasurable' means the transport does not exist, "
+        "not that the count is zero."
+    )
+
+
+class Metric(BaseModel):
+    """A leads/conversions/cost figure sourced from the instance-configured
+    leads source (issue #31) — or the reason it could not be measured.
+
+    Exactly one of two shapes, matching the wire contract:
+
+    - `measurable=True`, `value` set to a real number (a real zero renders
+      exactly this way — `value=0, measurable=True`, distinguishable from an
+      unmeasurable metric by `measurable` alone, never by `value` being falsy).
+    - `measurable=False`, `value=None`, `reason` set to why.
+
+    `denominator` carries the same meaning as `UnmeasuredMetric.denominator`
+    above (see that class) and is populated the same way regardless of
+    whether this instance ended up measurable or not.
+    """
+
+    value: float | int | None = None
+    measurable: bool
+    denominator: int | None = None
+    reason: str | None = None
 
 
 class CampaignResults(BaseModel):
     campaign_id: str
     campaign_name: str
     clicks: ClickBreakdown
-    leads: UnmeasuredMetric
-    conversions: UnmeasuredMetric
-    cost: UnmeasuredMetric
+    leads: Metric
+    conversions: Metric
+    cost: Metric
 
 
 class ResultsResponse(BaseModel):
@@ -194,6 +270,156 @@ def _click_breakdown(
     )
 
 
+class _LeadsSourceResult:
+    """The outcome of the one call to the instance-configured leads source.
+
+    Exactly one of the three states below holds — callers (`_metrics_for_campaign`)
+    check `not_configured` first, then `failure`, then fall through to
+    `by_campaign_id`:
+
+    - `not_configured=True`: `MARKETING_LEADS_SOURCE_URL` is unset. A normal,
+      first-class state (see module docstring), not a failure.
+    - `failure` set: the URL is configured but the call did not produce a
+      usable response (timeout, non-200, malformed body). Degrades to
+      unmeasurable with `failure` as the reason for every campaign — never a
+      500 on the results dashboard.
+    - `by_campaign_id` populated (possibly empty): the call succeeded.
+      A campaign id simply absent from it is unknown to the source, not an
+      error — handled by `_metrics_for_campaign`, not here.
+    """
+
+    def __init__(
+        self,
+        *,
+        not_configured: bool = False,
+        failure: str | None = None,
+        by_campaign_id: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self.not_configured = not_configured
+        self.failure = failure
+        self.by_campaign_id = by_campaign_id or {}
+
+
+async def _fetch_leads_source(campaign_ids: list[str], token: str) -> _LeadsSourceResult:
+    """Call the instance-configured leads source for `campaign_ids`, or
+    report why it couldn't be reached — never raises.
+
+    Every failure mode (unset URL, timeout, connection error, non-200,
+    unparseable body, wrong shape) is caught here and turned into a
+    `_LeadsSourceResult` state rather than an exception, because a broken
+    leads source must not take down `/results` — clicks are computed
+    locally from this plugin's own tables and must keep rendering
+    regardless of what this call does.
+    """
+    url = os.environ.get(_LEADS_SOURCE_URL_ENV, "").strip()
+    if not url:
+        return _LeadsSourceResult(not_configured=True)
+
+    if not campaign_ids:
+        # Nothing to ask about — same as a successful call that named no
+        # campaigns; every campaign below will fall into the "unknown to
+        # source" branch, which is the honest answer to "the source knows
+        # nothing about a campaign we never asked it about".
+        return _LeadsSourceResult(by_campaign_id={})
+
+    query = urlencode([("campaign_id", campaign_id) for campaign_id in campaign_ids])
+    full_path = f"{url}?{query}"
+
+    try:
+        resp = await admin_app._core("GET", full_path, token)
+    except httpx.HTTPError:
+        logger.warning("Leads source request failed", path=url, exc_info=True)
+        return _LeadsSourceResult(failure=_SOURCE_UNREACHABLE_REASON)
+    except Exception:  # noqa: BLE001 - a broken leads source must never 500 /results
+        logger.warning("Leads source request raised unexpectedly", path=url, exc_info=True)
+        return _LeadsSourceResult(failure=_SOURCE_UNREACHABLE_REASON)
+
+    if resp.status_code != 200:
+        logger.warning(
+            "Leads source returned a non-200 status", path=url, status_code=resp.status_code
+        )
+        return _LeadsSourceResult(failure=_SOURCE_UNREACHABLE_REASON)
+
+    try:
+        body = resp.json()
+    except ValueError:
+        logger.warning("Leads source returned a non-JSON body", path=url)
+        return _LeadsSourceResult(failure=_SOURCE_MALFORMED_REASON)
+
+    if not isinstance(body, dict) or not isinstance(body.get("campaigns"), list):
+        logger.warning("Leads source response missing a 'campaigns' list", path=url)
+        return _LeadsSourceResult(failure=_SOURCE_MALFORMED_REASON)
+
+    by_campaign_id: dict[str, dict[str, Any]] = {}
+    for entry in body["campaigns"]:
+        if isinstance(entry, dict) and isinstance(entry.get("campaign_id"), str):
+            by_campaign_id[entry["campaign_id"]] = entry
+    return _LeadsSourceResult(by_campaign_id=by_campaign_id)
+
+
+def _metric_from_raw(raw: Any, *, denominator: int | None = None) -> Metric:
+    """Parse one `{value, measurable[, reason]}` object from the leads
+    source into a `Metric`, defensively — a malformed individual field
+    degrades to unmeasurable rather than raising and taking the rest of the
+    response down with it.
+    """
+    if not isinstance(raw, dict):
+        return Metric(measurable=False, denominator=denominator, reason=_SOURCE_MALFORMED_REASON)
+
+    measurable = raw.get("measurable")
+    if measurable is True:
+        value = raw.get("value")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return Metric(
+                measurable=False, denominator=denominator, reason=_SOURCE_MALFORMED_REASON
+            )
+        return Metric(value=value, measurable=True, denominator=denominator)
+
+    if measurable is False:
+        reason = raw.get("reason")
+        if not isinstance(reason, str) or not reason:
+            reason = _NO_REASON_GIVEN
+        return Metric(measurable=False, denominator=denominator, reason=reason)
+
+    # `measurable` missing or not a bool at all — the contract requires it.
+    return Metric(measurable=False, denominator=denominator, reason=_SOURCE_MALFORMED_REASON)
+
+
+def _metrics_for_campaign(
+    campaign_id: str, source: _LeadsSourceResult, *, denominator: int
+) -> tuple[Metric, Metric, Metric]:
+    """`(leads, conversions, cost)` for one campaign, given the whole leads
+    source call's outcome.
+
+    `denominator` (the campaign's click count) is applied to `leads` only,
+    in every branch — matching the pre-#31 behaviour, since a click-to-lead
+    rate's population is this campaign's click count regardless of whether
+    leads turned out measurable. `conversions`/`cost` never carry one: a
+    conversion rate's population is a lead count this plugin does not
+    independently verify, and cost is an amount, not a share.
+    """
+    if source.not_configured:
+        reason = _NOT_CONFIGURED_REASON
+    elif source.failure is not None:
+        reason = source.failure
+    else:
+        entry = source.by_campaign_id.get(campaign_id)
+        if entry is None:
+            reason = _UNKNOWN_TO_SOURCE_REASON
+        else:
+            return (
+                _metric_from_raw(entry.get("leads"), denominator=denominator),
+                _metric_from_raw(entry.get("conversions")),
+                _metric_from_raw(entry.get("cost")),
+            )
+
+    return (
+        Metric(measurable=False, denominator=denominator, reason=reason),
+        Metric(measurable=False, reason=reason),
+        Metric(measurable=False, reason=reason),
+    )
+
+
 @router.get("/results")
 async def results(admin: Any = Depends(admin_app.require_admin)) -> ResultsResponse:
     """Clicks, leads, conversions and cost, per campaign.
@@ -202,16 +428,18 @@ async def results(admin: Any = Depends(admin_app.require_admin)) -> ResultsRespo
     clicks — each paged in full via `_list_all`, then joined in memory:
     `marketing_click.link_id` -> `marketing_link.is_paid` for the paid/organic
     split, and `marketing_click.campaign_id` -> `marketing_campaign.id` for
-    the per-campaign grouping. See the module docstring for why leads,
-    conversions and cost are reported as `UnmeasuredMetric` rather than
-    computed: no reachable Core surface carries them yet.
+    the per-campaign grouping. Leads, conversions and cost come from one
+    additional call to the instance-configured leads source (`_fetch_leads_source`),
+    made once for every campaign id this call knows about — see the module
+    docstring for the full contract.
     """
     campaigns = await _list_all(f"{_INTERNAL_PREFIX}/campaigns", admin.token, {})
     links = await _list_all(f"{_INTERNAL_PREFIX}/links", admin.token, {})
     clicks = await _list_all(f"{_INTERNAL_PREFIX}/clicks", admin.token, {})
 
     links_by_id = {link["id"]: link for link in links if link.get("id")}
-    known_campaign_ids = {campaign["id"] for campaign in campaigns if campaign.get("id")}
+    campaign_ids = [campaign["id"] for campaign in campaigns if campaign.get("id")]
+    known_campaign_ids = set(campaign_ids)
 
     clicks_by_campaign: dict[str, list[dict[str, Any]]] = defaultdict(list)
     unattributed = 0
@@ -222,24 +450,23 @@ async def results(admin: Any = Depends(admin_app.require_admin)) -> ResultsRespo
         else:
             unattributed += 1
 
+    leads_source = await _fetch_leads_source(campaign_ids, admin.token)
+
     out: list[CampaignResults] = []
     for campaign in campaigns:
         campaign_id = campaign["id"]
         breakdown = _click_breakdown(clicks_by_campaign.get(campaign_id, []), links_by_id)
+        leads, conversions, cost = _metrics_for_campaign(
+            campaign_id, leads_source, denominator=breakdown.total
+        )
         out.append(
             CampaignResults(
                 campaign_id=campaign_id,
                 campaign_name=campaign.get("name") or "",
                 clicks=breakdown,
-                # `denominator=breakdown.total`: once leads become reachable,
-                # a click-to-lead rate's population is exactly this
-                # campaign's click count. `conversions`/`cost` have no known
-                # denominator here — a conversion rate is a share of leads,
-                # which this plugin cannot see either, and cost is an amount
-                # rather than a share at all.
-                leads=UnmeasuredMetric(denominator=breakdown.total),
-                conversions=UnmeasuredMetric(),
-                cost=UnmeasuredMetric(),
+                leads=leads,
+                conversions=conversions,
+                cost=cost,
             )
         )
 

--- a/tests/test_marketing_results_routes.py
+++ b/tests/test_marketing_results_routes.py
@@ -5,11 +5,18 @@ convention: a fake that actually stores rows and answers `GET .../clicks`
 with a real page of them proves the wiring (method, path, and — new here —
 the `limit`/`offset` pagination params `_list_all` sends) rather than merely
 asserting a call happened with some argument order a reviewer has to trust.
+
+Also covers issue #31's leads-source contract: the instance configures
+`MARKETING_LEADS_SOURCE_URL`, and this plugin calls it and maps the response
+into `leads`/`conversions`/`cost`. `_FakeCore` answers that call too, at a
+fixed fake URL, so these tests exercise the real query-building and
+response-parsing code rather than mocking `_fetch_leads_source` itself.
 """
 
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import parse_qsl
 
 import httpx
 import pytest
@@ -21,18 +28,40 @@ _CAMPAIGN_A = "b3f1c0de-0000-4000-8000-0000000000fa"
 _CAMPAIGN_B = "b3f1c0de-0000-4000-8000-0000000000fb"
 _DELETED_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000fc"
 
+#: Deliberately not `/api/v1/internal/plugins/marketing/...` — the whole
+#: point of issue #31's contract is that the leads source lives on the
+#: INSTANCE's own mount (tabsii's real value is
+#: `/api/v1/internal/tabsii/campaign-results`), not this plugin's own.
+_LEADS_URL = "/api/v1/internal/tabsii/campaign-results"
+
 
 class _FakeCore:
     """An in-memory `marketing_campaign`/`marketing_link`/`marketing_click`
     store, paged the same way the real Core `list` route is (limit/offset,
     default order is whatever insertion order gave it — this fake doesn't
     need to match Core's `created_at DESC` ordering, since nothing under
-    test depends on row order)."""
+    test depends on row order).
+
+    Also stands in for the instance-configured leads source at `_LEADS_URL`:
+    `leads_response` is returned as the 200 body, `leads_status` overrides
+    the status code, and `leads_raises` — if set — is raised instead of
+    returning at all (simulating a timeout/connection failure). Every path
+    requested at `_LEADS_URL` is recorded in `leads_calls` so a test can
+    assert on the exact query string sent.
+    """
 
     def __init__(self) -> None:
         self.campaigns: list[dict[str, Any]] = []
         self.links: list[dict[str, Any]] = []
         self.clicks: list[dict[str, Any]] = []
+        self.leads_response: dict[str, Any] = {"campaigns": []}
+        self.leads_status: int = 200
+        self.leads_raises: Exception | None = None
+        #: When set, returned as the raw (non-JSON) response body instead of
+        #: `leads_response` — simulates the leads source answering with
+        #: something that isn't valid JSON at all.
+        self.leads_raw_body: bytes | None = None
+        self.leads_calls: list[str] = []
 
     def _table(self, path: str) -> list[dict[str, Any]] | None:
         prefix = results_routes._INTERNAL_PREFIX
@@ -44,6 +73,16 @@ class _FakeCore:
 
     async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
         request = httpx.Request(method, f"https://core.invalid{path}")
+        base_path = path.split("?", 1)[0]
+        if base_path == _LEADS_URL:
+            self.leads_calls.append(path)
+            if self.leads_raises is not None:
+                raise self.leads_raises
+            if self.leads_raw_body is not None:
+                return httpx.Response(
+                    self.leads_status, content=self.leads_raw_body, request=request
+                )
+            return httpx.Response(self.leads_status, json=self.leads_response, request=request)
         rows = self._table(path)
         if method != "GET" or rows is None:
             raise AssertionError(f"unexpected call {method} {path}")
@@ -116,10 +155,12 @@ def test_a_campaign_with_no_clicks_reports_a_real_verified_zero(ctx) -> None:
     assert clicks == {"total": 0, "paid": 0, "organic": 0, "unknown_channel_type": 0}
 
 
-def test_leads_conversions_and_cost_are_unmeasurable_never_zero(ctx) -> None:
-    """The milestone's actual claim: no reachable transport exists yet, so
-    these must never render as a bare `0` — that would claim "we looked and
-    nothing happened," which this plugin cannot say."""
+def test_unset_leads_source_url_is_unmeasurable_not_an_error(ctx, monkeypatch) -> None:
+    """Issue #31's contract: `MARKETING_LEADS_SOURCE_URL` unset is a
+    first-class state, not a failure — every platform other than tabsii sees
+    exactly this today. Must never render as a bare `0` — that would claim
+    "we looked and nothing happened," which this plugin cannot say."""
+    monkeypatch.delenv(results_routes._LEADS_SOURCE_URL_ENV, raising=False)
     client, core = ctx
     core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
     core.links = [_link("link-1", _CAMPAIGN_A, is_paid=True)]
@@ -128,14 +169,223 @@ def test_leads_conversions_and_cost_are_unmeasurable_never_zero(ctx) -> None:
     campaign = client.get("/results").json()["campaigns"][0]
 
     assert campaign["leads"]["measurable"] is False
+    assert campaign["leads"]["value"] is None
     assert campaign["leads"]["denominator"] == 2, "the click count, once leads become reachable"
-    assert "issue #31" in campaign["leads"]["reason"]
+    assert campaign["leads"]["reason"] == "no leads source is configured for this deployment"
 
     assert campaign["conversions"]["measurable"] is False
     assert campaign["conversions"]["denominator"] is None, "a lead count this plugin can't see"
+    assert campaign["conversions"]["reason"] == "no leads source is configured for this deployment"
 
     assert campaign["cost"]["measurable"] is False
     assert campaign["cost"]["denominator"] is None
+    assert core.leads_calls == [], "no configured URL means no call is even attempted"
+
+
+def test_leads_source_reports_a_real_zero_distinguishable_from_unmeasurable(
+    ctx, monkeypatch
+) -> None:
+    """A campaign with genuinely no leads (`value: 0, measurable: true`) must
+    render as a real, verified zero — not collapse into the same shape as
+    "no data"."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "No leads yet")]
+    core.leads_response = {
+        "campaigns": [
+            {
+                "campaign_id": _CAMPAIGN_A,
+                "leads": {"value": 0, "measurable": True},
+                "conversions": {"value": 0, "measurable": True},
+                "cost": {"value": 0, "measurable": True},
+            }
+        ]
+    }
+
+    campaign = client.get("/results").json()["campaigns"][0]
+    assert campaign["leads"] == {"value": 0, "measurable": True, "denominator": 0, "reason": None}
+    assert campaign["conversions"] == {
+        "value": 0,
+        "measurable": True,
+        "denominator": None,
+        "reason": None,
+    }
+    assert campaign["cost"]["value"] == 0
+    assert campaign["cost"]["measurable"] is True
+
+
+def test_leads_source_unmeasurable_metric_preserves_the_upstream_reason(ctx, monkeypatch) -> None:
+    """The exact example from issue #31's settled contract: a mix of
+    measured values and one explicitly unmeasurable metric with its own
+    reason, which must survive verbatim rather than being replaced or
+    dropped."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
+    core.leads_response = {
+        "campaigns": [
+            {
+                "campaign_id": _CAMPAIGN_A,
+                "leads": {"value": 12, "measurable": True},
+                "conversions": {"value": 3, "measurable": True},
+                "cost": {
+                    "value": None,
+                    "measurable": False,
+                    "reason": "no spend recorded for this campaign",
+                },
+            }
+        ]
+    }
+
+    campaign = client.get("/results").json()["campaigns"][0]
+    assert campaign["leads"]["value"] == 12
+    assert campaign["leads"]["measurable"] is True
+    assert campaign["conversions"]["value"] == 3
+    assert campaign["conversions"]["measurable"] is True
+    assert campaign["cost"]["measurable"] is False
+    assert campaign["cost"]["value"] is None
+    assert campaign["cost"]["reason"] == "no spend recorded for this campaign"
+
+
+def test_leads_source_unknown_campaign_id_is_unmeasurable_not_an_error(ctx, monkeypatch) -> None:
+    """A campaign the leads source has never heard of (never ran anywhere it
+    tracks) must render as unmeasurable, not fail the whole request."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Never ran anywhere tracked")]
+    core.leads_response = {"campaigns": []}  # source answered; just doesn't know this campaign
+
+    resp = client.get("/results")
+    assert resp.status_code == 200
+    campaign = resp.json()["campaigns"][0]
+    assert campaign["leads"]["measurable"] is False
+    assert (
+        campaign["leads"]["reason"] == "the configured leads source has no data for this campaign"
+    )
+    assert campaign["conversions"]["measurable"] is False
+    assert campaign["cost"]["measurable"] is False
+
+
+@pytest.mark.parametrize(
+    "configure",
+    [
+        pytest.param(lambda core: setattr(core, "leads_status", 500), id="non_200"),
+        pytest.param(
+            lambda core: setattr(core, "leads_response", {"not": "the contract"}),
+            id="malformed_body",
+        ),
+        pytest.param(
+            lambda core: setattr(core, "leads_raises", httpx.ConnectTimeout("simulated timeout")),
+            id="timeout",
+        ),
+        pytest.param(
+            lambda core: setattr(core, "leads_raises", RuntimeError("boom")),
+            id="unexpected_non_http_error",
+        ),
+        pytest.param(
+            lambda core: setattr(core, "leads_raw_body", b"not json at all"), id="non_json_body"
+        ),
+    ],
+)
+def test_a_failing_leads_source_degrades_to_unmeasurable_not_a_500(
+    ctx, monkeypatch, configure
+) -> None:
+    """Every named failure mode (non-200, malformed body, timeout/connection
+    failure) must degrade to unmeasurable-with-a-reason — never a 500 on the
+    whole results dashboard. Clicks, computed locally, must keep rendering
+    regardless of what the leads source does."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
+    core.links = [_link("link-1", _CAMPAIGN_A, is_paid=True)]
+    core.clicks = [_click("c1", _CAMPAIGN_A, "link-1"), _click("c2", _CAMPAIGN_A, "link-1")]
+    configure(core)
+
+    resp = client.get("/results")
+    assert resp.status_code == 200
+    campaign = resp.json()["campaigns"][0]
+    assert campaign["clicks"] == {"total": 2, "paid": 2, "organic": 0, "unknown_channel_type": 0}
+    assert campaign["leads"]["measurable"] is False
+    assert campaign["leads"]["reason"]
+    assert campaign["conversions"]["measurable"] is False
+    assert campaign["cost"]["measurable"] is False
+
+
+@pytest.mark.parametrize(
+    "leads_field",
+    [
+        pytest.param("not a dict at all", id="not_a_dict"),
+        pytest.param({"value": 12}, id="measurable_missing"),
+        pytest.param({"value": "twelve", "measurable": True}, id="value_wrong_type"),
+        pytest.param({"measurable": False}, id="unmeasurable_no_reason_given"),
+    ],
+)
+def test_a_malformed_individual_metric_degrades_without_failing_the_whole_campaign(
+    ctx, monkeypatch, leads_field
+) -> None:
+    """One malformed metric inside an otherwise well-formed response must not
+    crash the request — `_metric_from_raw` degrades just that field, per the
+    contract's "malformed body ... must degrade to unmeasurable" requirement
+    applied at the per-metric level too."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Spring launch")]
+    core.leads_response = {
+        "campaigns": [
+            {
+                "campaign_id": _CAMPAIGN_A,
+                "leads": leads_field,
+                "conversions": {"value": 3, "measurable": True},
+                "cost": {"value": 0, "measurable": True},
+            }
+        ]
+    }
+
+    resp = client.get("/results")
+    assert resp.status_code == 200
+    campaign = resp.json()["campaigns"][0]
+    assert campaign["leads"]["measurable"] is False
+    assert campaign["leads"]["value"] is None
+    assert campaign["leads"]["reason"]
+    # The rest of the entry is unaffected by one bad field.
+    assert campaign["conversions"] == {
+        "value": 3,
+        "measurable": True,
+        "denominator": None,
+        "reason": None,
+    }
+    assert campaign["cost"]["value"] == 0
+
+
+def test_leads_source_is_queried_with_one_repeated_campaign_id_param_per_campaign(
+    ctx, monkeypatch
+) -> None:
+    """The exact wire contract: `?campaign_id=<uuid>&campaign_id=<uuid>...`
+    — one call, all campaign ids, as repeated query params rather than any
+    other encoding (a list, a comma-joined string, ...)."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "A"), _campaign(_CAMPAIGN_B, "B")]
+
+    client.get("/results")
+
+    assert len(core.leads_calls) == 1
+    path = core.leads_calls[0]
+    assert path.startswith(f"{_LEADS_URL}?")
+    pairs = parse_qsl(path.split("?", 1)[1])
+    campaign_id_values = [v for k, v in pairs if k == "campaign_id"]
+    assert set(campaign_id_values) == {_CAMPAIGN_A, _CAMPAIGN_B}
+    assert len(campaign_id_values) == 2, "one param per campaign, not a single joined value"
+
+
+def test_leads_source_is_not_called_when_there_are_no_campaigns(ctx, monkeypatch) -> None:
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+
+    resp = client.get("/results")
+
+    assert resp.status_code == 200
+    assert core.leads_calls == []
 
 
 def test_pagination_gathers_every_click_not_just_the_first_page(ctx) -> None:


### PR DESCRIPTION
## What

Implements the plugin half of #31's settled design (option B): the plugin
declares it needs a leads source, and the instance configures which endpoint
answers it.

`results_routes.py` now reads `MARKETING_LEADS_SOURCE_URL` from the
environment and, when set, calls

```
GET <leads_source_url>?campaign_id=<uuid>&campaign_id=<uuid>...
```

mapping the response into the existing `leads`/`conversions`/`cost` fields on
`/results`, exactly per the contract in #31's final comment:

- **Unset URL is a first-class state, not an error.** Every metric renders
  unmeasurable with `"no leads source is configured for this deployment"` —
  the honest answer every platform other than tabsii sees today.
- **A real zero stays distinguishable from unmeasurable.** `{value: 0,
  measurable: true}` from the source renders as a real, verified zero.
- **An upstream `reason` is preserved verbatim** when `measurable: false`.
- **An unknown/omitted campaign id is unmeasurable, not an error.**
- **The source failing (timeout, non-200, malformed body) degrades to
  unmeasurable-with-a-reason, never a 500** — clicks (computed locally from
  this plugin's own tables) keep rendering regardless.
- `leads`' `denominator=breakdown.total` behaviour is unchanged.
- No reference to `demo_requests`, `lead_source_costs`, or anything else
  tabsii-specific — this file knows only the wire contract.

`CampaignResults.leads/conversions/cost` move from the always-unmeasurable
`UnmeasuredMetric` shape to a new `Metric` model that can also carry a real
measured value. `UnmeasuredMetric` itself is untouched and still used as-is
by `paid_pack_routes.py`'s separate, still-genuinely-unreachable `spend`
field (lightly corrected its docstring, which had gone stale by claiming the
same gap this PR just closed for `results_routes.py`).

## Tests

`tests/test_marketing_results_routes.py`'s fake Core now also answers the
configured leads-source URL, so these exercise the real query-building and
response-parsing code, not a mock of `_fetch_leads_source`:

- `test_unset_leads_source_url_is_unmeasurable_not_an_error`
- `test_leads_source_reports_a_real_zero_distinguishable_from_unmeasurable`
- `test_leads_source_unmeasurable_metric_preserves_the_upstream_reason`
- `test_leads_source_unknown_campaign_id_is_unmeasurable_not_an_error`
- `test_a_failing_leads_source_degrades_to_unmeasurable_not_a_500` (parametrized:
  non-200, malformed body, timeout, an unexpected non-HTTP error, and a
  non-JSON body)
- `test_a_malformed_individual_metric_degrades_without_failing_the_whole_campaign`
  (parametrized: not a dict, `measurable` missing, wrong `value` type,
  `measurable: false` with no `reason`)
- `test_leads_source_is_queried_with_one_repeated_campaign_id_param_per_campaign`
  — asserts the exact wire shape (`?campaign_id=...&campaign_id=...`, not a
  list or comma-joined string)
- `test_leads_source_is_not_called_when_there_are_no_campaigns`

Also fixed the one pre-existing test that asserted the old
always-`UnmeasuredMetric` reason text, since that state (URL unset) now
renders the new, contract-mandated reason instead.

`tests/test_marketing_core_paths_guard.py` needed no changes: the leads
source URL is read from the environment at runtime, so its call site is
never a statically-resolvable literal and the guard's AST walk already skips
it (verified — the full guard suite is green).

## Gates run locally

`uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`,
`uv run pytest --cov` (461 passed, `results_routes.py` at 100% coverage), and
the repo's own pre-push `verify` gate (ruff/pyright/pytest/terraform-fmt/
plugin-tf/plugin-names/adr-numbering/gitleaks/web-admin lint+typecheck+test) —
all green.

## Not implemented here (by design)

The instance side — an actual `/api/v1/internal/tabsii/campaign-results`
route in tabsii-platform, and setting `MARKETING_LEADS_SOURCE_URL` via
`plugin_host_environment` — is out of scope for this repo and this PR, per
the task ("implement the PLUGIN half"). Per-unit attribution (#73) is
explicitly out of scope per #31's own "Not in scope" section.

Closes #31
