### PR TITLE
chore(marketing): move every pipeline stage to the Claude 5 family

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -600,22 +600,33 @@ RESEARCH_INSTRUCTIONS: dict[str, str] = {
     RESEARCH_COMPETITIVE_AGENT_NAME: COMPETITIVE_RESEARCH_INSTRUCTIONS,
 }
 
-#: Research requires OpenRouter's ``:online`` suffix (live web results attached
-#: to the turn) for the same reason idea-scout's does — the search capability
-#: travels with the model id, so it cannot be silently half-configured by a
-#: missing Brave key. **Use the canonical dotted slug**, not a hyphenated
-#: alias — see idea-scout's ``DEFAULT_RESEARCH_MODEL``/``DEFAULT_SYNTHESIS_MODEL``
-#: docstring for why (an unlisted alias is accepted today but is undocumented
-#: behaviour, not a documented guarantee).
-DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-4:online"
+#: Every stage runs on the Claude 5 family (issue #62). The tier is chosen per
+#: stage rather than uniformly: research is the fan-out, reading-heavy leg and
+#: runs on the Sonnet tier; the four stages that turn evidence into artefacts an
+#: operator publishes run on Opus, because their failure mode is a
+#: confident-sounding fabrication rather than a visible error.
+#:
+#: **Use the canonical slug**, not an unlisted alias — see idea-scout's
+#: ``DEFAULT_RESEARCH_MODEL``/``DEFAULT_SYNTHESIS_MODEL`` docstring for why (an
+#: unlisted alias is accepted today but is undocumented behaviour, not a
+#: documented guarantee). The Claude 5 ids carry no minor version, so there is
+#: no dotted/hyphenated choice to get wrong the way ``claude-opus-4.8`` had.
+#:
+#: Research also requires OpenRouter's ``:online`` suffix (live web results
+#: attached to the turn) for the same reason idea-scout's does — the search
+#: capability travels with the model id, so it cannot be silently
+#: half-configured by a missing Brave key. Sonnet 5 keeps `:online`; the suffix
+#: is a routing directive OpenRouter applies to any supported chat model, not a
+#: per-model capability that a tier change can drop.
+DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-5:online"
 #: Neither synthesis, positioning nor channel planning searches — all three
 #: reason over what they are given — so none of them needs `:online`.
-DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-4.8"
-DEFAULT_POSITIONING_MODEL = "anthropic/claude-opus-4.8"
-DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-opus-4.8"
+DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-5"
+DEFAULT_POSITIONING_MODEL = "anthropic/claude-opus-5"
+DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-opus-5"
 #: Copy reasons over what it is given, same as positioning and channel
 #: planning — no `:online` needed.
-DEFAULT_COPY_MODEL = "anthropic/claude-opus-4.8"
+DEFAULT_COPY_MODEL = "anthropic/claude-opus-5"
 
 # Matches idea-scout's research budget: enough turns to search several times
 # and still answer. Every turn has an invoice attached and this plugin fans out

--- a/tests/test_marketing_stage_models.py
+++ b/tests/test_marketing_stage_models.py
@@ -1,0 +1,75 @@
+"""The model each pipeline stage runs on.
+
+Issue #62 moved every stage from the Claude 4 generation to the Claude 5
+family. None of that was covered by a test, which is exactly why the move was
+invisible: a model id is a plain string that no schema validates, so a typo, a
+half-finished upgrade, or a dropped ``:online`` suffix all read as ordinary
+configuration until a run comes back wrong in production.
+
+The two invariants worth pinning are the ones whose breakage is silent:
+
+* **Family.** A stage left behind on an older generation still runs and still
+  bills — nothing fails — so the only way to notice is to assert it.
+* **``:online`` on research, and only research.** The suffix is what gives
+  research grounded retrieval, and it is the sole reason the zero-citation
+  guard has anything to cite (Biffo's native ``web_search`` is silently never
+  offered on dev, so an agent that declares it fabricates rather than errors).
+  Losing it on research would produce confident, uncited findings; gaining it
+  on a downstream stage would bill for retrieval that stage does not use and
+  would make issue #90's "this run was never grounded" reasoning wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from marketing.definitions import (
+    DEFAULT_CHANNEL_PLAN_MODEL,
+    DEFAULT_COPY_MODEL,
+    DEFAULT_POSITIONING_MODEL,
+    DEFAULT_RESEARCH_MODEL,
+    DEFAULT_SYNTHESIS_MODEL,
+)
+
+#: Every stage constant, named as the pipeline names it.
+_STAGE_MODELS = {
+    "research": DEFAULT_RESEARCH_MODEL,
+    "synthesis": DEFAULT_SYNTHESIS_MODEL,
+    "positioning": DEFAULT_POSITIONING_MODEL,
+    "channel_plan": DEFAULT_CHANNEL_PLAN_MODEL,
+    "copy": DEFAULT_COPY_MODEL,
+}
+
+
+@pytest.mark.parametrize(("stage", "model"), sorted(_STAGE_MODELS.items()))
+def test_every_stage_runs_on_the_claude_5_family(stage: str, model: str) -> None:
+    """A stage left on an older generation bills and succeeds — assert it."""
+    base = model.split(":", 1)[0]
+
+    assert base.startswith("anthropic/claude-"), f"{stage} is not on an Anthropic slug: {model!r}"
+    assert base.endswith("-5"), f"{stage} is not on the Claude 5 family: {model!r}"
+
+
+def test_only_research_carries_the_online_suffix() -> None:
+    """`:online` is grounded retrieval. Research needs it; nothing downstream
+    does, and issue #90's not-grounded reasoning depends on that staying true."""
+    online = {stage for stage, model in _STAGE_MODELS.items() if ":online" in model}
+
+    assert online == {"research"}
+
+
+def test_the_seeded_synthesis_model_is_the_constant() -> None:
+    """The trap in issue #62: `scripts/seed_fan_in_workflow.py` **copies**
+    `DEFAULT_SYNTHESIS_MODEL` into the workflow's `action_config` at seed time,
+    so synthesis reads the frozen copy at run time, not this constant. Changing
+    the constant alone therefore leaves every environment on the old model
+    until the workflow is re-seeded with `--replace`.
+
+    This asserts the two are the same value at the point of seeding, so the
+    diff at least names the seeded field a reader has to go re-seed.
+    """
+    from _scripts import load_script
+
+    config = load_script("seed_fan_in_workflow").definition()["action_config"]
+
+    assert config["model"] == DEFAULT_SYNTHESIS_MODEL


