### PR TITLE
fix(marketing): render placements at generation time, not fetched back from storage

### DIFF
--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -33,10 +33,34 @@ The flow:
    promises.
 
 Then a `marketing_asset` row is created with `is_source=True`: the ONE
-approved creative placements are later rendered from (`render.py`, M5) —
-never a placement render itself. This route is the only path in this plugin
-that calls a provider to *create* image bytes, so every asset it writes is,
-by construction, a source.
+approved creative placements are later rendered from (`render.py`, M5). This
+route is the only path in this plugin that calls a provider to *create* image
+bytes, so every asset it writes with `is_source=True` is, by construction, a
+source.
+
+4. **Render every `PLACEMENTS` entry from the SAME in-memory bytes** the
+   provider returned in step 1, and write one more `marketing_asset` row per
+   placement (`is_source=False`) — issue #36. An earlier design rendered
+   placements later, in `pack_routes.py`, by fetching the stored source
+   creative back from object storage; CodeQL correctly flagged that fetch as
+   `py/full-ssrf` (see `pack_routes.py`'s module docstring for the full
+   story). Rendering here instead needs no fetch, no presigned URL, no
+   outbound request — `image.content` is already sitting in this function's
+   own memory, exactly once, and `render.render` (M5) is pure, local,
+   Pillow-only cropping with no network surface at all. This is also what
+   "rendered once, never regenerated" (`definitions.py`, `render.py`) was
+   already asking for.
+
+   **This step is best-effort, per placement, and never billable.** By the
+   time it runs, the provider has been paid and ledgered, and the source row
+   is durably written — placement rendering and its uploads are local
+   bookkeeping on top of that, never a reason to fail the request. If
+   rendering or storing one placement fails, that placement is simply absent
+   from `marketing_asset`, which `pack_routes.py`'s `missing_placements`
+   already reports honestly to an operator — the alternative, failing the
+   whole request after the provider has already been charged, would tell an
+   operator to regenerate and charge them again for a source that in fact
+   saved successfully. See `_store_placement_renders` below.
 
 Both internal Core routes (storage, ledger) are SigV4-signed as
 `system:marketing` (ADR-0009) via the SDK's `create_core_client()` — the same
