### PR TITLE
security: mirror instance's biffo-aws-account-id gitleaks rule

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+title = "Biffo Plugin Gitleaks Configuration"
+
+# Mirrors biffo-template's .gitleaks.toml `biffo-aws-account-id` rule
+# verbatim (see /home/keiran/code/biffo-template/.gitleaks.toml). Without it,
+# a bare 12-digit fixture value passes this repo's own Secret Scan and only
+# fails one repo and one CI cycle downstream, once vendored into an instance
+# whose gitleaks config does have this rule (#19). A plugin repo's gates
+# should be a superset of what its vendored copy will face downstream.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "biffo-aws-account-id"
+description = "AWS Account ID — should only appear in .tfvars.example or biffo.config.json placeholders"
+regex = '''\b\d{12}\b'''
+entropy = 0
+[rules.allowlist]
+regexes = [
+  "\\{\\{AWS_ACCOUNT_ID\\}\\}",  # placeholder in template files
+  "123456789012",                  # canonical example account ID used in tests
+  "999999999999",                  # canonical wrong-account ID used in error-path tests
+]
+# security-secrets' history scan runs `--full-history HEAD` (see ci.yml), so
+# this rule reaches every commit reachable from dev, not only this branch's
+# diff. #14 already fixed the *current* fixture values (the all-digit UUID
+# suffixes this rule exists to catch, e.g. b3f1c0de-...-000000000001), but the
+# pre-fix values are permanently part of dev's merged history and this rule
+# would otherwise flag them retroactively on every PR from now on — dev is
+# protected and its history is not ours to rewrite. Allowlisted by commit,
+# not by value or path, so the rule stays fully live against any NEW bare
+# 12-digit number introduced anywhere in the repo going forward — only these
+# three already-merged, already-superseded commits are exempted.
+commits = [
+  "bfb5dc5e075cc740dfaed146aa53aa1fca4dab45", # feat(marketing): mint tracked links for a campaign (#13)
+  "86f57b34c7ada4b7f84276148722602b29e8e57b", # feat(marketing): research + positioning agents, citation-enforced (#18)
+  "d2ddeef824268a5ec6464f5019b71735fd6d249c", # feat(marketing): still-image generation behind a provider port (#20)
+]


### PR DESCRIPTION
## What changed

`.gitleaks.toml` — this repo had no gitleaks config at all, so it lacked the
`biffo-aws-account-id` rule the instance (`tabsii-platform` / `biffo-template`)
enforces (any bare 12-digit number, allowlisting only `123456789012` and
`999999999999`). A fixture UUID ending in twelve digits passed this repo's gate
twice and only failed one repo and one CI cycle downstream, after being
vendored. Mirrors the rule verbatim from `biffo-template`'s canonical
`.gitleaks.toml`.

The pre-#14 fixture values this rule exists to catch
(`b3f1c0de-...-000000000001/2`) are already fixed at HEAD, but they are
permanently part of `dev`'s merged history — `security-secrets`'s history
scan runs `--full-history HEAD`, so a naive mirror of the rule would flag
those three already-merged, already-superseded commits on every future PR.
`dev` is protected and its history isn't ours to rewrite, so they're
allowlisted **by commit SHA**, not by value or path — the rule stays fully
live against any *new* bare 12-digit number introduced anywhere in the repo.

Verified locally: both the filesystem scan and the full-history scan (the
exact commands `security-secrets` runs) pass clean, and a sanity check
confirms the rule still fires on a genuinely new bare 12-digit value.

## Reduced scope — the web-admin CI job has been dropped

This PR originally also added a `web-admin` CI job. While it was being
written, a concurrent session merged **#107**, which added the same coverage
under the job name `Admin frontend (lint, types, test, build)` — it is live
on `dev` today and runs `pnpm install --frozen-lockfile --ignore-workspace`,
`lint`, `typecheck`, `test` and `build` against `web-admin/`, matching what
this PR's job would have done. Re-verified directly against
`origin/dev:.github/workflows/ci.yml` before dropping anything here — #107's
job fully covers it, so carrying a second, differently-named job here would
just be a duplicate.

The `ci.yml` commit has been dropped from this branch entirely (rebased onto
current `dev`, then only the `.gitleaks.toml` commit cherry-picked back).
This PR now touches `.gitleaks.toml` only.

## Why this was also a Release Guards fix

The original two-commit branch failed the closing-keyword guard: it changed
`.github/workflows/ci.yml` (a path a green suite doesn't evidence) while the
second commit's body carried a GitHub auto-close reference to issue 97. That
coverage now lives in #107, not here, so the second commit — and its
auto-close reference — has been dropped from this branch entirely rather than
reworded; issue 97 was already closed by #107's own merge. With the `ci.yml`
change gone, the flagged path no longer exists in this diff, and the
remaining auto-close reference to issue 19 (see below) is for a
`.gitleaks.toml` change evidenced by the `security-secrets` job, so it
stands.

## What I deliberately did NOT change

- Did not touch `biffo-plugin-idea-scout`'s own CI or the
  `_skeletons/plugin-template/` CI skeleton in `biffo-template` — template-owned,
  out of scope for this repo's PR.
- Did not rewrite `dev`'s history to scrub the pre-#14 fixture values — `dev`
  is protected, rewriting shared history is destructive, and the commit-SHA
  allowlist achieves the same outcome without it.
- Did not add the gitleaks rule to the shared-files set — worth doing, but
  that's an upstream `biffo-template` change plus a distribution, not an edit
  here.
- Did not touch `web-admin/` CI at all in this PR — #107 already covers it on
  `dev`.

Closes #19
