### PR TITLE
fix(marketing): stop treating a source-omitted campaign as unmeasurable

### DIFF
--- a/src/marketing/results_routes.py
+++ b/src/marketing/results_routes.py
@@ -58,8 +58,20 @@ timeout, a non-200, or a malformed body degrades every campaign's
 leads/conversions/cost to unmeasurable-with-a-reason; clicks, computed
 locally, keep rendering regardless (`_fetch_leads_source` never raises).
 
-**A campaign the source doesn't know about is unmeasurable, not an error** —
-see the "unknown campaign id" handling in `_metrics_for_campaign`.
+**The source MUST return an entry for every requested `campaign_id`.**
+Issue #99 corrected #31's original contract, which required the opposite
+("unknown ids are omitted, not errored") and collided with the "real zero
+must be distinguishable" property below: with no campaign registry of its
+own, the instance could not tell "exists, zero leads" apart from "never
+heard of it" — both are zero rows — so omission made `leads: 0, measurable:
+true` unreachable for the single most common campaign state (published,
+clicked, no leads yet). A requested id with no matching rows is now a real
+zero, because the caller — this plugin — already vouches the campaign exists
+by asking about it. An id genuinely absent from the source's response is
+therefore evidence the source does not conform to the contract, not a
+legitimate "unknown campaign" outcome; kept as a defensive fallback in
+`_metrics_for_campaign` rather than removed, so a non-conforming source still
+degrades honestly instead of this plugin fabricating a zero it cannot verify.
 
 **`measurable: false` is never rendered as a zero, and an upstream `reason`
 is always preserved verbatim** when the source gives one — see
@@ -131,10 +143,19 @@ _SOURCE_UNREACHABLE_REASON = "the configured leads source could not be reached"
 #: "nothing answered" from "something answered wrong".
 _SOURCE_MALFORMED_REASON = "the configured leads source returned data this plugin could not parse"
 
-#: The call succeeded and the source is working — this specific campaign id
-#: simply wasn't in its response. Per the contract: "a campaign the source
-#: does not know about is simply unmeasurable, not a 500."
-_UNKNOWN_TO_SOURCE_REASON = "the configured leads source has no data for this campaign"
+#: The call succeeded, but this specific campaign id was absent from the
+#: response. Per the corrected contract (issue #99), the source MUST return
+#: an entry for every requested campaign_id — the caller already vouches the
+#: campaign exists by asking about it, so an omission here means the source
+#: does not conform, not that the campaign is genuinely unmeasurable. Kept as
+#: a defensive fallback rather than removed: this plugin cannot tell a
+#: non-conforming source apart from a real absence, and inventing a zero
+#: here would reintroduce exactly the dishonesty the contract exists to
+#: prevent, so it still degrades to unmeasurable-with-a-reason.
+_SOURCE_OMITTED_CAMPAIGN_REASON = (
+    "the configured leads source did not return an entry for this campaign, "
+    "though the contract requires one for every requested campaign_id"
+)
 
 #: `measurable: false` with no `reason` at all is itself a malformed
 #: response — the contract requires one — but still degrades to unmeasurable
@@ -283,9 +304,11 @@ class _LeadsSourceResult:
       usable response (timeout, non-200, malformed body). Degrades to
       unmeasurable with `failure` as the reason for every campaign — never a
       500 on the results dashboard.
-    - `by_campaign_id` populated (possibly empty): the call succeeded.
-      A campaign id simply absent from it is unknown to the source, not an
-      error — handled by `_metrics_for_campaign`, not here.
+    - `by_campaign_id` populated (possibly empty): the call succeeded. Per
+      the corrected contract (issue #99) the source is required to return an
+      entry for every requested campaign_id; an id absent from it means the
+      source did not conform, not that it has no data — handled defensively
+      by `_metrics_for_campaign`, not here.
     """
 
     def __init__(
@@ -316,10 +339,10 @@ async def _fetch_leads_source(campaign_ids: list[str], token: str) -> _LeadsSour
         return _LeadsSourceResult(not_configured=True)
 
     if not campaign_ids:
-        # Nothing to ask about — same as a successful call that named no
-        # campaigns; every campaign below will fall into the "unknown to
-        # source" branch, which is the honest answer to "the source knows
-        # nothing about a campaign we never asked it about".
+        # Nothing to ask about. This only happens when this plugin has no
+        # campaigns at all, so the per-campaign loop in `results()` never
+        # iterates — returned for symmetry with a real response, not because
+        # anything downstream needs it.
         return _LeadsSourceResult(by_campaign_id={})
 
     query = urlencode([("campaign_id", campaign_id) for campaign_id in campaign_ids])
@@ -405,7 +428,14 @@ def _metrics_for_campaign(
     else:
         entry = source.by_campaign_id.get(campaign_id)
         if entry is None:
-            reason = _UNKNOWN_TO_SOURCE_REASON
+            # Defensive fallback only: the contract (issue #99) requires the
+            # source to return an entry for every requested campaign_id, so
+            # reaching this means the source did not conform — not that this
+            # is a legitimate "unknown campaign" outcome. Never fabricate a
+            # zero here; this plugin cannot tell "source is broken" from
+            # "source omitted a real zero" and guessing zero would be
+            # exactly the dishonesty the contract exists to prevent.
+            reason = _SOURCE_OMITTED_CAMPAIGN_REASON
         else:
             return (
                 _metric_from_raw(entry.get("leads"), denominator=denominator),

--- a/tests/test_marketing_results_routes.py
+++ b/tests/test_marketing_results_routes.py
@@ -11,6 +11,13 @@ Also covers issue #31's leads-source contract: the instance configures
 into `leads`/`conversions`/`cost`. `_FakeCore` answers that call too, at a
 fixed fake URL, so these tests exercise the real query-building and
 response-parsing code rather than mocking `_fetch_leads_source` itself.
+
+Issue #99 corrected #31's contract: "unknown campaign ids are omitted" is
+withdrawn, replaced by "the source MUST return an entry for every requested
+campaign_id". A requested id absent from the source's response is now
+evidence the source did not conform, handled as a defensive fallback only —
+see `test_leads_source_omitting_a_requested_campaign_degrades_without_fabricating_a_zero`
+and `test_leads_source_reports_a_real_zero_for_a_campaign_with_no_leads_yet`.
 """
 
 from __future__ import annotations
@@ -247,23 +254,63 @@ def test_leads_source_unmeasurable_metric_preserves_the_upstream_reason(ctx, mon
     assert campaign["cost"]["reason"] == "no spend recorded for this campaign"
 
 
-def test_leads_source_unknown_campaign_id_is_unmeasurable_not_an_error(ctx, monkeypatch) -> None:
-    """A campaign the leads source has never heard of (never ran anywhere it
-    tracks) must render as unmeasurable, not fail the whole request."""
+def test_leads_source_omitting_a_requested_campaign_degrades_without_fabricating_a_zero(
+    ctx, monkeypatch
+) -> None:
+    """Issue #99's corrected contract: the source MUST return an entry for
+    every requested campaign_id, so an id genuinely absent from its response
+    means the source did not conform — not "unknown campaign" (that rule was
+    withdrawn; see the module docstring). This is now purely a defensive
+    fallback: the plugin cannot tell a broken source from a real zero it
+    dropped, so it must degrade to unmeasurable rather than guess `0`."""
     monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
     client, core = ctx
-    core.campaigns = [_campaign(_CAMPAIGN_A, "Never ran anywhere tracked")]
-    core.leads_response = {"campaigns": []}  # source answered; just doesn't know this campaign
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Omitted by a non-conforming source")]
+    core.leads_response = {"campaigns": []}  # source answered but omitted a requested id
 
     resp = client.get("/results")
     assert resp.status_code == 200
     campaign = resp.json()["campaigns"][0]
     assert campaign["leads"]["measurable"] is False
-    assert (
-        campaign["leads"]["reason"] == "the configured leads source has no data for this campaign"
+    assert campaign["leads"]["value"] is None, "never fabricate a zero for an omitted campaign"
+    assert campaign["leads"]["reason"] == (
+        "the configured leads source did not return an entry for this campaign, "
+        "though the contract requires one for every requested campaign_id"
     )
     assert campaign["conversions"]["measurable"] is False
     assert campaign["cost"]["measurable"] is False
+
+
+def test_leads_source_reports_a_real_zero_for_a_campaign_with_no_leads_yet(
+    ctx, monkeypatch
+) -> None:
+    """The case issue #99 exists to make reachable: a campaign that has been
+    clicked but has produced no leads yet — the single most common campaign
+    state — must render as a real, verified zero, not unmeasurable. Distinct
+    from `test_leads_source_reports_a_real_zero_distinguishable_from_unmeasurable`,
+    which proves the shape survives parsing; this proves the specific
+    scenario #99 reported (an entry present with a zero value) is reachable
+    at all now that the source is required to include every requested id."""
+    monkeypatch.setenv(results_routes._LEADS_SOURCE_URL_ENV, _LEADS_URL)
+    client, core = ctx
+    core.campaigns = [_campaign(_CAMPAIGN_A, "Published and clicked, zero leads so far")]
+    core.links = [_link("link-1", _CAMPAIGN_A, is_paid=True)]
+    core.clicks = [_click("c1", _CAMPAIGN_A, "link-1"), _click("c2", _CAMPAIGN_A, "link-1")]
+    core.leads_response = {
+        "campaigns": [
+            {
+                "campaign_id": _CAMPAIGN_A,
+                "leads": {"value": 0, "measurable": True},
+                "conversions": {"value": 0, "measurable": True},
+                "cost": {"value": 0, "measurable": True},
+            }
+        ]
+    }
+
+    campaign = client.get("/results").json()["campaigns"][0]
+    assert campaign["leads"]["value"] == 0
+    assert campaign["leads"]["measurable"] is True
+    assert campaign["leads"]["denominator"] == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #99, #31

## What changed

Issue #99 found that #31's original leads contract collided with itself: "unknown campaign ids are omitted" and "a real zero must be distinguishable" together made `leads: 0, measurable: true` unreachable, because the instance had no way to tell "campaign exists, zero leads" apart from "campaign id never heard of" — both are zero rows in `demo_requests`.

The fix on the instance side (tabsii-platform, in parallel) is to make the leads source return an entry for **every** requested `campaign_id`, with a real zero when there are no matching rows — the caller already vouches the campaign exists by asking about it. This PR is the plugin half.

- `_metrics_for_campaign` in `src/marketing/results_routes.py`: the branch that fires when a requested campaign id is absent from the source's response is **kept**, but reworded. Under the corrected contract this can only happen if the configured source does not conform (a bug on the instance side, or a non-tabsii implementation with a gap), so its reason text now says exactly that (`"...did not return an entry for this campaign, though the contract requires one for every requested campaign_id"`) instead of implying the campaign has no data. The constant is renamed `_UNKNOWN_TO_SOURCE_REASON` → `_SOURCE_OMITTED_CAMPAIGN_REASON` to match.
- The module docstring, the `_LeadsSourceResult` docstring, and the `_fetch_leads_source` empty-campaign-ids comment are all updated to describe the corrected contract rather than the withdrawn one.
- Tests: renamed/reworked the old "unknown campaign id" test into `test_leads_source_omitting_a_requested_campaign_degrades_without_fabricating_a_zero` (proves the defensive-fallback branch still degrades honestly and never fabricates a value), and added `test_leads_source_reports_a_real_zero_for_a_campaign_with_no_leads_yet` (proves the specific scenario #99 reported — a clicked campaign with no leads yet — now renders as a real, verified zero once the source includes it).

## Decision: keep the absent-campaign branch as a defensive fallback

Per the brief, I kept the branch rather than deleting it as dead code. Reasoning:

- Under the corrected contract, a conforming source can never omit a requested campaign id, so the branch should be unreachable against tabsii's implementation once the instance-side change for issue 99 ships.
- But this plugin has no way to verify the source conforms, and "another platform answering the same three questions from entirely different tables is an equally valid implementation" (#31) — a future or misbehaving implementation could still omit an id.
- The plugin genuinely cannot distinguish "the source is broken/non-conforming" from "the source dropped a real zero" — those look identical on the wire (absence). Removing the branch would leave no defined behaviour for that case; keeping it and returning unmeasurable-with-a-reason is the honest answer, matching the same discipline every other failure mode in this file already follows (timeout, non-200, malformed body → unmeasurable, never a fabricated value).
- The one thing that had to change was the wording: the old reason text ("the configured leads source has no data for this campaign") asserted the campaign has no data, which is no longer a supportable claim — the new text says the source failed to honor the contract, which is what's actually known.

## Not done here

- Item 1 of the brief (correct #31's contract text) is a comment on #31, not code — done separately, see that issue.
- The instance-side fix (return a row per requested id) is out of scope for this repo; tracked as the parallel change in tabsii-platform.

## Gates run locally (in the worktree)

- `uv run pytest` — 466 passed (full suite)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright` — 0 errors
- `web-admin/` not touched by this change, but `pnpm install` + the repo's push gate (lint/typecheck/test for `web-admin`) all ran and passed as part of the pre-push hook

Not verified: this is unit-tested against a fake leads source only. The real end-to-end behaviour against tabsii's corrected `campaign-results` endpoint has not been exercised — that needs both halves deployed together.
