### PR TITLE
fix(campaign-studio): stop repeating research citations across every artefact

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -116,7 +116,22 @@ class Source(BaseModel):
     """A piece of evidence an agent actually found, not a plausible-looking
     citation. The prompts require these to come from search results —
     ``url`` is required and non-empty by construction, so a claim with no
-    citation cannot be represented, only omitted."""
+    citation cannot be represented, only omitted.
+
+    ``note`` is deliberately NOT ``min_length=1``. On a research finding it
+    should always carry real content — that is the only place a source's
+    note is ever rendered in full (``ArtefactBody.tsx``'s ``SourceList``).
+    Downstream (positioning, channel plan, copy), the prompts now tell an
+    agent to leave ``note`` empty rather than retype the research finding's
+    note into every segment/pillar/CTA/channel that draws on it: a note
+    copied verbatim onto several items carries no information past its first
+    appearance, and was the reported "same explanatory notes... appearing
+    over and over" defect. The UI never shows a downstream item's ``note``
+    at all (``SourceRefs``, as opposed to research's ``SourceList``), so an
+    empty one costs nothing and a non-empty one is simply ignored there —
+    the field stays on every downstream item because the citation guard
+    (``pipeline.py``) counts entries in ``sources``, not characters in
+    ``note``."""
 
     url: str = Field(min_length=1, description="A URL the agent actually found.")
     note: str = Field(description="What this source shows, in one sentence.")
@@ -464,11 +479,17 @@ Turn the research into:
 3. **Calls to action** — candidate CTAs, each tied to the segment(s) and
    pillar(s) it serves.
 
-Every segment, pillar and CTA must carry `sources`: copy the relevant
-`Source` objects (url and note) from the research findings you were given —
-verbatim, not reworded. Never invent a source, and never produce a segment,
-pillar or CTA that cites nothing: if the research does not support a claim,
-do not make the claim.
+Every segment, pillar and CTA must carry `sources`: copy the `url` of each
+relevant `Source` from the research findings you were given, exactly as
+written — never invent one, alter one, or cite one you were not shown. For
+`note`, do NOT paste the research finding's note verbatim: your segment,
+pillar or CTA already has its own `description`/`rationale` explaining why it
+follows from the research, so a `note` that repeats that finding's note word
+for word adds nothing an operator hasn't already read twice. Write one short
+phrase naming what THIS item specifically draws from that source that its
+`description`/`rationale` doesn't already say, or leave `note` empty if there
+is nothing left to add. Never produce a segment, pillar or CTA that cites
+nothing: if the research does not support a claim, do not make the claim.
 
 If the research is too thin to support any segment, pillar or CTA, return
 empty lists rather than inventing content to fill them.
@@ -516,10 +537,13 @@ behind it is the most confident-sounding fabrication in this pipeline —
 anyone researched it, so generic channel wisdom is not an acceptable
 rationale.
 
-Every recommendation must carry `sources`: copy the relevant `Source` objects
-(url and note) from the positioning you were given — verbatim, not reworded.
-Never invent a source, and never recommend a channel that cites nothing: if
-the positioning does not support recommending a channel, do not recommend it.
+Every recommendation must carry `sources`: copy the `url` of each relevant
+`Source` from the positioning you were given, exactly as written. For `note`,
+do not paste the positioning item's note verbatim — your `rationale` already
+says why this channel follows from the evidence, so repeat only what a
+`note` genuinely adds beyond that, or leave it empty. Never invent a source,
+and never recommend a channel that cites nothing: if the positioning does not
+support recommending a channel, do not recommend it.
 
 If the positioning is too thin to support any recommendation in a motion,
 return fewer channels (or none) for that motion rather than inventing content
@@ -555,12 +579,14 @@ each channel:
 3. Ground every line in the positioning's segments, pillars and CTAs — never
    in generic marketing copy that could belong to any campaign.
 
-Every channel's copy must carry `sources`: copy the relevant `Source`
-objects (url and note) from the positioning pillar(s) or CTA(s) you drew from
-— verbatim, not reworded. Never invent a source, and never produce copy for a
-channel that cites nothing: if the positioning does not support what you
-would write, do not write it — omit that channel's copy rather than filling
-it with something ungrounded.
+Every channel's copy must carry `sources`: copy the `url` of each relevant
+`Source` from the positioning pillar(s) or CTA(s) you drew from, exactly as
+written. For `note`, do not paste the pillar's or CTA's note verbatim — say
+only what is specific to this piece of copy beyond that, or leave it empty.
+Never invent a source, and never produce copy for a channel that cites
+nothing: if the positioning does not support what you would write, do not
+write it — omit that channel's copy rather than filling it with something
+ungrounded.
 
 {_UNTRUSTED_INPUT_RULE}
 Return your answer by calling the `{COPY_TOOL_NAME}` tool exactly once. Do

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -14,13 +14,19 @@ this module adds is the part that is genuinely paid-only:
    artefact's channels already exist (``copy_routes.py``, M5); this module
    filters to the ``paid`` ones and trims headline/body/cta to the limit its
    guessed platform actually enforces, never mid-word.
-2. **Targeting**, drawn straight from the approved positioning artefact's
+2. **Targeting**, drawn from the approved positioning artefact's
    ``segments`` — the only audience description this pipeline has ever
    produced, and the plugin's own citation discipline (every segment carries
-   ``sources``) already makes it a defensible brief rather than a guess. An
-   approved positioning with zero segments 404s rather than shipping an
-   empty targeting brief silently — the same gap-must-be-visible discipline
-   this file uses for ``paid_channels``.
+   ``sources``) already makes it a defensible brief rather than a guess. Only
+   ``name``, ``description`` and a ``source_count`` cross into the brief
+   (``_targeting_segment``): the full ``{url, note}`` pairs stay on the
+   positioning artefact itself, which is where an operator reviews evidence.
+   Carrying them into every paid brief too was the reported duplication —
+   the same handful of research URLs and notes, repeated verbatim on every
+   segment of every downstream artefact that touched them. An approved
+   positioning with zero segments 404s rather than shipping an empty
+   targeting brief silently — the same gap-must-be-visible discipline this
+   file uses for ``paid_channels``.
 3. **A budget recommendation.** This plugin calls no ad platform API and has
    no historical spend or performance data to optimise against, so this is a
    declared, fixed starting-point heuristic — not a bidding model — and says
@@ -253,6 +259,28 @@ def _budget_recommendation(paid_channel_count: int) -> dict[str, Any]:
     }
 
 
+def _targeting_segment(segment: dict[str, Any]) -> dict[str, Any]:
+    """One positioning segment, shaped for the targeting brief.
+
+    Deliberately drops the segment's full `sources` (each a `{url, note}`
+    pair) down to a bare count. The full citations already live on the
+    positioning artefact this pack was built from — this brief is meant to be
+    read by a person setting up ad targeting, not to re-litigate the
+    evidence, and repeating every source's URL and note on every segment here
+    was the exact duplication reported against the campaign studio: the same
+    handful of research URLs, verbatim, on every artefact that touches a
+    segment. `source_count` keeps the "this is evidenced, not a guess" signal
+    (the module docstring's own reasoning for using segments here) without
+    reprinting the evidence itself.
+    """
+    sources = segment.get("sources") or []
+    return {
+        "name": segment.get("name"),
+        "description": segment.get("description"),
+        "source_count": len(sources),
+    }
+
+
 @router.get("/campaigns/{campaign_id}/paid-pack")
 async def get_paid_pack_route(
     campaign_id: str,
@@ -347,12 +375,13 @@ async def get_paid_pack_route(
         if isinstance(raw_positioning_body, str)
         else (raw_positioning_body or {})
     )
-    targeting = positioning_body.get("segments") or []
-    if not targeting:
+    raw_segments = positioning_body.get("segments") or []
+    if not raw_segments:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The approved positioning artefact has no segments to target.",
         )
+    targeting = [_targeting_segment(s) for s in raw_segments]
 
     ad_platforms = await _channel_ad_platforms(admin.token)
 

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -441,8 +441,19 @@ def test_assembles_the_paid_pack(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["assets"][0]["is_source"] is True
     assert set(body["missing_placements"]) == set(PLACEMENTS)
 
-    # 3. Targeting: the approved positioning's segments, verbatim.
-    assert body["targeting"] == _SEGMENTS
+    # 3. Targeting: name + description from the approved positioning's
+    # segments, plus a source count — never the full {url, note} pairs.
+    # Those stay on the positioning artefact; repeating them here (the same
+    # handful of research URLs and notes on every downstream artefact) was
+    # the reported duplication.
+    assert body["targeting"] == [
+        {
+            "name": "Multi-site operators",
+            "description": "Operators running more than one location.",
+            "source_count": 1,
+        }
+    ]
+    assert "sources" not in body["targeting"][0]
 
     # 4. Budget: a stated, non-fabricated heuristic over the paid channel
     # count (2 here), not a bid-optimisation number.

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -412,6 +412,60 @@ def test_channel_copy_cannot_be_built_with_empty_sources() -> None:
         )
 
 
+def test_segment_cannot_be_built_with_empty_sources() -> None:
+    """Same structural half of the guard, for `Segment` (M3 positioning) —
+    the one the duplicated-links defect touched directly: fixing how sources
+    are rendered/attached downstream must not loosen this `min_length=1`."""
+    from pydantic import ValidationError
+
+    from marketing.definitions import Segment
+
+    with pytest.raises(ValidationError):
+        Segment(name="x", description="y", sources=[])
+
+
+def test_message_pillar_cannot_be_built_with_empty_sources() -> None:
+    """Same structural half of the guard, for `MessagePillar` (M3 positioning)."""
+    from pydantic import ValidationError
+
+    from marketing.definitions import MessagePillar
+
+    with pytest.raises(ValidationError):
+        MessagePillar(pillar="x", rationale="y", sources=[])
+
+
+def test_call_to_action_cannot_be_built_with_empty_sources() -> None:
+    """Same structural half of the guard, for `CallToAction` (M3 positioning)."""
+    from pydantic import ValidationError
+
+    from marketing.definitions import CallToAction
+
+    with pytest.raises(ValidationError):
+        CallToAction(text="x", rationale="y", sources=[])
+
+
+def test_source_note_may_be_empty_but_url_still_cannot() -> None:
+    """The de-duplication fix (definitions.py's `POSITIONING_INSTRUCTIONS` /
+    `CHANNEL_PLAN_INSTRUCTIONS` / `COPY_INSTRUCTIONS`) now tells downstream
+    agents to leave `note` empty rather than paste a research note verbatim —
+    so `note` must genuinely accept `""`. `url` must not: it is the actual
+    citation, `Field(min_length=1)`, and nothing about this fix should touch
+    that half of the guard."""
+    from pydantic import ValidationError
+
+    from marketing.definitions import Segment, Source
+
+    # note="" is a legitimate downstream citation now — must not raise.
+    segment = Segment(
+        name="x", description="y", sources=[Source(url="https://example.com/a", note="")]
+    )
+    assert segment.sources[0].note == ""
+
+    # url="" must still be rejected — the guard's actual teeth are unchanged.
+    with pytest.raises(ValidationError):
+        Source(url="", note="")
+
+
 # ── extract_research_findings — per-angle, degrades rather than fails ────────
 #
 # Unlike the synthesis/positioning extractors above, one research angle

--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -9,6 +9,7 @@ import {
   PositioningArtefact,
   ResearchArtefact,
   SourceList,
+  SourceRefs,
 } from './ArtefactBody'
 
 /** A stub taxonomy lookup — the real one is `useChannelTaxonomy`'s hook,
@@ -43,7 +44,7 @@ describe('SourceList', () => {
 })
 
 describe('ResearchArtefact', () => {
-  it('renders the summary and every finding with its sources', () => {
+  it('renders the summary and every finding, with its citation reachable via the Sources cited list', () => {
     render(
       <ResearchArtefact
         body={{
@@ -61,6 +62,40 @@ describe('ResearchArtefact', () => {
     expect(screen.getByText('Owners want faster onboarding.')).toBeInTheDocument()
     expect(screen.getByText('Competitors take 3 weeks')).toBeInTheDocument()
     expect(screen.getByText('https://example.com/report')).toBeInTheDocument()
+    expect(screen.getByText('Industry report')).toBeInTheDocument()
+    // The finding itself points at the citation with a compact marker, not
+    // a second copy of the URL — the URL text above is the canonical list's.
+    expect(screen.getByText('[1]')).toBeInTheDocument()
+  })
+
+  it('prints a source shared by several findings exactly once, not once per finding (#93 follow-up)', () => {
+    // Live evidence this regresses against: a real research run had
+    // https://gorilladash.com/ cited by 4 of 5 findings, each printing the
+    // full URL and note — 13 source lines for 5 unique URLs.
+    const shared = { url: 'https://gorilladash.com/', note: 'All-in-one franchise platform.' }
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'Multiple angles converge on one competitor.',
+          findings: [
+            {
+              signal: 'Audience signal A',
+              why_it_matters: 'Matters A',
+              sources: [shared],
+            },
+            {
+              signal: 'Audience signal B',
+              why_it_matters: 'Matters B',
+              sources: [shared],
+            },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getAllByText('https://gorilladash.com/')).toHaveLength(1)
+    expect(screen.getAllByText('All-in-one franchise platform.')).toHaveLength(1)
+    // Both findings still carry a working, distinct pointer to it.
+    expect(screen.getAllByText('[1]')).toHaveLength(2)
   })
 })
 
@@ -99,6 +134,64 @@ describe('PositioningArtefact', () => {
     expect(screen.getByText('https://example.com/segment')).toBeInTheDocument()
     expect(screen.getByText('https://example.com/pillar')).toBeInTheDocument()
     expect(screen.getByText('https://example.com/cta')).toBeInTheDocument()
+  })
+
+  it('never renders a source note downstream, even when the agent copied it byte-for-byte onto every item (#93 follow-up)', () => {
+    // Live evidence this regresses against: an identical note string
+    // appeared under a segment AND a message pillar AND in research — the
+    // note carries no new information at its 2nd/3rd appearance, and the
+    // fix is that it is not shown here at all, only the reference count.
+    const copiedVerbatimNote =
+      "States that most networks use their platform to replace 'six to ten separate subscriptions'."
+    render(
+      <PositioningArtefact
+        body={{
+          segments: [
+            {
+              name: 'Busy owners',
+              description: 'Time-poor franchise owners.',
+              sources: [{ url: 'https://example.com/shared', note: copiedVerbatimNote }],
+            },
+          ],
+          pillars: [
+            {
+              pillar: 'Onboard in a day, not a month',
+              rationale: 'Speed is the differentiator',
+              sources: [{ url: 'https://example.com/shared', note: copiedVerbatimNote }],
+            },
+          ],
+          ctas: [],
+        }}
+      />,
+    )
+    expect(screen.queryByText(copiedVerbatimNote)).not.toBeInTheDocument()
+    // The compact reference is still there — provenance is not lost, only
+    // the repeated note text.
+    expect(screen.getAllByText(/1 source cited/)).toHaveLength(2)
+  })
+})
+
+describe('SourceRefs', () => {
+  it('collapses a source list to a count, deduplicated by URL, with no note text', () => {
+    render(
+      <SourceRefs
+        sources={[
+          { url: 'https://example.com/a', note: 'Note A' },
+          { url: 'https://example.com/a', note: 'Note A repeated' },
+          { url: 'https://example.com/b', note: 'Note B' },
+        ]}
+      />,
+    )
+    expect(screen.getByText(/2 sources cited/)).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/a')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com/b')).toBeInTheDocument()
+    expect(screen.queryByText('Note A')).not.toBeInTheDocument()
+    expect(screen.queryByText('Note B')).not.toBeInTheDocument()
+  })
+
+  it('says plainly when there are no sources — the zero-citation case', () => {
+    render(<SourceRefs sources={[]} />)
+    expect(screen.getByText(/no sources cited/i)).toBeInTheDocument()
   })
 })
 

--- a/web-admin/src/components/ArtefactBody.tsx
+++ b/web-admin/src/components/ArtefactBody.tsx
@@ -12,8 +12,17 @@ import { ChannelName } from './ChannelName'
 
 /** Every artefact kind's body is grounded in citations, and the citations are
  * the whole reason a human approval gate exists here at all — see
- * `pipeline.py`'s module docstring on the zero-citation guard. Shown next to
- * every claim, never collapsed into a count. */
+ * `pipeline.py`'s module docstring on the zero-citation guard.
+ *
+ * This is the ONE place a source's full `url` and `note` are ever printed —
+ * `ResearchArtefact` below, once per unique URL. Every downstream artefact
+ * (positioning, channel plan, copy) uses `SourceRefs` instead, which points
+ * back here rather than repeating the same URL and note on every segment,
+ * pillar, CTA, channel and piece of copy that draws on it — the literal
+ * defect reported: the same handful of research links and explanatory notes
+ * "duplicated everywhere" in the campaign studio. Provenance still lives in
+ * the data on every one of those items (`sources`, `Field(min_length=1)` in
+ * `definitions.py`) — only the RENDERING stops repeating it in full. */
 export function SourceList({ sources }: { sources: Source[] }) {
   if (sources.length === 0) {
     return <p className="no-sources">No sources cited.</p>
@@ -25,10 +34,94 @@ export function SourceList({ sources }: { sources: Source[] }) {
           <a href={s.url} target="_blank" rel="noreferrer">
             {s.url}
           </a>
-          <span className="note">{s.note}</span>
+          {s.note !== '' && <span className="note">{s.note}</span>}
         </li>
       ))}
     </ul>
+  )
+}
+
+/** The first occurrence of each URL, in encounter order — used both to build
+ * the research artefact's single canonical source list (so a URL cited by
+ * four findings is printed once, not four times) and to collapse one item's
+ * own `sources` down to what it actually adds. */
+function dedupeByUrl(sources: Source[]): Source[] {
+  const seen = new Set<string>()
+  const unique: Source[] = []
+  for (const s of sources) {
+    if (seen.has(s.url)) continue
+    seen.add(s.url)
+    unique.push(s)
+  }
+  return unique
+}
+
+/** A downstream item's compact pointer back to its evidence — a count plus,
+ * on request, the bare URLs (never the note: the note is where the verbatim
+ * duplication was worst, since the agent copied it wholesale from the
+ * research finding it drew from). Collapsed by default via `<details>`, so
+ * reviewing ten segments does not mean scrolling past the same citation ten
+ * times — the count alone already answers "is this grounded", which is what
+ * an operator scanning the artefact needs; the URLs are here for whoever
+ * wants to check one. */
+export function SourceRefs({ sources }: { sources: Source[] }) {
+  const unique = dedupeByUrl(sources)
+  if (unique.length === 0) {
+    return <p className="no-sources">No sources cited.</p>
+  }
+  return (
+    <details className="source-refs">
+      <summary>
+        {unique.length} source{unique.length === 1 ? '' : 's'} cited — see Research for the full citation
+      </summary>
+      <ul className="source-refs-list">
+        {unique.map((s) => (
+          <li key={s.url}>
+            <a href={s.url} target="_blank" rel="noreferrer">
+              {s.url}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
+}
+
+/** A research finding's compact pointer into the artefact's own "Sources
+ * cited" list, built once from every finding's sources combined
+ * (`ResearchArtefact`'s `indexByUrl`). This is what stops the WITHIN-research
+ * duplication: five findings that between them cite four unique URLs used to
+ * print each URL and its note up to five times over; each finding now prints
+ * a numbered marker instead, and the URL/note appear exactly once, in the
+ * canonical list below. The marker still links straight to the source and
+ * carries its note as a `title` tooltip, so nothing is less reachable — only
+ * less repeated. */
+function CitationMarkers({
+  sources,
+  indexByUrl,
+}: {
+  sources: Source[]
+  indexByUrl: Map<string, number>
+}) {
+  const unique = dedupeByUrl(sources)
+  if (unique.length === 0) {
+    return <p className="no-sources">No sources cited.</p>
+  }
+  return (
+    <p className="citation-markers">
+      {unique.map((s) => (
+        <a
+          key={s.url}
+          className="citation-marker"
+          href={s.url}
+          target="_blank"
+          rel="noreferrer"
+          title={s.note !== '' ? s.note : s.url}
+        >
+          [{indexByUrl.get(s.url)}]
+        </a>
+      ))}
+    </p>
   )
 }
 
@@ -47,15 +140,25 @@ interface FindingItem {
  * artefact kind's body is a list of exactly this shape (a heading, some
  * prose, and its sources), so the four renderers below share this one loop
  * rather than repeating `.map(...) => <div className="finding">…` four
- * times with nothing to keep them in step. */
-function FindingGroup({ items }: { items: FindingItem[] }) {
+ * times with nothing to keep them in step.
+ *
+ * `renderSources` is the one thing that varies: the research artefact prints
+ * full citations (`SourceList`) since it is the single home for them; every
+ * other artefact prints a compact reference (`SourceRefs`) instead. */
+function FindingGroup({
+  items,
+  renderSources,
+}: {
+  items: FindingItem[]
+  renderSources: (sources: Source[]) => ReactNode
+}) {
   return (
     <>
       {items.map((item) => (
         <div className="finding" key={item.key}>
           {item.heading}
           {item.body}
-          <SourceList sources={item.sources} />
+          {renderSources(item.sources)}
         </div>
       ))}
     </>
@@ -63,6 +166,13 @@ function FindingGroup({ items }: { items: FindingItem[] }) {
 }
 
 export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
+  // One canonical, deduplicated citation list for the whole artefact — a URL
+  // cited by several findings (common: two findings from different angles
+  // independently landing on the same source) used to print its full URL and
+  // note once per finding. Each finding now points at this list instead of
+  // repeating it.
+  const allSources = dedupeByUrl(body.findings.flatMap((f) => f.sources))
+  const indexByUrl = new Map(allSources.map((s, i) => [s.url, i + 1]))
   return (
     <div className="artefact-body">
       <p className="summary">{body.summary}</p>
@@ -73,7 +183,10 @@ export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
           body: <p>{f.why_it_matters}</p>,
           sources: f.sources,
         }))}
+        renderSources={(sources) => <CitationMarkers sources={sources} indexByUrl={indexByUrl} />}
       />
+      <h4>Sources cited</h4>
+      <SourceList sources={allSources} />
     </div>
   )
 }
@@ -89,6 +202,7 @@ export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
           body: <p>{s.description}</p>,
           sources: s.sources,
         }))}
+        renderSources={(sources) => <SourceRefs sources={sources} />}
       />
 
       <h4>Message pillars</h4>
@@ -99,6 +213,7 @@ export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
           body: <p>{p.rationale}</p>,
           sources: p.sources,
         }))}
+        renderSources={(sources) => <SourceRefs sources={sources} />}
       />
 
       <h4>Calls to action</h4>
@@ -109,6 +224,7 @@ export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
           body: <p>{c.rationale}</p>,
           sources: c.sources,
         }))}
+        renderSources={(sources) => <SourceRefs sources={sources} />}
       />
     </div>
   )
@@ -137,6 +253,7 @@ export function ChannelPlanArtefact({
           body: <p>{c.rationale}</p>,
           sources: c.sources,
         }))}
+        renderSources={(sources) => <SourceRefs sources={sources} />}
       />
     </div>
   )
@@ -163,6 +280,7 @@ export function CopyArtefact({ body, channelLookup }: { body: CopySetBody; chann
           ),
           sources: c.sources,
         }))}
+        renderSources={(sources) => <SourceRefs sources={sources} />}
       />
     </div>
   )

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -45,7 +45,7 @@ describe('PaidPack', () => {
           ],
           assets: [],
           missing_placements: ['feed_1x1'],
-          targeting: [{ name: 'Busy owners', description: 'Time-poor franchise owners.', sources: [] }],
+          targeting: [{ name: 'Busy owners', description: 'Time-poor franchise owners.', source_count: 2 }],
           budget: {
             currency: 'USD',
             channel_count: 1,
@@ -72,6 +72,9 @@ describe('PaidPack', () => {
     expect(await screen.findByText(/missing renders for: feed_1x1/i)).toBeInTheDocument()
     expect(screen.getByText(/trimmed to 125 chars/i)).toBeInTheDocument()
     expect(screen.getByText('Busy owners')).toBeInTheDocument()
+    // Grounded, but the full {url, note} pairs are not repeated here — only
+    // a count, pointing back at the positioning artefact for the citations.
+    expect(screen.getByText(/grounded in 2 research sources/i)).toBeInTheDocument()
     expect(screen.getByText(/1 paid channel\(s\)/)).toBeInTheDocument()
     expect(screen.getByText(/not measurable — no route reachable/i)).toBeInTheDocument()
   })

--- a/web-admin/src/components/PaidPack.tsx
+++ b/web-admin/src/components/PaidPack.tsx
@@ -78,6 +78,10 @@ export function PaidPack({ campaignId }: { campaignId: string }) {
               <li key={`${s.name}-${i}`}>
                 <strong>{s.name}</strong>
                 <p>{s.description}</p>
+                <p className="hint">
+                  Grounded in {s.source_count} research source{s.source_count === 1 ? '' : 's'} — see the
+                  positioning artefact for the full citations.
+                </p>
               </li>
             ))}
           </ul>

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -348,6 +348,39 @@ button.secondary {
   font-style: italic;
 }
 
+/* Downstream artefacts (positioning, channel plan, copy) point back at
+   research's full citations instead of repeating them — see
+   ArtefactBody.tsx's SourceRefs. Collapsed by default so scanning several
+   segments/pillars/CTAs doesn't mean scrolling past the same citation
+   repeatedly. */
+.source-refs {
+  margin: 0.4rem 0 0;
+  font-size: 0.75rem;
+}
+
+.source-refs summary {
+  cursor: pointer;
+  color: #666;
+}
+
+.source-refs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.3rem 0 0;
+}
+
+/* A research finding's compact pointer into the artefact's own "Sources
+   cited" list (ArtefactBody.tsx's CitationMarkers) — the URL and note print
+   once in that list rather than once per finding that cites it. */
+.citation-markers {
+  margin: 0.3rem 0 0;
+}
+
+.citation-marker {
+  font-size: 0.75rem;
+  margin-right: 0.4rem;
+}
+
 .warning {
   background: #fff3cd;
   color: #7a5b00;

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -586,12 +586,25 @@ export interface BudgetRecommendation {
   basis: string
 }
 
+/** One segment as it appears in the paid pack's targeting brief —
+ * `paid_pack_routes.py`'s `_targeting_segment`. Deliberately NOT `Segment`:
+ * the full `sources` (`{url, note}` pairs) stay on the positioning artefact,
+ * where an operator reviews evidence. Repeating them on every targeting
+ * entry too was the reported duplication — the same handful of research
+ * URLs and notes on every artefact that touched a segment. `source_count`
+ * keeps the "this is evidenced" signal without the repetition. */
+export interface TargetingSegment {
+  name: string
+  description: string
+  source_count: number
+}
+
 export interface PaidPack {
   campaign_id: string
   ad_copy: AdCopyVariant[]
   assets: PackAsset[]
   missing_placements: string[]
-  targeting: Segment[]
+  targeting: TargetingSegment[]
   budget: BudgetRecommendation
   links: PackLink[]
   guidance: string


### PR DESCRIPTION
## The report

Operators saw the same source URLs and explanatory notes "duplicated
everywhere" in the campaign studio — the decisive instruction was "the links
should be within research, no idea why they keep coming through."

## Investigation

Checked against a live campaign on tabsii dev
(`f7e38903-b99a-483b-8741-4313ca79a282`). Two distinct causes, both real:

**1. Within the research artefact itself.** Each finding rendered its own
full source list. Across 5 findings citing 4 unique URLs, one URL appeared 4
times and another 3 — the full URL and note printed once per finding that
cited it, not once per unique source.

**2. Across artefacts, byte-identical.** Every positioning segment, message
pillar, channel recommendation and piece of copy carried a full `sources`
list, and `POSITIONING_INSTRUCTIONS` / `CHANNEL_PLAN_INSTRUCTIONS` /
`COPY_INSTRUCTIONS` told the agent to copy each `Source`'s `url` **and**
`note` "verbatim, not reworded" from the artefact one stage up. That
instruction is the actual cause: the identical note string showed up under a
segment *and* a message pillar *and* in research, because the prompt
literally told the agent to retype it unchanged into each one. A note
repeated three times character-for-character carries no new information at
its 2nd or 3rd appearance — it isn't evidence for three different claims,
it's one piece of evidence pasted three times.

So this is **both** a rendering problem (1) and a source-attachment problem
(2) — not one or the other.

## What changed, and where

**Data (`src/marketing/definitions.py`)** — prompt text only, no schema
change:
- `Source` (`url`/`note`) is unchanged: still on every `ResearchFinding`,
  `Segment`, `MessagePillar`, `CallToAction`, `ChannelRecommendation` and
  `ChannelCopy`, still `sources: list[Source] = Field(min_length=1)`
  everywhere it already was. The citation guard (#22's subject) reads
  exactly the same data it always did.
- What changed is the instruction downstream agents are given for `note`:
  copy the `url` forward exactly (still required, still verbatim, still the
  actual citation) but do **not** retype the upstream item's `note` — the
  item's own `description`/`rationale` already explains why it follows from
  the research, so a `note` that repeats that verbatim adds nothing. Write a
  short addition if there's something new to say, or leave it empty.
  `Source.note` has no `min_length`, so `note=""` was already valid Pydantic
  — this was a prompt gap, not a schema gap.
- `paid_pack_routes.py`'s new `_targeting_segment` shapes the paid pack's
  `targeting` entries down to `{name, description, source_count}` — the full
  `{url, note}` pairs stay on the positioning artefact, where an operator
  reviews evidence; the paid brief only needs to say "this is grounded", not
  reprint the grounding. (`PaidPack.tsx` never rendered `sources` before
  this change either, so this is a payload-shaping fix, not a rendering
  regression.)

**Rendering (`web-admin/src/components/ArtefactBody.tsx`)** — this is where
most of the actual fix lives:
- `ResearchArtefact` now builds one deduplicated "Sources cited" list across
  all findings (first-seen order) and each finding shows a compact numbered
  marker (`[1]`, `[2]`, …) linking to the source, with the note as a
  `title` tooltip, instead of repeating the full URL and note per finding.
  This is the *only* place a source's full `url`+`note` is ever printed now.
- `PositioningArtefact`, `ChannelPlanArtefact`, `CopyArtefact` now render a
  new `SourceRefs` component instead of the old `SourceList`: a collapsed
  `<details>` showing "N source(s) cited — see Research for the full
  citation", expandable to the bare deduplicated URLs. The `note` is never
  rendered downstream, full stop — the exact text the user was seeing
  "everywhere" is no longer in that DOM at all, whatever the underlying data
  says.

## What I deliberately did NOT change

Per the steer I was given mid-task: this is **not** a reason to strip
`sources` from any downstream schema. Every one of
`Segment`/`MessagePillar`/`CallToAction`/`ChannelRecommendation`/
`ChannelCopy` still requires `sources: list[Source]` with `min_length=1`,
and `Source.url` is still `min_length=1`. The guard's structural half
(`_total_citations` / `flatten_citations` in `pipeline.py`) is completely
untouched.

I also found the **organic** pack (`pack_routes.py`'s `"copy": channels`)
passes the approved copy artefact's channels through verbatim, sources
included — same latent duplication as the paid pack had, but
`DistributionPack.tsx` never renders `.sources` so it isn't user-visible
today. Left alone to keep this PR scoped to the reported defect; flagging it
here rather than silently leaving it undiscovered.

## Proof the citation guard still fires

New tests in `tests/test_marketing_pipeline.py`:
- `test_segment_cannot_be_built_with_empty_sources`,
  `test_message_pillar_cannot_be_built_with_empty_sources`,
  `test_call_to_action_cannot_be_built_with_empty_sources` — closes a gap
  that existed *before* this change: `ResearchFinding`/`ChannelRecommendation`
  /`ChannelCopy` already had a direct "cannot be built with `sources=[]`"
  test each; `Segment`/`MessagePillar`/`CallToAction` (the three types this
  fix's prompt changes touch most directly) did not. All three now do.
- `test_source_note_may_be_empty_but_url_still_cannot` — the regression test
  this fix specifically needed: proves `Source(url=..., note="")` is valid
  (the new legitimate case) while `Source(url="", note=...)` still raises
  `ValidationError` — so a future change that "cleans up" by loosening `url`
  right after this PR loosened `note` gets caught immediately.
- All pre-existing `NoCitationsError` guard tests
  (`test_positioning_with_no_segments_pillars_or_ctas_raises_no_citations`
  etc.) pass unchanged — nothing about the aggregate zero-citation guard
  moved.

`web-admin/src/components/ArtefactBody.test.tsx` adds:
- A test proving a source shared by two findings prints its URL and note
  **exactly once** in `ResearchArtefact`, not once per finding.
- A test proving a note copied byte-for-byte onto a segment and a pillar
  (mirroring the live evidence) is **not** in the rendered DOM at all for
  `PositioningArtefact`, while the compact source-count reference still is —
  provenance reachable, duplication gone.
- Direct `SourceRefs` tests: dedup by URL, no note text ever, correct
  zero-sources message.

## What I did not verify

- **The prompt change is unverified against a live model.** I have no
  OpenRouter/agent-run access from this environment. The instruction change
  in `definitions.py` is a legitimate fix for what the evidence showed (the
  prompt literally said "verbatim, not reworded"), but whether the model
  actually stops retyping notes can only be confirmed by running a real
  campaign through positioning/channel-plan/copy on dev and inspecting the
  output — flagging this explicitly rather than claiming it's proven.
- **web-admin has no CI job in this repo** (`.github/workflows/ci.yml` has
  no `pnpm`/`web-admin` step at all — pre-existing, not something this PR
  introduces). I ran `pnpm run typecheck`, `pnpm run lint`, and
  `pnpm vitest run` locally (94/94 passing) since nothing else will.
- I did not touch `pack_routes.py`'s organic-pack `copy` passthrough — see
  above.

## Local gates run

- `uv run pytest -q` — 451 passed
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright` — 0 errors
- `pnpm run typecheck` / `pnpm run lint` / `pnpm vitest run` (web-admin) —
  clean, 94/94 tests passing