@@ -61,7 +85,8 @@ from biffo_plugin_sdk.user_serving import require_group
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from . import principal_client
+from . import principal_client, render
+from .definitions import PLACEMENTS
 from .image_provider import (
     GeneratedImage,
     ImageProvider,
@@ -343,6 +368,102 @@ async def _upload(core_client: BiffoAPIClient, image: GeneratedImage) -> dict[st
         raise _core_error(exc) from exc
 
 
+def _placement_variant(image: GeneratedImage, placement: str, rendered: bytes) -> GeneratedImage:
+    """`rendered` packaged the way `_upload` needs, for one placement.
+
+    `render.render` returns the original bytes UNCHANGED (never re-encoded)
+    when the source already matches the placement's ratio (see that
+    function's docstring) — detected here by identity comparison, not by
+    asking `render` to say so, since that is already the exact contract it
+    guarantees. In that case the variant keeps the source's own content type
+    and extension, so a pre-cropped asset round-trips as the same file it
+    always was. Otherwise `render` always re-encodes as PNG, so the variant
+    is `image/png`.
+
+    Other `GeneratedImage` fields (`provider`, `model`, `unit_kind`) are
+    carried over for context only — `_upload` reads none of them — and
+    `units`/`cost_usd` are zero/`None` because this render is not billable:
+    no provider was called to produce it.
+    """
+    is_noop = rendered == image.content
+    content_type = image.content_type if is_noop else "image/png"
+    if is_noop and "." in image.filename:
+        extension = image.filename.rsplit(".", 1)[-1]
+    else:
+        extension = "png"
+    return GeneratedImage(
+        content=rendered,
+        content_type=content_type,
+        filename=f"{placement}-{uuid.uuid4()}.{extension}",
+        provider=image.provider,
+        model=image.model,
+        units=0.0,
+        unit_kind=image.unit_kind,
+        cost_usd=None,
+    )
+
+
+async def _store_placement_renders(
+    *,
+    core_client: BiffoAPIClient,
+    campaign_client: principal_client.PrincipalCoreClient,
+    campaign_id: str,
+    image: GeneratedImage,
+) -> None:
+    """Render every `PLACEMENTS` entry from `image.content` — the provider's
+    own in-memory bytes, never fetched back from storage — and write one
+    `marketing_asset` row per placement. Issue #36's fix; see the module
+    docstring's step 4 for why this belongs here rather than in
+    `pack_routes.py`.
+
+    Called only after `generate_still_route` has ledgered the charge and
+    written the source row, so every placement here is local bookkeeping on
+    top of an already-durable generation. Each placement is independently
+    best-effort: a render failure (`render.render` raises on bytes it cannot
+    decode, or — in principle, since `PLACEMENTS` and `render`'s own table
+    are guarded to stay in step — an unknown placement) or a storage failure
+    for ONE placement is logged and skipped, never raised. Raising here would
+    turn a partial, recoverable gap into a 502 on an otherwise fully
+    successful, already-charged generation — exactly the blind-retry-doubles-
+    the-charge risk issue #24 exists to prevent, for a step that never had a
+    charge to lose in the first place. A placement that fails here is simply
+    absent from `marketing_asset`, which `pack_routes.py`'s
+    `missing_placements` already reports honestly.
+    """
+    for placement in PLACEMENTS:
+        try:
+            rendered = render.render(image.content, placement)
+        except Exception as exc:  # noqa: BLE001 - best-effort per placement, see docstring
+            logger.warning(
+                "Could not render placement %r for campaign %s: %s", placement, campaign_id, exc
+            )
+            continue
+
+        variant = _placement_variant(image, placement, rendered)
+        try:
+            media = await _upload(core_client, variant)
+            media_id = _required_field(media, "id", context="Storage confirm")
+            await campaign_client.post(
+                f"{_INTERNAL_PREFIX}/assets",
+                json={
+                    "campaign_id": campaign_id,
+                    "media_kind": "image",
+                    "placement": placement,
+                    "media_id": media_id,
+                    "is_source": False,
+                },
+            )
+        except (HTTPException, BiffoAPIError) as exc:
+            detail = exc.detail
+            logger.warning(
+                "Could not store rendered placement %r for campaign %s: %s",
+                placement,
+                campaign_id,
+                detail,
+            )
+            continue
+
+
 @router.post("/campaigns/{campaign_id}/stills", status_code=status.HTTP_201_CREATED)
 async def generate_still_route(
     campaign_id: str,
@@ -378,6 +499,17 @@ async def generate_still_route(
     an idempotency key Core's `/internal/media-generations` route does not
     yet accept, which is a Core-side change, not something this route can
     build around on its own. Tracked as biffo-template#1515.
+
+    **After the source row, every `PLACEMENTS` entry is rendered from the
+    same in-memory bytes and stored too (issue #36)** — see
+    `_store_placement_renders`. That step runs last, strictly after the
+    charge is ledgered and the source row committed, and never moves the
+    ledger write later to accommodate it (the ordering above is unchanged).
+    It is best-effort and cannot fail this request: a placement that could
+    not be rendered or stored is simply missing from `marketing_asset`,
+    which the pack (`pack_routes.py`) already reports honestly via
+    `missing_placements` rather than this route inventing a second failure
+    mode for a step that was never billable.
     """
     campaign_id = _validated_campaign_id(campaign_id)
 
@@ -474,6 +606,19 @@ async def generate_still_route(
             asset,
         )
         asset_id = None
+
+    # The charge, the source's storage and its asset row have all committed
+    # above — everything from here on is local bookkeeping. Placement
+    # rendering (issue #36) runs here, from `image.content` still in memory,
+    # rather than being reconstructed later from storage: see
+    # `_store_placement_renders`'s docstring for why it cannot fail this
+    # request.
+    await _store_placement_renders(
+        core_client=core_client,
+        campaign_client=campaign_client,
+        campaign_id=campaign_id,
+        image=image,
+    )
 
     try:
         url_resp = await core_client.get(f"{_STORAGE_PATH}/{media_id}/url")

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -13,10 +13,17 @@ A standalone app with only `image_routes.router` — not `admin_app.build_app()`
 concurrently, and so overriding `image_routes.require_admin` cannot be
 confused with `admin_app.require_admin` (two different dependency callables,
 per the module's own docstring on why routes live here rather than there).
+
+The issue #36 tests near the bottom of this file import `pack_routes` too —
+not to exercise its app, only to call `pack_routes._existing_assets`
+directly and prove it needs no change to pick up the rows this route now
+writes. See the import block's own comment for why `admin_app` has to be
+imported ahead of it there.
 """
 
 from __future__ import annotations
 
+import io
 from typing import Any
 
 import httpx
@@ -24,14 +31,36 @@ import pytest
 from biffo_plugin_sdk import BiffoAPIError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from PIL import Image
 
-from marketing import image_routes
+# `admin_app` MUST be imported before `pack_routes` in this statement:
+# `pack_routes.py` imports `admin_app`, which in turn imports `pack_routes`'s
+# own `router` to mount it (`admin_app.build_app`) — importing `pack_routes`
+# first would catch it only partially initialized. Importing `admin_app`
+# first here lets that chain resolve fully before this module asks for
+# `pack_routes` itself, exactly the ordering `test_marketing_pack_routes.py`
+# already relies on (`from marketing import admin_app, config, pack_routes`).
+from marketing import admin_app, image_routes, pack_routes  # noqa: F401
+from marketing.definitions import PLACEMENTS
 from marketing.image_provider import GeneratedImage, ImageProviderError
 
 _CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ef"
 _MEDIA_ID = "media-1"
 _LEDGER_ID = "ledger-1"
 _PRESIGN_URL = "https://s3.example.invalid/upload"
+
+
+def _png_bytes(width: int, height: int, color: tuple[int, int, int] = (10, 20, 30)) -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+#: A real, decodable image, square (1:1) — matches `feed_1x1`'s ratio exactly
+#: (so that placement is a no-op render) while `portrait_4x5` and
+#: `story_9x16` both need an actual crop. One fixture exercises both halves
+#: of `render.render`'s contract at once.
+_SQUARE_SOURCE = _png_bytes(300, 300)
 
 
 class _FakeImageProvider:
@@ -612,3 +641,165 @@ def test_rejects_an_empty_prompt() -> None:
     resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": ""})
 
     assert resp.status_code == 422
+
+
+# ── issue #36: placements are rendered here, from the provider's in-memory
+# bytes, never fetched back from storage — see `_store_placement_renders` ──
+
+
+def _find_upload(calls: list[httpx.Request], *, name_contains: str) -> httpx.Request:
+    """The one raw S3 upload whose multipart filename contains
+    `name_contains` — `_placement_variant` names every rendered file
+    `f"{placement}-{uuid}.{ext}"`, so the placement name in the multipart
+    body is enough to tell the source upload and each placement's upload
+    apart without threading anything extra through the fakes."""
+    for call in calls:
+        if name_contains.encode() in call.content:
+            return call
+    raise AssertionError(f"no upload call contained {name_contains!r} in {len(calls)} calls")
+
+
+def test_writes_one_marketing_asset_row_per_placement_alongside_the_source(_s3_upload_ok) -> None:
+    """The core of issue #36. Before the fix, `generate_still_route` wrote
+    only the source row — this fails against that code (only 1 row, not 4)
+    and passes once placements are rendered and stored here."""
+    provider = _FakeImageProvider(content=_SQUARE_SOURCE)
+    campaign = _FakeCampaignClient()
+    client = TestClient(
+        _app(provider=provider, core_client=_FakeCoreClient(), campaign_client=campaign)
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 201
+    # The source row, unchanged.
+    assert campaign.created_assets[0]["is_source"] is True
+    assert campaign.created_assets[0]["placement"] is None
+
+    # One row per placement, mirroring the source row's shape.
+    placement_rows = campaign.created_assets[1:]
+    assert len(placement_rows) == len(PLACEMENTS)
+    assert {row["placement"] for row in placement_rows} == set(PLACEMENTS)
+    for row in placement_rows:
+        assert row["is_source"] is False
+        assert row["campaign_id"] == _CAMPAIGN
+        assert row["media_kind"] == "image"
+        assert row["media_id"]
+
+
+async def test_pack_reports_no_missing_placements_after_generation(_s3_upload_ok) -> None:
+    """Integration proof of the PR's central claim: `pack_routes.py` needs no
+    change. `pack_routes._existing_assets` — untouched by this change — is
+    fed exactly the rows `generate_still_route` wrote and reports the gap
+    closed, the same way `test_marketing_pack_routes.py`'s own
+    `test_includes_placement_assets_that_already_exist_and_reports_no_gap`
+    proves it generically from synthetic fixtures."""
+    provider = _FakeImageProvider(content=_SQUARE_SOURCE)
+    campaign = _FakeCampaignClient()
+    client = TestClient(
+        _app(provider=provider, core_client=_FakeCoreClient(), campaign_client=campaign)
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+    assert resp.status_code == 201
+
+    class _AssetsOnlyClient:
+        async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+            assert path == f"{pack_routes._INTERNAL_PREFIX}/assets"
+            return campaign.created_assets
+
+    # `_AssetsOnlyClient` is a structural stand-in for
+    # `principal_client.PrincipalCoreClient` (only `.get` is called by
+    # `_existing_assets`) — pyright checks nominally, so the mismatch is
+    # silenced here rather than making the fake inherit from the real
+    # dual-auth client just to satisfy the checker.
+    _, missing_placements, _ = await pack_routes._existing_assets(
+        _CAMPAIGN,
+        campaign_client=_AssetsOnlyClient(),  # type: ignore[arg-type]
+    )
+    assert missing_placements == []
+
+
+def test_a_source_already_matching_a_placements_ratio_is_not_re_encoded(_s3_upload_ok) -> None:
+    """`render.render`'s no-op path (see its own module docstring): a source
+    already at a placement's exact ratio is returned byte-for-byte, not
+    decoded and re-encoded. `_SQUARE_SOURCE` is 1:1, matching `feed_1x1`
+    exactly, so that placement's upload must carry the ORIGINAL source bytes
+    verbatim — provable here because multipart embeds file bytes unchanged,
+    so the raw source bytes appear as a literal substring of the request
+    that succeeded, and only for that placement."""
+    provider = _FakeImageProvider(content=_SQUARE_SOURCE)
+    client = TestClient(
+        _app(
+            provider=provider,
+            core_client=_FakeCoreClient(),
+            campaign_client=_FakeCampaignClient(),
+        )
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+    assert resp.status_code == 201
+
+    feed_call = _find_upload(_s3_upload_ok, name_contains="feed_1x1")
+    assert _SQUARE_SOURCE in feed_call.content
+
+    # The other two placements DO need a crop — their upload must NOT carry
+    # the untouched source bytes (a no-op there would mean the crop never
+    # actually ran).
+    for placement in ("portrait_4x5", "story_9x16"):
+        cropped_call = _find_upload(_s3_upload_ok, name_contains=placement)
+        assert _SQUARE_SOURCE not in cropped_call.content
+
+
+def test_a_failed_placement_upload_does_not_lose_the_source_or_fail_the_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The partial-failure decision this issue asks for: the provider has
+    already been paid and the source has already been stored by the time
+    placement rendering runs, so a failure storing ONE placement (here,
+    `portrait_4x5`'s S3 upload is refused) must not lose the source row, must
+    not fail the request with a 5xx that would prompt an operator to
+    regenerate (and be charged again), and must leave exactly that placement
+    absent from `marketing_asset` — the gap `pack_routes.py`'s
+    `missing_placements` already reports honestly, rather than a new failure
+    mode invented here."""
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if b"portrait_4x5" in request.content:
+            return httpx.Response(403, text="access denied")
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    class _PatchedClient(real_async_client):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedClient)
+
+    provider = _FakeImageProvider(content=_SQUARE_SOURCE)
+    campaign = _FakeCampaignClient()
+    core = _FakeCoreClient()
+    client = TestClient(_app(provider=provider, core_client=core, campaign_client=campaign))
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    # Not a 5xx: the failure is contained, never surfaced as a request
+    # failure over an already-charged, already-stored generation.
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["asset"]["is_source"] is True
+    assert body["asset"]["media_id"] == _MEDIA_ID
+
+    # The ledger was written exactly once — no re-charge was attempted or
+    # implied by this partial failure.
+    ledger_calls = [c for c in core.calls if c[1] == image_routes._LEDGER_PATH]
+    assert len(ledger_calls) == 1
+
+    placements_written = {row["placement"] for row in campaign.created_assets if row["placement"]}
+    assert placements_written == {"feed_1x1", "story_9x16"}
+    assert "portrait_4x5" not in placements_written


### PR DESCRIPTION
Closes #36

## The defect

Every distribution pack, for every campaign, permanently showed:

> Missing renders for: feed_1x1, portrait_4x5, story_9x16 — only the source creative is available for these placements so far.

`generate_still_route` in `src/marketing/image_routes.py` only ever wrote the
source row (`is_source=True`, `placement=None`). Nothing in this plugin ever
wrote a placement row, so operators got one landscape image and no
square/portrait/story crops.

## The fix

Render each `PLACEMENTS` entry **inside `generate_still_route`**, from the
bytes `image_provider.ImageProvider.generate_still` already returns in
memory, immediately before upload — no fetch, no presigned URL, no outbound
request, no sink. Write one `marketing_asset` row per placement
(`is_source=False`), mirroring the existing source-row write.

This is the fix issue #36 asks for, replacing the earlier design (fetching
the stored source back at pack-assembly time) that CodeQL correctly flagged
as `py/full-ssrf` — the taint source there was the injected storage client
itself, so no amount of host-allowlisting the derived URL cleared it.

## Ordering

The provider call remains the only billable step, and the ledger write stays
immediately after it (issue #24). Placement rendering runs **last**, strictly
after the charge is ledgered and the source row is committed — it never moves
the ledger write later to accommodate it.

## Partial-failure decision

Placement rendering and its upload are best-effort, per placement. If
rendering or storing ONE placement fails, that placement is simply logged and
skipped — never raised as a request failure. Reasoning:

- By the time this step runs, the provider has already been paid and the
  charge is durably ledgered, and the source row is already stored. Failing
  the whole request at this point would tell an operator to regenerate,
  which would charge the provider again for a source that in fact saved
  successfully.
- A missing placement is exactly the gap `pack_routes.py`'s
  `missing_placements` already reports honestly to an operator — no new
  failure mode is invented, the pack just says "not yet available for this
  one" the same way it does today for a still that predates this fix.

Covered by `test_a_failed_placement_upload_does_not_lose_the_source_or_fail_the_request`.

## `pack_routes.py` needed no change

Confirmed: `pack_routes._existing_assets` already derives `assets` and
`missing_placements` from whatever `marketing_asset` rows exist, with no
placement-specific logic beyond "is there a row for this key". A new
integration test (`test_pack_reports_no_missing_placements_after_generation`)
feeds `pack_routes._existing_assets` exactly the rows this route now writes
and confirms `missing_placements == []` — no edit to `pack_routes.py` in this
diff.

## Tests

Added to `tests/test_marketing_image_routes.py`, all verified fail-first
against the pre-fix code:

- `test_writes_one_marketing_asset_row_per_placement_alongside_the_source` —
  one row per `PLACEMENTS` entry alongside the source.
- `test_pack_reports_no_missing_placements_after_generation` — the pack's
  `missing_placements` is empty afterwards, via `pack_routes.py` unmodified.
- `test_a_source_already_matching_a_placements_ratio_is_not_re_encoded` —
  the no-op path in `render.render` still returns byte-identical output
  through this route (proven via the raw multipart upload body), while the
  two placements that actually need a crop do not.
- `test_a_failed_placement_upload_does_not_lose_the_source_or_fail_the_request`
  — the partial-failure behaviour above.

Full suite: 470 passed (up from 466), `ruff check`/`ruff format --check`/
`pyright` clean. `web-admin/` untouched by this change, but its lint/
typecheck/vitest were run by hand anyway (no CI job there — #97) and are
clean.