### PR DESCRIPTION
Closes #62

## What changed

`src/marketing/definitions.py` — the five stage-model constants, and the comment block explaining them:

| stage | before | after | why this tier |
|---|---|---|---|
| Research | `anthropic/claude-sonnet-4:online` | `anthropic/claude-sonnet-5:online` | The fan-out, reading-heavy leg: **two** agents per run, 8 turns each, searching and extracting with citations. That is Sonnet-tier work — search-and-read, not deep judgement — and it was already on Sonnet 4, so this is a straight generational upgrade at the same tier. Putting the highest-volume stage on Opus would double the most-repeated cost in the pipeline for the stage least likely to benefit. |
| Synthesis | `anthropic/claude-opus-4.8` | `anthropic/claude-opus-5` | Reconciles two independent research reports and must carry every source through **unchanged** — no invention, no dropped citation — and must say "the research came back empty" rather than filling the gap. Everything downstream is built on its output. |
| Positioning | `anthropic/claude-opus-4.8` | `anthropic/claude-opus-5` | The core strategic judgement: segments, pillars and CTAs, each of which must cite the research or not exist. |
| Channel plan | `anthropic/claude-opus-4.8` | `anthropic/claude-opus-5` | **Considered for Sonnet 5 and deliberately not moved.** It is the most mechanical of the four (pick from a bounded taxonomy, rank, justify), but its own instructions name the risk: "run paid social" reads as correct whether or not anyone researched it, so ungrounded output here is invisible rather than wrong-looking. Evidence-grounding fidelity is exactly what a tier drop costs, and this is one call per campaign — the saving would be marginal against a silent-failure risk. |
| Copy | `anthropic/claude-opus-4.8` | `anthropic/claude-opus-5` | Publish-ready prose, tone-matched per channel, and the most visible artefact the product ships. |

No other file in the repo carries a model id — `grep -rn "anthropic/"` returns only this one block. Terraform, `biffo.plugin.json`, `web-admin/` and the seed scripts all reach the values through `marketing.definitions`.

## Cost

**No cost/pricing constants exist to update.** This plugin never hardcodes a rate card: `agent_runs.cost_usd` and `media_generations.cost_usd` are read from the provider's `usage` object on each completion (see `image_provider.py`'s unpriced-vs-zero contract). List price per stage is unchanged in both directions anyway:

- Sonnet 4 → Sonnet 5: $3 / $15 per MTok either way (Sonnet 5 is at an introductory $2 / $10 through 2026-08-31, so research is temporarily *cheaper*).
- Opus 4.8 → Opus 5: $5 / $25 per MTok, unchanged.

`:online` retrieval is billed by OpenRouter per result, independent of the model, so that is unchanged too.

## `:online` is preserved, and now asserted

`:online` is a routing directive OpenRouter applies to any supported chat model, not a per-model capability, so the tier change cannot drop it. But **nothing asserted that**, which is how a dropped suffix would reach production: research would keep running, keep billing, and return confident uncited findings, because Biffo's native `web_search` is silently never offered on dev.

New `tests/test_marketing_stage_models.py` pins the two invariants whose breakage is silent:

1. every stage constant is on the Claude 5 family (parametrised per stage);
2. `:online` is on research **and only** research — losing it breaks the zero-citation guard's premise, gaining it downstream makes issue #90's "this run was never grounded" reasoning wrong;
3. the seeded fan-in workflow's frozen `action_config["model"]` equals `DEFAULT_SYNTHESIS_MODEL` at seed time.

## ⚠️ Re-seed required — the diff does not carry synthesis

Per the trap called out in #62: `scripts/seed_fan_in_workflow.py` **copies** `DEFAULT_SYNTHESIS_MODEL` into the workflow's `action_config` when it seeds, and synthesis reads that frozen copy at run time. **Merging this PR leaves synthesis running Opus 4.8 in every environment** until the workflow is re-seeded:

```bash
uv run python scripts/seed_fan_in_workflow.py --replace
```

Then read the deployed `action_config` back and confirm `model == "anthropic/claude-opus-5"`. The remaining #62 checkboxes that need a live environment — an observed research run returning real URLs, the zero-citation guard rejecting an empty run — are post-deploy verification, not something this diff can prove.

## Local verification

```
$ uv run ruff check . && uv run ruff format --check .
All checks passed!
56 files already formatted

$ uv run pytest -q
482 passed, 4 warnings in 5.90s
```

Pre-push `verify` (the gate that mirrors CI) passed all of: ruff-check, ruff-format, pyright, pytest, terraform-fmt, plugin-tf, plugin-names, adr-numbering, gitleaks, lint/typecheck/test (web-admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)