### PR TITLE
feat(marketing): copy buttons and per-channel publish links on both packs

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -358,6 +358,12 @@
           "type": "String(32)",
           "nullable": true,
           "description": "Optional. The ad platform this channel's spend and character limits belong to (e.g. 'google', 'meta', 'linkedin', 'tiktok'), NULL for channels with no platform-specific limits (organic search, direct mail, events, ...). Exists now so the shape a future `_platform_for_channel` lookup needs (replacing today's substring guessing) does not require a second schema change — the lookup itself is #76 increment 2, out of scope here."
+        },
+        {
+          "name": "publish_url",
+          "type": "String(500)",
+          "nullable": true,
+          "description": "Optional. Where an operator actually goes to publish on this channel — LinkedIn's post composer, Google Ads, and so on (#103b). NULL for channels with no single composer to deep-link to: a pitch to a publication (`trade_press_earned`), a channel whose venue is tenant-specific (an owned email list, a chosen webinar platform), or one covering several distinct destinations under one taxonomy row (`short_form_video_organic`). Never a login/credential flow of this plugin's own — it is a plain third-party URL the browser opens in a new tab; an unauthenticated operator lands on that platform's own sign-in, which is expected. A wrong or dead link is worse than none, so this is left NULL on any channel this plugin isn't confident naming a stable entry point for, same discipline as `ad_platform` above."
         }
       ],
       "indexes": [

--- a/scripts/seed_marketing_channels.py
+++ b/scripts/seed_marketing_channels.py
@@ -68,6 +68,18 @@ _CHANNELS_PATH = "/api/v1/plugins/marketing/channels"
 #: `category` values are exactly #67's eleven: search, social, video, email,
 #: content, communities, partner, events, trade_press, direct_mail, local_field
 #: — asserted by `tests/test_marketing_seed_marketing_channels.py`.
+#:
+#: `publish_url` (#103b) is the operator's actual "where do I go to publish"
+#: link, opened in a new tab and never handling credentials of its own — an
+#: unauthenticated operator bounces through that platform's own sign-in,
+#: which is the expected flow. Set only where a channel has one genuinely
+#: stable, single composer/landing entry point; left `None` everywhere else —
+#: a pitch to a named outlet (`trade_press_earned`/`trade_press_paid`), a
+#: venue that is tenant-specific (an owned email list, a chosen webinar tool,
+#: a physical event), or a taxonomy row that spans more than one real
+#: destination (`short_form_video_organic` covers Reels, Shorts and TikTok
+#: clips at once). A wrong link is worse than no link, so this stays `None`
+#: on anything this list is not confident naming.
 CHANNELS: list[dict[str, Any]] = [
     # ── Search ───────────────────────────────────────────────────────────────
     {
@@ -76,6 +88,9 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "search",
         "ad_platform": None,
+        # No single composer — SEO is published through whatever the
+        # tenant's own site/CMS is, not a third-party surface.
+        "publish_url": None,
     },
     {
         "key": "google_search_paid",
@@ -83,6 +98,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "search",
         "ad_platform": "google",
+        "publish_url": "https://ads.google.com/home/",
     },
     # ── Social — organic and paid are separate channels (#67) ──────────────────
     {
@@ -91,6 +107,9 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "social",
         "ad_platform": None,
+        # Meta Business Suite is where an operator composes and publishes an
+        # organic Facebook Page post today, not facebook.com itself.
+        "publish_url": "https://business.facebook.com/latest/home",
     },
     {
         "key": "facebook_paid",
@@ -98,6 +117,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "social",
         "ad_platform": "meta",
+        "publish_url": "https://adsmanager.facebook.com/adsmanager/",
     },
     {
         "key": "instagram_organic",
@@ -105,6 +125,9 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "social",
         "ad_platform": None,
+        # Same composer as Facebook organic — Meta Business Suite manages
+        # both connected surfaces from one place.
+        "publish_url": "https://business.facebook.com/latest/home",
     },
     {
         "key": "instagram_paid",
@@ -112,6 +135,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "social",
         "ad_platform": "meta",
+        "publish_url": "https://adsmanager.facebook.com/adsmanager/",
     },
     {
         "key": "linkedin_organic",
@@ -119,6 +143,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "social",
         "ad_platform": None,
+        "publish_url": "https://www.linkedin.com/feed/?shareActive=true",
     },
     {
         "key": "linkedin_paid",
@@ -126,6 +151,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "social",
         "ad_platform": "linkedin",
+        "publish_url": "https://www.linkedin.com/campaignmanager/",
     },
     {
         "key": "tiktok_organic",
@@ -133,6 +159,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "social",
         "ad_platform": None,
+        "publish_url": "https://www.tiktok.com/upload",
     },
     {
         "key": "tiktok_paid",
@@ -140,6 +167,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "social",
         "ad_platform": "tiktok",
+        "publish_url": "https://ads.tiktok.com/",
     },
     {
         "key": "x_organic",
@@ -147,6 +175,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "social",
         "ad_platform": None,
+        "publish_url": "https://twitter.com/compose/tweet",
     },
     {
         "key": "x_paid",
@@ -154,6 +183,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "social",
         "ad_platform": "x",
+        "publish_url": "https://ads.twitter.com/",
     },
     # ── Video — short-form and long-form (#67) ──────────────────────────────
     {
@@ -162,6 +192,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "video",
         "ad_platform": None,
+        "publish_url": "https://www.youtube.com/upload",
     },
     {
         "key": "youtube_paid",
@@ -169,6 +200,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "video",
         "ad_platform": "google",
+        # YouTube ads are bought through Google Ads, the same as search.
+        "publish_url": "https://ads.google.com/home/",
     },
     {
         "key": "short_form_video_organic",
@@ -176,6 +209,9 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "video",
         "ad_platform": None,
+        # Spans three distinct platforms/composers under one taxonomy row —
+        # no single stable URL to send an operator to.
+        "publish_url": None,
     },
     # ── Email ────────────────────────────────────────────────────────────────
     {
@@ -184,6 +220,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "email",
         "ad_platform": None,
+        # Whatever ESP the tenant uses — not this plugin's to guess.
+        "publish_url": None,
     },
     {
         "key": "email_newsletter_sponsorship",
@@ -191,6 +229,9 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "email",
         "ad_platform": None,
+        # Bought directly from whichever newsletter is sponsored — no
+        # general-purpose URL exists.
+        "publish_url": None,
     },
     # ── Content ──────────────────────────────────────────────────────────────
     {
@@ -199,6 +240,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "content",
         "ad_platform": None,
+        # Published to the tenant's own site/CMS.
+        "publish_url": None,
     },
     {
         "key": "guest_content",
@@ -206,6 +249,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "content",
         "ad_platform": None,
+        # A pitch to whichever outlet, not a composer.
+        "publish_url": None,
     },
     {
         "key": "webinar",
@@ -213,6 +258,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "content",
         "ad_platform": None,
+        # Whatever webinar platform the tenant runs on.
+        "publish_url": None,
     },
     # ── Communities ──────────────────────────────────────────────────────────
     {
@@ -221,6 +268,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "communities",
         "ad_platform": None,
+        # No single community — this row covers however many the tenant is in.
+        "publish_url": None,
     },
     # ── Partner / affiliate ──────────────────────────────────────────────────
     {
@@ -229,6 +278,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "partner",
         "ad_platform": None,
+        "publish_url": None,
     },
     {
         "key": "affiliate_referral",
@@ -236,6 +286,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "partner",
         "ad_platform": None,
+        # Whichever affiliate network/platform the tenant uses.
+        "publish_url": None,
     },
     # ── Events ───────────────────────────────────────────────────────────────
     {
@@ -244,6 +296,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "events",
         "ad_platform": None,
+        # Physical presence — nothing to deep-link to.
+        "publish_url": None,
     },
     {
         "key": "own_event",
@@ -251,6 +305,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "events",
         "ad_platform": None,
+        "publish_url": None,
     },
     {
         "key": "event_sponsorship",
@@ -258,6 +313,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "events",
         "ad_platform": None,
+        # A negotiated placement with a specific event organiser.
+        "publish_url": None,
     },
     # ── Trade press ──────────────────────────────────────────────────────────
     {
@@ -266,6 +323,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "trade_press",
         "ad_platform": None,
+        # A pitch to a publication (#103's own framing), not a URL.
+        "publish_url": None,
     },
     {
         "key": "trade_press_paid",
@@ -273,6 +332,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "trade_press",
         "ad_platform": None,
+        # Bought directly from whichever outlet — no general entry point.
+        "publish_url": None,
     },
     # ── Direct mail ──────────────────────────────────────────────────────────
     {
@@ -281,6 +342,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "direct_mail",
         "ad_platform": None,
+        # Physical mail — nothing online to link to.
+        "publish_url": None,
     },
     # ── Local / field ────────────────────────────────────────────────────────
     {
@@ -289,6 +352,7 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "organic",
         "category": "local_field",
         "ad_platform": None,
+        "publish_url": None,
     },
     {
         "key": "local_paid_advertising",
@@ -296,6 +360,8 @@ CHANNELS: list[dict[str, Any]] = [
         "motion": "paid",
         "category": "local_field",
         "ad_platform": None,
+        # Bought directly from whichever local outlet — no general URL.
+        "publish_url": None,
     },
 ]
 

--- a/tests/test_marketing_seed_marketing_channels.py
+++ b/tests/test_marketing_seed_marketing_channels.py
@@ -107,6 +107,46 @@ def test_taxonomy_has_no_duplicate_keys() -> None:
     assert len(set(keys)) == len(keys)
 
 
+# ── publish_url (#103b) ───────────────────────────────────────────────────
+
+
+def test_every_channel_declares_a_publish_url_key() -> None:
+    """`None` is a valid, deliberate value (most channels have no single
+    composer) — the key must still be present so a caller can tell "checked,
+    found none" from "this row predates the field"."""
+    for channel in CHANNELS:
+        assert "publish_url" in channel, channel["key"]
+
+
+def test_publish_url_is_either_none_or_a_stable_https_link() -> None:
+    """A wrong link is worse than no link (#103b's own instruction) — every
+    non-`None` value must at least be shaped like a real, stable third-party
+    URL: `https://`, no query-string credential/token, no bare IP."""
+    for channel in CHANNELS:
+        url = channel["publish_url"]
+        if url is None:
+            continue
+        assert url.startswith("https://"), channel["key"]
+        assert "@" not in url, f"{channel['key']!r} looks like it embeds credentials"
+
+
+def test_trade_press_earned_has_no_publish_url() -> None:
+    """#103's own framing: `trade_press_earned` is a pitch to a publication,
+    not a composer — the channel most likely to be reached for a deep link
+    that must not exist."""
+    trade_press_earned = next(c for c in CHANNELS if c["key"] == "trade_press_earned")
+    assert trade_press_earned["publish_url"] is None
+
+
+def test_at_least_one_channel_per_named_platform_has_a_publish_url() -> None:
+    """The load-bearing coverage check for #103b: enough of the taxonomy
+    actually carries a link that the feature is not vacuously true. Every key
+    here is asserted present above in `CHANNELS`."""
+    have_links = {c["key"] for c in CHANNELS if c["publish_url"] is not None}
+    expected = {"google_search_paid", "linkedin_organic", "linkedin_paid", "tiktok_organic"}
+    assert expected <= have_links
+
+
 def test_taxonomy_contains_nothing_platform_or_vertical_specific() -> None:
     """This plugin installs on every Biffo platform. Franchise operators are
     the motivating example for breadth (#67), not a reason to encode

--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -238,6 +238,7 @@ const LINKEDIN: ChannelTaxonomyEntry = {
   motion: 'organic',
   category: 'social',
   ad_platform: null,
+  publish_url: null,
 }
 const GOOGLE: ChannelTaxonomyEntry = {
   key: 'google_search_paid',
@@ -245,6 +246,7 @@ const GOOGLE: ChannelTaxonomyEntry = {
   motion: 'paid',
   category: 'search',
   ad_platform: 'google',
+  publish_url: null,
 }
 
 describe('ChannelPlanArtefact', () => {

--- a/web-admin/src/components/CampaignDetail.tsx
+++ b/web-admin/src/components/CampaignDetail.tsx
@@ -87,7 +87,7 @@ export function CampaignDetail({
       <DistributionPack campaignId={campaign.id} channelLookup={channelLookup} />
 
       <h3>Paid brief pack</h3>
-      <PaidPack campaignId={campaign.id} />
+      <PaidPack campaignId={campaign.id} channelLookup={channelLookup} />
 
       <h3>Results</h3>
       <Results campaignId={campaign.id} />

--- a/web-admin/src/components/ChannelName.test.tsx
+++ b/web-admin/src/components/ChannelName.test.tsx
@@ -11,6 +11,7 @@ const LINKEDIN_PAID: ChannelTaxonomyEntry = {
   motion: 'paid',
   category: 'social',
   ad_platform: 'linkedin',
+  publish_url: null,
 }
 
 function fakeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {

--- a/web-admin/src/components/CopyButton.test.tsx
+++ b/web-admin/src/components/CopyButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CopyButton } from './CopyButton'
+
+describe('CopyButton', () => {
+  it('calls onCopy with its own text, and shows the copied label once copied is that text', async () => {
+    const user = userEvent.setup()
+    const onCopy = vi.fn()
+
+    const { rerender } = render(<CopyButton text="Book a demo" copied={null} onCopy={onCopy} />)
+    const button = screen.getByRole('button', { name: 'Copy' })
+    await user.click(button)
+    expect(onCopy).toHaveBeenCalledWith('Book a demo')
+
+    // The caller owns `copied` state (one shared `useClipboard()` per pack) —
+    // this only renders whatever it is told.
+    rerender(<CopyButton text="Book a demo" copied="Book a demo" onCopy={onCopy} />)
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument()
+  })
+
+  it('does not show "Copied" for a different button sharing the same copied state', () => {
+    render(<CopyButton text="Book a demo" copied="Some other text" onCopy={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument()
+  })
+
+  it('accepts custom labels — used for a trimmed field and the copy-all control', () => {
+    render(
+      <CopyButton text="Headline" label="Copy headline (trimmed)" copiedLabel="Copied all" copied={null} onCopy={() => {}} />,
+    )
+    expect(screen.getByRole('button', { name: 'Copy headline (trimmed)' })).toBeInTheDocument()
+  })
+
+  it('is a real <button> — keyboard-focusable and activatable without a mouse', async () => {
+    const user = userEvent.setup()
+    const onCopy = vi.fn()
+    render(<CopyButton text="Book a demo" copied={null} onCopy={onCopy} />)
+
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'Copy' })).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(onCopy).toHaveBeenCalledWith('Book a demo')
+  })
+})

--- a/web-admin/src/components/CopyButton.tsx
+++ b/web-admin/src/components/CopyButton.tsx
@@ -1,0 +1,41 @@
+/** A copy affordance for one piece of pack text, backed by the shared
+ * `useClipboard` hook (`useClipboard.ts`) rather than a second clipboard
+ * implementation — the same hook `MintLinks`/`PackLinks` already use for
+ * tracked links now backs every copy block in both distribution packs too
+ * (#103a).
+ *
+ * `copied`/`onCopy` are threaded down from the caller's own single
+ * `useClipboard()` call (`DistributionPack`, `PaidPack`) — one clipboard
+ * state shared across every copy control a pack renders, the same sharing
+ * `PackLinks` already does for tracked-link copying, not one hook instance
+ * per button.
+ *
+ * A native `<button>` gets keyboard focus and activation, and the visible
+ * focus ring, for free from `index.css`'s existing `button:focus-visible`
+ * rule — nothing new needed there for this control to be keyboard-accessible.
+ */
+export function CopyButton({
+  text,
+  label = 'Copy',
+  copiedLabel = 'Copied',
+  copied,
+  onCopy,
+  className = '',
+}: {
+  text: string
+  label?: string
+  copiedLabel?: string
+  copied: string | null
+  onCopy: (text: string) => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      className={`copy-btn secondary ${className}`.trim()}
+      onClick={() => onCopy(text)}
+    >
+      {copied === text ? copiedLabel : label}
+    </button>
+  )
+}

--- a/web-admin/src/components/DistributionPack.test.tsx
+++ b/web-admin/src/components/DistributionPack.test.tsx
@@ -18,6 +18,20 @@ function stubSession(jwt = 'test-jwt') {
   } as never)
 }
 
+/** jsdom has no `navigator.clipboard` at all — see `PaidPack.test.tsx`'s own
+ * copy of this helper for why a click must go through a real stub rather
+ * than nothing, or every copy button here would silently land on
+ * `useClipboard`'s "could not copy" error path instead of the success one
+ * these tests are checking. */
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
+  return writeText
+}
+
 /** `channelLookup` is fetched once by `CampaignDetail` (`useChannelTaxonomy`)
  * and passed down — `DistributionPack` itself never fetches `/channels`, so
  * these tests only need this stub, not a second mocked response. */
@@ -32,6 +46,7 @@ const LINKEDIN: ChannelTaxonomyEntry = {
   motion: 'organic',
   category: 'social',
   ad_platform: null,
+  publish_url: 'https://www.linkedin.com/feed/?shareActive=true',
 }
 
 const CAMPAIGN = 'c1'
@@ -233,5 +248,110 @@ describe('DistributionPack', () => {
 
     expect(await screen.findByText(/loading channel/i)).toBeInTheDocument()
     expect(screen.queryByText(/unrecognised channel/i)).not.toBeInTheDocument()
+  })
+
+  // #103a/#103b: a copy control per copy block, a copy-all control that
+  // composes the channel's own tracked link in, and a publish link sourced
+  // from the taxonomy — the operator-experience gaps issue #103 reports.
+  it('gives every copy block its own copy button, composes copy-all with the tracked link, and links to where to publish', async () => {
+    stubSession()
+    // `userEvent.setup()` installs (and resets) its own `navigator.clipboard`
+    // stub, so this must be stubbed AFTER setup(), not before — otherwise
+    // `useClipboard` silently talks to userEvent's stub, not this test's.
+    const user = userEvent.setup()
+    const writeText = stubClipboard()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          assets: [],
+          missing_placements: [],
+          copy: [
+            {
+              channel_key: 'linkedin_organic',
+              motion: 'organic',
+              headline: 'Fast onboarding, done right',
+              body: 'Get every franchise unit live in a day.',
+              cta: 'Book a demo',
+              sources: [],
+            },
+          ],
+          links: [{ channel: 'linkedin_organic', variant: null, is_paid: false, url: 'https://x/c/tok' }],
+          guidance: '',
+        }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+    await screen.findByText('Fast onboarding, done right')
+
+    // A copy control per block.
+    await user.click(screen.getByRole('button', { name: 'Copy headline' }))
+    expect(writeText).toHaveBeenLastCalledWith('Fast onboarding, done right')
+    await user.click(screen.getByRole('button', { name: 'Copy body' }))
+    expect(writeText).toHaveBeenLastCalledWith('Get every franchise unit live in a day.')
+    await user.click(screen.getByRole('button', { name: 'Copy CTA' }))
+    expect(writeText).toHaveBeenLastCalledWith('Book a demo')
+
+    // Copy-all composes headline + body + CTA + this channel's own tracked
+    // link — the real unit of work when pasting into a composer (#103a).
+    await user.click(screen.getByRole('button', { name: 'Copy all for this channel' }))
+    expect(writeText).toHaveBeenLastCalledWith(
+      ['Fast onboarding, done right', 'Get every franchise unit live in a day.', 'Book a demo', 'https://x/c/tok'].join(
+        '\n\n',
+      ),
+    )
+
+    // The publish link comes from the taxonomy (`LINKEDIN.publish_url`), not
+    // from anything hardcoded in this component (#103b).
+    const publishLink = screen.getByRole('link', { name: /publish on linkedin — organic/i })
+    expect(publishLink).toHaveAttribute('href', 'https://www.linkedin.com/feed/?shareActive=true')
+    expect(publishLink).toHaveAttribute('target', '_blank')
+    expect(publishLink).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders no publish link for a channel with no publish_url, never a dead or placeholder link', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    const NO_COMPOSER: ChannelTaxonomyEntry = {
+      key: 'trade_press_earned',
+      label: 'Trade press — earned coverage',
+      motion: 'organic',
+      category: 'trade_press',
+      ad_platform: null,
+      publish_url: null,
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          assets: [],
+          missing_placements: [],
+          copy: [
+            {
+              channel_key: 'trade_press_earned',
+              motion: 'organic',
+              headline: 'H',
+              body: 'B',
+              cta: 'C',
+              sources: [],
+            },
+          ],
+          links: [],
+          guidance: '',
+        }),
+      }),
+    )
+
+    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([NO_COMPOSER])} />)
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+    await screen.findByText('Trade press — earned coverage')
+
+    expect(screen.queryByRole('link', { name: /publish on/i })).not.toBeInTheDocument()
   })
 })

--- a/web-admin/src/components/DistributionPack.tsx
+++ b/web-admin/src/components/DistributionPack.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react'
 
 import { getPack, type Pack } from '../lib/api'
+import { composeChannelCopy } from '../lib/packCopy'
 import { useClipboard } from '../lib/useClipboard'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import { ChannelName } from './ChannelName'
+import { CopyButton } from './CopyButton'
 import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from './PackParts'
+import { PublishLink } from './PublishLink'
 
 /** The distribution pack (M5): assets, approved copy, tracked links and
  * guidance, assembled from an **approved** copy artefact — `pack_routes.py`'s
@@ -62,17 +65,48 @@ export function DistributionPack({
           <h4>Copy</h4>
           {pack.copy.length === 0 && <p className="empty">No approved copy channels.</p>}
           <ul className="copy-list">
-            {pack.copy.map((c, i) => (
-              <li key={`${c.channel_key}-${i}`}>
-                <strong>
-                  <ChannelName channelKey={c.channel_key} suggestedLabel={null} lookup={channelLookup} />
-                </strong>{' '}
-                <span className={`motion motion-${c.motion}`}>{c.motion}</span>
-                <p className="headline">{c.headline}</p>
-                <p>{c.body}</p>
-                <p className="cta">{c.cta}</p>
-              </li>
-            ))}
+            {pack.copy.map((c, i) => {
+              const link = pack.links.find((l) => l.channel === c.channel_key) ?? null
+              const allText = composeChannelCopy({
+                headline: c.headline,
+                body: c.body,
+                cta: c.cta,
+                linkUrl: link?.url ?? null,
+              })
+              return (
+                <li key={`${c.channel_key}-${i}`}>
+                  <div className="copy-list-head">
+                    <strong>
+                      <ChannelName channelKey={c.channel_key} suggestedLabel={null} lookup={channelLookup} />
+                    </strong>{' '}
+                    <span className={`motion motion-${c.motion}`}>{c.motion}</span>
+                    <PublishLink channelKey={c.channel_key} lookup={channelLookup} />
+                  </div>
+                  <p className="headline copy-field">
+                    <span>{c.headline}</span>
+                    <CopyButton text={c.headline} label="Copy headline" copied={copied} onCopy={copy} />
+                  </p>
+                  <p className="copy-field">
+                    <span>{c.body}</span>
+                    <CopyButton text={c.body} label="Copy body" copied={copied} onCopy={copy} />
+                  </p>
+                  <p className="cta copy-field">
+                    <span>{c.cta}</span>
+                    <CopyButton text={c.cta} label="Copy CTA" copied={copied} onCopy={copy} />
+                  </p>
+                  <div className="copy-actions">
+                    <CopyButton
+                      text={allText}
+                      label="Copy all for this channel"
+                      copiedLabel="Copied all"
+                      copied={copied}
+                      onCopy={copy}
+                      className="copy-all"
+                    />
+                  </div>
+                </li>
+              )
+            })}
           </ul>
 
           <PackLinks links={pack.links} copied={copied} onCopy={copy} />

--- a/web-admin/src/components/MintLinks.test.tsx
+++ b/web-admin/src/components/MintLinks.test.tsx
@@ -26,6 +26,7 @@ const LINKEDIN_ORGANIC: ChannelTaxonomyEntry = {
   motion: 'organic',
   category: 'social',
   ad_platform: null,
+  publish_url: 'https://www.linkedin.com/feed/?shareActive=true',
 }
 const LINKEDIN_PAID: ChannelTaxonomyEntry = {
   key: 'linkedin_paid',
@@ -33,6 +34,7 @@ const LINKEDIN_PAID: ChannelTaxonomyEntry = {
   motion: 'paid',
   category: 'social',
   ad_platform: 'linkedin',
+  publish_url: 'https://www.linkedin.com/campaignmanager/',
 }
 
 /** A stub taxonomy lookup, matching the shape `useChannelTaxonomy` produces

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -2,7 +2,9 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChannelTaxonomyEntry } from '../lib/api'
 import * as auth from '../lib/auth'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import { PaidPack } from './PaidPack'
 
 afterEach(() => {
@@ -16,12 +18,47 @@ function stubSession(jwt = 'test-jwt') {
   } as never)
 }
 
+/** jsdom has no `navigator.clipboard` at all, so `useClipboard`'s real
+ * `navigator.clipboard.writeText` would throw and every copy button would
+ * quietly land on its "could not copy" error path — this stands in the same
+ * seam a real browser provides, so a `CopyButton` click here exercises the
+ * exact code path production does. */
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
+  return writeText
+}
+
+/** Matching `DistributionPack.test.tsx`'s own `makeLookup` — `channelLookup`
+ * is fetched once by `CampaignDetail` and threaded down, so `PaidPack`
+ * itself never fetches `/channels`. */
+function makeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
+  const byKey = new Map(entries.map((e) => [e.key, e]))
+  return { get: (key) => byKey.get(key), entries, loading }
+}
+
+const FACEBOOK_PAID: ChannelTaxonomyEntry = {
+  key: 'facebook_paid',
+  label: 'Facebook ads',
+  motion: 'paid',
+  category: 'social',
+  ad_platform: 'meta',
+  publish_url: 'https://adsmanager.facebook.com/adsmanager/',
+}
+
 const CAMPAIGN = 'c1'
 
 describe('PaidPack', () => {
   it('shows trimmed ad copy, targeting, budget, and spend as explicitly unmeasurable', async () => {
     stubSession()
+    // `userEvent.setup()` installs (and resets) its own `navigator.clipboard`
+    // stub, so this must be stubbed AFTER setup(), not before — otherwise
+    // `useClipboard` silently talks to userEvent's stub, not this test's.
     const user = userEvent.setup()
+    const writeText = stubClipboard()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -30,7 +67,7 @@ describe('PaidPack', () => {
           campaign_id: CAMPAIGN,
           ad_copy: [
             {
-              channel: 'Facebook Feed',
+              channel: 'facebook_paid',
               platform: 'meta',
               headline: 'Fast onboarding, done right',
               headline_limit: 40,
@@ -55,7 +92,7 @@ describe('PaidPack', () => {
             total_test_budget: 140,
             basis: 'A fixed starting-point heuristic.',
           },
-          links: [],
+          links: [{ channel: 'facebook_paid', variant: null, is_paid: true, url: 'https://x/c/fb1' }],
           guidance: '',
           spend: {
             measurable: false,
@@ -66,7 +103,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} />)
+    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([FACEBOOK_PAID])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/missing renders for: feed_1x1/i)).toBeInTheDocument()
@@ -77,6 +114,29 @@ describe('PaidPack', () => {
     expect(screen.getByText(/grounded in 2 research sources/i)).toBeInTheDocument()
     expect(screen.getByText(/1 paid channel\(s\)/)).toBeInTheDocument()
     expect(screen.getByText(/not measurable — no route reachable/i)).toBeInTheDocument()
+
+    // #103a: a copy control per copy block — the trimmed body must say so in
+    // its own control, not just in the inline "(trimmed to ... chars)" text.
+    expect(screen.getByRole('button', { name: 'Copy headline' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy body (trimmed)' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy CTA' })).toBeInTheDocument()
+
+    // #103a: copy-all composes headline + body + CTA + the channel's own
+    // tracked link, in that order, joined by blank lines — never silently
+    // dropping the fact that the body was trimmed to fit the platform limit.
+    const copyAll = screen.getByRole('button', { name: /copy all for this channel \(includes trimmed copy\)/i })
+    await user.click(copyAll)
+    expect(writeText).toHaveBeenCalledWith(
+      ['Fast onboarding, done right', 'A'.repeat(130), 'Learn more', 'https://x/c/fb1'].join('\n\n'),
+    )
+    expect(await screen.findByText('Copied all')).toBeInTheDocument()
+
+    // #103b: the publish link comes from the taxonomy, opens in a new tab,
+    // and never carries a referrer back to this pack.
+    const publishLink = screen.getByRole('link', { name: /publish on facebook ads/i })
+    expect(publishLink).toHaveAttribute('href', 'https://adsmanager.facebook.com/adsmanager/')
+    expect(publishLink).toHaveAttribute('target', '_blank')
+    expect(publishLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   // The three distinct 4xx branches `paid_pack_routes.get_paid_pack_route`
@@ -95,7 +155,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} />)
+    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/no copy artefact for this campaign yet/i)).toBeInTheDocument()
@@ -114,7 +174,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} />)
+    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/^campaign not found\./i)).toBeInTheDocument()
@@ -135,7 +195,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} />)
+    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/copy artefact must be approved before this can proceed/i)).toBeInTheDocument()

--- a/web-admin/src/components/PaidPack.tsx
+++ b/web-admin/src/components/PaidPack.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react'
 
 import { getPaidPack, type PaidPack as PaidPackData } from '../lib/api'
+import { composeChannelCopy } from '../lib/packCopy'
 import { useClipboard } from '../lib/useClipboard'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+import { CopyButton } from './CopyButton'
 import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from './PackParts'
+import { PublishLink } from './PublishLink'
 
 /** The paid brief pack (M9): ad copy at real platform character limits,
  * creative, targeting drawn from the approved positioning, a declared budget
@@ -16,8 +20,19 @@ import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from '.
  * than duplicated (`paid_pack_routes.py`'s own module docstring: "this is
  * the organic pack's shape, with paid-specific additions, not a second
  * assembler").
+ *
+ * `channelLookup` (fetched once by `CampaignDetail` via `useChannelTaxonomy`,
+ * threaded down the same way `DistributionPack` already receives it) is what
+ * resolves each ad-copy row's `channel` — a real taxonomy `channel_key`,
+ * per `paid_pack_routes._ad_copy_variant` — into its `publish_url` (#103b).
  */
-export function PaidPack({ campaignId }: { campaignId: string }) {
+export function PaidPack({
+  campaignId,
+  channelLookup,
+}: {
+  campaignId: string
+  channelLookup: ChannelLookup
+}) {
   const [pack, setPack] = useState<PaidPackData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -50,25 +65,82 @@ export function PaidPack({ campaignId }: { campaignId: string }) {
 
           <h4>Ad copy</h4>
           <ul className="ad-copy">
-            {pack.ad_copy.map((c, i) => (
-              <li key={`${c.channel}-${i}`}>
-                <strong>{c.channel}</strong> <span className="platform">{c.platform}</span>
-                <p className="headline">
-                  {c.headline}
-                  {c.headline_truncated && (
-                    <span className="trimmed"> (trimmed to {c.headline_limit} chars)</span>
-                  )}
-                </p>
-                <p>
-                  {c.body}
-                  {c.body_truncated && <span className="trimmed"> (trimmed to {c.body_limit} chars)</span>}
-                </p>
-                <p className="cta">
-                  {c.cta}
-                  {c.cta_truncated && <span className="trimmed"> (trimmed to {c.cta_limit} chars)</span>}
-                </p>
-              </li>
-            ))}
+            {pack.ad_copy.map((c, i) => {
+              const link = pack.links.find((l) => l.channel === c.channel) ?? null
+              // The server never returns the untrimmed original alongside the
+              // fitted copy (`_ad_copy_variant`'s own docstring: a second,
+              // longer version sitting next to the one that actually fits is
+              // an invitation to paste the wrong one) — so the fitted text,
+              // ellipsis included, is the only thing there is to copy, and
+              // the only thing "copy all" can compose from.
+              const allText = composeChannelCopy({
+                headline: c.headline,
+                body: c.body,
+                cta: c.cta,
+                linkUrl: link?.url ?? null,
+              })
+              const anyTruncated = c.headline_truncated || c.body_truncated || c.cta_truncated
+              return (
+                <li key={`${c.channel}-${i}`}>
+                  <div className="copy-list-head">
+                    <strong>{c.channel}</strong> <span className="platform">{c.platform}</span>
+                    <PublishLink channelKey={c.channel} lookup={channelLookup} />
+                  </div>
+                  <p className="headline copy-field">
+                    <span>
+                      {c.headline}
+                      {c.headline_truncated && (
+                        <span className="trimmed"> (trimmed to {c.headline_limit} chars)</span>
+                      )}
+                    </span>
+                    <CopyButton
+                      text={c.headline}
+                      label={c.headline_truncated ? 'Copy headline (trimmed)' : 'Copy headline'}
+                      copied={copied}
+                      onCopy={copy}
+                    />
+                  </p>
+                  <p className="copy-field">
+                    <span>
+                      {c.body}
+                      {c.body_truncated && <span className="trimmed"> (trimmed to {c.body_limit} chars)</span>}
+                    </span>
+                    <CopyButton
+                      text={c.body}
+                      label={c.body_truncated ? 'Copy body (trimmed)' : 'Copy body'}
+                      copied={copied}
+                      onCopy={copy}
+                    />
+                  </p>
+                  <p className="cta copy-field">
+                    <span>
+                      {c.cta}
+                      {c.cta_truncated && <span className="trimmed"> (trimmed to {c.cta_limit} chars)</span>}
+                    </span>
+                    <CopyButton
+                      text={c.cta}
+                      label={c.cta_truncated ? 'Copy CTA (trimmed)' : 'Copy CTA'}
+                      copied={copied}
+                      onCopy={copy}
+                    />
+                  </p>
+                  <div className="copy-actions">
+                    <CopyButton
+                      text={allText}
+                      label={
+                        anyTruncated
+                          ? 'Copy all for this channel (includes trimmed copy)'
+                          : 'Copy all for this channel'
+                      }
+                      copiedLabel="Copied all"
+                      copied={copied}
+                      onCopy={copy}
+                      className="copy-all"
+                    />
+                  </div>
+                </li>
+              )
+            })}
           </ul>
 
           <h4>Targeting</h4>

--- a/web-admin/src/components/PublishLink.test.tsx
+++ b/web-admin/src/components/PublishLink.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { ChannelTaxonomyEntry } from '../lib/api'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+import { PublishLink } from './PublishLink'
+
+function makeLookup(entries: ChannelTaxonomyEntry[], loading = false): ChannelLookup {
+  const byKey = new Map(entries.map((e) => [e.key, e]))
+  return { get: (key) => byKey.get(key), entries, loading }
+}
+
+const LINKEDIN_ORGANIC: ChannelTaxonomyEntry = {
+  key: 'linkedin_organic',
+  label: 'LinkedIn — organic',
+  motion: 'organic',
+  category: 'social',
+  ad_platform: null,
+  publish_url: 'https://www.linkedin.com/feed/?shareActive=true',
+}
+
+// `trade_press_earned` (#103's own example): a pitch to a publication, not a
+// composer — the seed script leaves this one's `publish_url` unset.
+const TRADE_PRESS: ChannelTaxonomyEntry = {
+  key: 'trade_press_earned',
+  label: 'Trade press — earned coverage',
+  motion: 'organic',
+  category: 'trade_press',
+  ad_platform: null,
+  publish_url: null,
+}
+
+describe('PublishLink', () => {
+  it('renders a new-tab link to the taxonomy publish_url when one is set', () => {
+    render(<PublishLink channelKey="linkedin_organic" lookup={makeLookup([LINKEDIN_ORGANIC])} />)
+    const link = screen.getByRole('link', { name: /publish on linkedin — organic/i })
+    expect(link).toHaveAttribute('href', 'https://www.linkedin.com/feed/?shareActive=true')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders nothing — not a dead or placeholder link — when the channel has no publish_url', () => {
+    const { container } = render(<PublishLink channelKey="trade_press_earned" lookup={makeLookup([TRADE_PRESS])} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a channel_key the taxonomy does not recognise', () => {
+    const { container } = render(<PublishLink channelKey="unknown_channel" lookup={makeLookup([LINKEDIN_ORGANIC])} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing while the taxonomy is still loading, rather than a flash of a broken link', () => {
+    const { container } = render(<PublishLink channelKey="linkedin_organic" lookup={makeLookup([], true)} />)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/web-admin/src/components/PublishLink.tsx
+++ b/web-admin/src/components/PublishLink.tsx
@@ -1,0 +1,31 @@
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+
+/** A link to where an operator actually publishes on one channel — LinkedIn's
+ * post composer, Google Ads, and so on (#103b). The URL lives on the channel
+ * taxonomy (`marketing_channel.publish_url`, set server-side in
+ * `scripts/seed_marketing_channels.py`), not hardcoded here — this component
+ * only renders whatever `channelLookup` resolves.
+ *
+ * Renders nothing at all when the channel has no `publish_url` (loading, an
+ * unrecognised `channel_key`, or a channel that genuinely has none —
+ * `trade_press_earned` is a pitch to a publication, not a composer) — never a
+ * disabled or dead link, per #103b's own requirement that absence must read
+ * as nothing.
+ *
+ * `target="_blank"` + `rel="noopener noreferrer"` (#103b): these are
+ * third-party sign-in surfaces, so an unauthenticated operator bouncing
+ * through that platform's own login in a new tab, without losing this pack,
+ * is the correct and expected flow — this component never touches
+ * credentials of its own.
+ */
+export function PublishLink({ channelKey, lookup }: { channelKey: string; lookup: ChannelLookup }) {
+  const entry = lookup.get(channelKey)
+  const url = entry?.publish_url
+  if (entry === undefined || url === null || url === undefined || url === '') return null
+
+  return (
+    <a className="publish-link" href={url} target="_blank" rel="noopener noreferrer">
+      Publish on {entry.label} ↗
+    </a>
+  )
+}

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -895,6 +895,62 @@ details.mint-toggle[open] > .mint {
   text-transform: uppercase;
 }
 
+/* ── Copy blocks and publish links (#103a, #103b) ─────────────────────────
+ *
+ * Every headline/body/CTA row gets its own copy control, plus one
+ * "copy all for this channel" action per channel (composed in
+ * `lib/packCopy.ts`) — the actual unit of work when pasting into a
+ * composer. `.publish-link` sits beside the channel name/motion badge,
+ * pointing at wherever `marketing_channel.publish_url` says the operator
+ * actually goes to publish; it renders nothing when there is none
+ * (`PublishLink.tsx`), so no extra "empty" styling is needed here.
+ */
+
+.copy-list-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.copy-field {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.copy-field > span:first-child {
+  flex: 1;
+}
+
+.copy-btn {
+  flex: none;
+  font-size: 0.75rem;
+  padding: 0.3rem 0.65rem;
+  white-space: nowrap;
+}
+
+.copy-actions {
+  margin-top: 0.5rem;
+}
+
+.copy-btn.copy-all {
+  font-weight: 700;
+}
+
+.publish-link {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.publish-link:hover {
+  text-decoration: underline;
+}
+
 /* ── Accessibility: keyboard focus ────────────────────────────────────────
  *
  * A catch-all for anything interactive not already covered above (links,

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -406,6 +406,11 @@ export interface ChannelTaxonomyEntry {
   motion: 'organic' | 'paid'
   category: string
   ad_platform: string | null
+  /** Where an operator actually goes to publish on this channel — LinkedIn's
+   * post composer, Google Ads, and so on (#103b). `null` for channels with
+   * no single composer (a pitch to a publication, a tenant-specific email
+   * tool) — render nothing, never a placeholder or dead link. */
+  publish_url: string | null
 }
 
 export async function listChannels(): Promise<ChannelTaxonomyEntry[]> {

--- a/web-admin/src/lib/packCopy.test.ts
+++ b/web-admin/src/lib/packCopy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { composeChannelCopy } from './packCopy'
+
+describe('composeChannelCopy', () => {
+  it('joins headline, body, CTA and the tracked link with a blank line between each', () => {
+    const text = composeChannelCopy({
+      headline: 'Fast onboarding, done right',
+      body: 'Get every franchise unit live in a day.',
+      cta: 'Book a demo',
+      linkUrl: 'https://x/c/tok',
+    })
+    expect(text).toBe(
+      ['Fast onboarding, done right', 'Get every franchise unit live in a day.', 'Book a demo', 'https://x/c/tok'].join(
+        '\n\n',
+      ),
+    )
+  })
+
+  it('omits the link line entirely when there is no tracked link yet, rather than a placeholder', () => {
+    const text = composeChannelCopy({
+      headline: 'Fast onboarding, done right',
+      body: 'Get every franchise unit live in a day.',
+      cta: 'Book a demo',
+      linkUrl: null,
+    })
+    expect(text).toBe(['Fast onboarding, done right', 'Get every franchise unit live in a day.', 'Book a demo'].join('\n\n'))
+    expect(text).not.toContain('null')
+  })
+})

--- a/web-admin/src/lib/packCopy.ts
+++ b/web-admin/src/lib/packCopy.ts
@@ -1,0 +1,28 @@
+/** Composes the "copy everything for this channel" text (#103a) — headline,
+ * body, CTA and, when one exists, the channel's own tracked link, joined the
+ * way an operator would actually want to paste them into a composer: one
+ * blank line between each piece, not run together.
+ *
+ * This is the real unit of work when publishing (issue #103's own framing):
+ * an operator copying a channel's copy four separate times, in the right
+ * order, into a composer is exactly the tedium a single "copy all" control
+ * removes. `linkUrl` is omitted entirely when there is nothing to copy (no
+ * tracked link minted yet, or this deployment has no public base URL) —
+ * never a placeholder line saying so, since that placeholder would itself
+ * get pasted into the composer.
+ */
+export function composeChannelCopy({
+  headline,
+  body,
+  cta,
+  linkUrl,
+}: {
+  headline: string
+  body: string
+  cta: string
+  linkUrl: string | null
+}): string {
+  const parts = [headline, body, cta]
+  if (linkUrl !== null && linkUrl !== '') parts.push(linkUrl)
+  return parts.join('\n\n')
+}


### PR DESCRIPTION
Closes #103

Parts (a) and (b) of #103 only. Part (c) — naming real trade-press venues
instead of "trade press" — depends on #101's retrieval fix and is
deliberately untouched here.

## (a) Copy buttons on copy blocks

Every headline/body/CTA in both the distribution pack (`DistributionPack.tsx`)
and the paid pack (`PaidPack.tsx`) now gets its own copy button
(`CopyButton.tsx`), backed by the existing `useClipboard` hook — the same one
`MintLinks`/`PackLinks` already use for tracked links, not a second
implementation. Each channel also gets a **copy-all-for-this-channel**
control that composes headline + body + CTA + that channel's own tracked
link (`lib/packCopy.ts`), joined with blank lines — the real unit of work
when pasting into a composer, per the issue.

**Truncated paid copy:** the server (`paid_pack_routes._ad_copy_variant`)
never returns the untrimmed original alongside the fitted text — a second,
longer version sitting next to the one that fits is "an invitation to paste
the wrong one" per its own docstring — so there is nothing to copy *but* the
trimmed text. What this PR adds is visibility: a truncated field's own copy
button reads "Copy headline (trimmed)" etc., and the copy-all button reads
"Copy all for this channel (includes trimmed copy)" when any field was cut,
so the operator can tell before clicking, not just from the inline
"(trimmed to N chars)" note next to the text.

All controls are plain `<button>`s, so they're keyboard-focusable and get
the existing `button:focus-visible` ring from the recent design pass for
free — no new focus-styling needed. Styled with the existing token
variables (`.copy-btn`, `.copy-field`, `.copy-actions` in `index.css`).

## (b) Per-channel publish links

`marketing_channel` gains an optional `publish_url` column (`biffo.plugin.json`),
the same pattern as the existing optional `ad_platform` column. Seeded
server-side in `scripts/seed_marketing_channels.py` — the URL lives in the
taxonomy, not hardcoded in the UI. `PublishLink.tsx` resolves a `channel_key`
through `channelLookup` (already threaded through both packs; `PaidPack` now
also receives it, matching `DistributionPack`) and renders a `target="_blank"
rel="noopener noreferrer"` link, or **nothing** when `publish_url` is unset,
unrecognised, or still loading.

**Set** (13 of 31 channels) — each a single, stable, well-known composer or
landing entry point I'm confident about:

| Channel | URL |
|---|---|
| `google_search_paid`, `youtube_paid` | `https://ads.google.com/home/` |
| `facebook_organic`, `instagram_organic` | `https://business.facebook.com/latest/home` (Meta Business Suite — the shared organic composer for both) |
| `facebook_paid`, `instagram_paid` | `https://adsmanager.facebook.com/adsmanager/` |
| `linkedin_organic` | `https://www.linkedin.com/feed/?shareActive=true` |
| `linkedin_paid` | `https://www.linkedin.com/campaignmanager/` |
| `tiktok_organic` | `https://www.tiktok.com/upload` |
| `tiktok_paid` | `https://ads.tiktok.com/` |
| `x_organic` | `https://twitter.com/compose/tweet` |
| `x_paid` | `https://ads.twitter.com/` |
| `youtube_organic` | `https://www.youtube.com/upload` |

**Left unset** (18 channels), and why — every one is a deliberate "I'm not
confident enough to link this" rather than an oversight:

- `trade_press_earned`, `trade_press_paid` — a pitch/negotiation with a
  specific, unnamed outlet, not a composer (the issue's own framing for the
  first one).
- `short_form_video_organic` — spans Reels/Shorts/TikTok clips under one
  taxonomy row; no single stable URL covers all three.
- `email_owned_list`, `email_newsletter_sponsorship` — whichever ESP/outlet
  the tenant uses; this plugin has no way to know which.
- `blog_seo_content`, `search_organic` — published to the tenant's own
  site/CMS, not a third party.
- `guest_content`, `partner_comarketing`, `affiliate_referral` — a pitch or
  a negotiated relationship, not a composer.
- `webinar`, `online_communities` — depends entirely on which tool/community
  the tenant uses.
- `trade_show_presence`, `own_event`, `event_sponsorship`,
  `direct_mail`, `local_field_activity`, `local_paid_advertising` — physical
  or negotiated with a specific local outlet; nothing online to deep-link to.

If any of the 13 set URLs look wrong, or a case for adding one I left unset
looks stronger than I judged, that's a one-line follow-up in
`scripts/seed_marketing_channels.py` (idempotent re-seed script — a new/
corrected entry reaches existing installs without touching anything an
instance already customised).

## Tests

`web-admin/` has no CI (#97), so run by hand from `web-admin/`:

- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm vitest run` — **108 passed** (17 files), including new suites for
  `CopyButton`, `PublishLink`, `lib/packCopy`, and new cases in
  `DistributionPack.test.tsx`/`PaidPack.test.tsx` covering: a copy control
  per block, copy-all composing headline+body+CTA+link in order, a truncated
  field's button/label, and a channel with no `publish_url` rendering no
  link at all.

Python: `uv run pytest` — **470 passed**; `uv run ruff check .` / `ruff
format --check .` / `uv run pyright` — all clean. New tests in
`tests/test_marketing_seed_marketing_channels.py` assert every channel
declares a `publish_url` key (`None` is valid), every non-`None` value is a
plausible stable `https://` URL with no embedded credentials,
`trade_press_earned` specifically has none, and a representative subset of
named-platform channels do have one (so the check isn't vacuously true).

The repo's own pre-push gate (`sh scripts/biffo.sh` verify) ran automatically
on push and passed everything including `lint(web-admin)`,
`typecheck(web-admin)` and `test(web-admin)`.

## Not verified

No running deployment to click through — this is unverified against a real
browser/real third-party composer beyond the URL shapes themselves. I did
not sign in to any of the 13 linked platforms to confirm the exact
composer/ads-manager URL still resolves the way I expect; they're long-
standing, well-known entry points, but a platform can move a URL without
notice.
