### PR TITLE
fix(marketing): deterministic pack link order, one shared artefact-body parser

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -513,6 +513,22 @@ async def _latest_approved_artefact(
     return approved[0]
 
 
+def _parse_artefact_body(raw: Any) -> dict[str, Any]:
+    """An artefact's ``body`` normalised to a dict, whether it arrived as
+    Core's persisted JSON *text* or as a dict some caller already parsed (or
+    never serialised at all, e.g. a pending-state placeholder body built and
+    read back in the same request).
+
+    This exact ternary (``json.loads(raw) if isinstance(raw, str) else (raw
+    or {})``) was duplicated near-verbatim at every artefact-reading call
+    site across the plugin — ``pack_routes.py``, ``paid_pack_routes.py``
+    (twice), ``copy_routes.py``, ``channel_plan_routes.py``, this module's
+    own ``start_positioning_route``, and ``user_app.py`` (issue #49). One
+    implementation here; every call site below imports it rather than
+    re-deriving it."""
+    return json.loads(raw) if isinstance(raw, str) else (raw or {})
+
+
 def _require_known_kind(kind: str) -> None:
     if kind not in _PIPELINE_ARTEFACT_KINDS:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown artefact kind.")
@@ -811,8 +827,7 @@ async def start_positioning_route(
             detail="The research artefact must be approved before this can proceed.",
         )
 
-    raw_body = approved_research.get("body")
-    research_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+    research_body = _parse_artefact_body(approved_research.get("body"))
 
     # The closed set of URLs this run is actually being shown: the approved
     # research's own citations (issue #22). Read HERE, at start time, and

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -75,8 +75,7 @@ async def start_channel_plan_route(
             detail="The positioning artefact must be approved before this can proceed.",
         )
 
-    raw_body = approved_positioning.get("body")
-    positioning_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+    positioning_body = admin_app._parse_artefact_body(approved_positioning.get("body"))
     # The closed set of URLs this run is being shown (issue #22): exactly the
     # approved positioning's own citations. Read at start time and stashed on
     # the pending artefact below for the same reason `taxonomy_motions` is —

--- a/src/marketing/copy_routes.py
+++ b/src/marketing/copy_routes.py
@@ -93,11 +93,7 @@ async def start_copy_route(
             detail="The channel-plan artefact must be approved before this can proceed.",
         )
 
-    def _body(artefact: dict[str, Any]) -> dict[str, Any]:
-        raw = artefact.get("body")
-        return json.loads(raw) if isinstance(raw, str) else (raw or {})
-
-    channel_plan_body = _body(approved_channel_plan)
+    channel_plan_body = admin_app._parse_artefact_body(approved_channel_plan.get("body"))
     # `{channel_key: motion}` for the plan's real entries (#76 increment 2) —
     # excludes any suggested_label-only proposal, since it is not a real
     # channel yet. Stored on the pending artefact below and re-read at
@@ -132,7 +128,7 @@ async def start_copy_route(
 
     causation_id, run_id = await pipeline.start_copy(
         gateway,
-        positioning_body=_body(approved_positioning),
+        positioning_body=admin_app._parse_artefact_body(approved_positioning.get("body")),
         channel_plan_body=channel_plan_body,
     )
 

--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -94,7 +94,6 @@ someone checks on a real phone.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
@@ -262,6 +261,44 @@ async def _create_link_or_422(
     return response.json()
 
 
+def _link_sort_key(link: dict[str, Any]) -> tuple[bool, str, str]:
+    """A total order over a pack's ``links`` that does not depend on which
+    of them were already in Core and which were just minted (issue #94).
+
+    Before this, ``_ensure_links`` returned ``existing`` links (Core's own
+    list-route order, which carries no ``ORDER BY`` and is not guaranteed
+    stable) followed by whatever was minted just now (``channels`` iteration
+    order) appended after them. The two orderings agree by coincidence at
+    most once: the very first call that mints every link. Every later call
+    is all "existing" and reflects Core's order instead, which can — and in
+    the field, did — differ from the mint call's order. An operator refreshing
+    the same pack then sees the same links reshuffle for no reason, and
+    anything indexing ``links[n]`` positionally (this plugin does not, but a
+    caller reasonably could) gets a different answer each time.
+
+    Sorting the same key on every return path, regardless of whether a given
+    entry came from ``existing`` or was just minted, means the two paths
+    cannot diverge again — there is only one code path that decides order,
+    not two that happen to agree.
+
+    Organic before paid (`is_paid` ascending: `False`/`None` before `True`)
+    is the "reading order the pack otherwise implies" the issue itself names
+    — copy and creative are organic-first throughout this pack, so the links
+    list matching that is what an operator actually expects on top. Within a
+    motion, ``channel`` (a taxonomy ``channel_key``, short and stable — see
+    ``_ensure_links``'s own docstring) breaks ties alphabetically; ``variant``
+    (currently always ``None`` from this function, but not from generic CRUD
+    ``create``, which any admin can call directly) breaks any further tie so
+    the order stays fully deterministic even for two rows that otherwise
+    look identical.
+    """
+    return (
+        link.get("is_paid") is True,
+        str(link.get("channel") or ""),
+        str(link.get("variant") or ""),
+    )
+
+
 async def _ensure_links(
     campaign_id: str,
     channels: list[dict[str, Any]],
@@ -367,53 +404,57 @@ async def _ensure_links(
         for c in channels
         if _requested_key(c)[1] not in channel_motions.get(_requested_key(c)[0], set())
     ]
-    if not missing:
-        return out
+    if missing:
+        if not base_url:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="No public base URL is configured for this deployment.",
+            )
+        destination = campaign.get("destination_url")
+        if not destination:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="This campaign has no destination_url, so its links would lead nowhere.",
+            )
 
-    if not base_url:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="No public base URL is configured for this deployment.",
-        )
-    destination = campaign.get("destination_url")
-    if not destination:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="This campaign has no destination_url, so its links would lead nowhere.",
-        )
+        for c in missing:
+            channel_key = c["channel_key"]
+            is_paid = c.get("motion") == "paid"
+            token = mint_token()
+            # The created row itself is not needed — the token minted it from is.
+            await _create_link_or_422(
+                channel_key,
+                admin_token,
+                {
+                    "campaign_id": campaign_id,
+                    "token": token,
+                    "channel": channel_key,
+                    "variant": None,
+                    "is_paid": is_paid,
+                    "destination_url": destination_with_utms(
+                        destination,
+                        campaign_id=campaign_id,
+                        channel=channel_key,
+                        variant=None,
+                        is_paid=is_paid,
+                    ),
+                },
+            )
+            out.append(
+                {
+                    "channel": channel_key,
+                    "variant": None,
+                    "is_paid": is_paid,
+                    "url": tracked_url(base_url, token),
+                }
+            )
 
-    for c in missing:
-        channel_key = c["channel_key"]
-        is_paid = c.get("motion") == "paid"
-        token = mint_token()
-        # The created row itself is not needed — the token minted it from is.
-        await _create_link_or_422(
-            channel_key,
-            admin_token,
-            {
-                "campaign_id": campaign_id,
-                "token": token,
-                "channel": channel_key,
-                "variant": None,
-                "is_paid": is_paid,
-                "destination_url": destination_with_utms(
-                    destination,
-                    campaign_id=campaign_id,
-                    channel=channel_key,
-                    variant=None,
-                    is_paid=is_paid,
-                ),
-            },
-        )
-        out.append(
-            {
-                "channel": channel_key,
-                "variant": None,
-                "is_paid": is_paid,
-                "url": tracked_url(base_url, token),
-            }
-        )
-    return out
+    # Sorted once, on the way out, regardless of which entries came from
+    # `existing` (Core's own unordered list) and which were just minted
+    # (`channels` iteration order) — see `_link_sort_key`'s own docstring
+    # for why a single shared key is what keeps the mint call and every
+    # later fetch call in agreement (issue #94).
+    return sorted(out, key=_link_sort_key)
 
 
 @router.get("/campaigns/{campaign_id}/assets")
@@ -525,8 +566,7 @@ async def get_pack_route(
             detail="The copy artefact must be approved before this can proceed.",
         )
 
-    raw_body = approved_copy.get("body")
-    copy_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+    copy_body = admin_app._parse_artefact_body(approved_copy.get("body"))
     channels = copy_body.get("channels") or []
     try:
         pipeline.require_channel_keyed_copy(channels)

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -54,7 +54,6 @@ calling the same two functions, not by re-deriving the reasoning.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, create_core_client
@@ -330,10 +329,7 @@ async def get_paid_pack_route(
             detail="The copy artefact must be approved before this can proceed.",
         )
 
-    raw_copy_body = approved_copy.get("body")
-    copy_body = (
-        json.loads(raw_copy_body) if isinstance(raw_copy_body, str) else (raw_copy_body or {})
-    )
+    copy_body = admin_app._parse_artefact_body(approved_copy.get("body"))
     channels = copy_body.get("channels") or []
     try:
         pipeline.require_channel_keyed_copy(channels)
@@ -368,12 +364,7 @@ async def get_paid_pack_route(
             detail="The positioning artefact must be approved before this can proceed.",
         )
 
-    raw_positioning_body = approved_positioning.get("body")
-    positioning_body = (
-        json.loads(raw_positioning_body)
-        if isinstance(raw_positioning_body, str)
-        else (raw_positioning_body or {})
-    )
+    positioning_body = admin_app._parse_artefact_body(approved_positioning.get("body"))
     raw_segments = positioning_body.get("segments") or []
     if not raw_segments:
         raise HTTPException(

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -119,7 +119,6 @@ version the admin surface builds.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
@@ -296,8 +295,7 @@ async def get_pack_route(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No approved copy for this campaign yet.",
         )
-    raw_body = copy_artefact.get("body")
-    copy_body = json.loads(raw_body) if isinstance(raw_body, str) else (raw_body or {})
+    copy_body = admin_app._parse_artefact_body(copy_artefact.get("body"))
     channels = copy_body.get("channels") or []
 
     asset_rows = await _list_all(

--- a/tests/test_marketing_admin_app.py
+++ b/tests/test_marketing_admin_app.py
@@ -102,3 +102,30 @@ def test_the_manifest_app_path_resolves(monkeypatch: pytest.MonkeyPatch) -> None
     module_name, _, attr = "marketing.admin_app:app".partition(":")
     module = __import__(module_name, fromlist=[attr])
     assert getattr(module, attr) is not None
+
+
+# ── issue #49: one shared artefact-body parser, not six duplicated ternaries ─
+
+
+def test_parse_artefact_body_parses_a_json_string() -> None:
+    """The common case: `body` as Core actually persists it — JSON text."""
+    assert admin_app._parse_artefact_body('{"channels": []}') == {"channels": []}
+
+
+def test_parse_artefact_body_passes_a_dict_through_unchanged() -> None:
+    """A caller that already holds the parsed dict (never re-serialised) must
+    not be forced through `json.loads` a second time — this is what every
+    converted call site relied on the ternary for, not just the string case."""
+    body = {"channels": [{"channel_key": "x"}]}
+    assert admin_app._parse_artefact_body(body) is body
+
+
+def test_parse_artefact_body_treats_none_and_an_empty_dict_as_empty() -> None:
+    """A pending-state artefact's `body` can be `None` (never written yet) or
+    `{}` (a real, empty payload) — both non-string cases read as `{}`
+    without ever reaching `json.loads`, matching every ternary this helper
+    replaced. An empty *string* is deliberately NOT covered here: it is a
+    `str`, so it takes the `json.loads` branch and raises — the identical
+    behaviour the duplicated ternary already had, unchanged by this refactor."""
+    assert admin_app._parse_artefact_body(None) == {}
+    assert admin_app._parse_artefact_body({}) == {}

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -816,3 +816,92 @@ def test_assets_route_includes_placement_renders(monkeypatch: pytest.MonkeyPatch
     body = resp.json()
     assert {a["placement"] for a in body["assets"] if a["placement"]} == set(PLACEMENTS)
     assert body["missing_placements"] == []
+
+
+# ── issue #94: link order must agree between mint and every later fetch ─────
+
+_ORDER_CHANNELS = [
+    {
+        "channel_key": "search_organic",
+        "motion": "organic",
+        "headline": "Free listing shows up before anyone pays for a click.",
+        "body": "Organic search brings in the operators already looking.",
+        "cta": "See how it ranks",
+        "sources": [{"url": "https://example.com/a", "note": "n"}],
+    },
+    {
+        "channel_key": "trade_press_paid",
+        "motion": "paid",
+        "headline": "Reach the operators who read the trade press.",
+        "body": "A placement in front of exactly the right audience.",
+        "cta": "Book a placement",
+        "sources": [{"url": "https://example.com/b", "note": "n"}],
+    },
+    {
+        "channel_key": "google_search_paid",
+        "motion": "paid",
+        "headline": "Show up for the exact searches that convert.",
+        "body": "Paid search alongside the organic listing above.",
+        "cta": "Start a campaign",
+        "sources": [{"url": "https://example.com/c", "note": "n"}],
+    },
+]
+
+
+def test_link_order_agrees_between_the_minting_call_and_a_later_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #94, the reported disagreement itself: the first call for a
+    campaign mints every link (`_ensure_links` used to append in `channels`
+    iteration order); every later call is all "existing" links, read back
+    from Core with no `ORDER BY`. Those two orderings had no reason to
+    agree, and in the field, did not — the same campaign's pack listed
+    `search_organic` first on mint and last on every refresh.
+
+    Reorders Core's own storage between the two calls, so a fix that merely
+    happens to preserve insertion order (and would still pass if `existing`
+    came back in a different sequence) is not enough to pass this — only a
+    fix that imposes the SAME order regardless of storage order can.
+    """
+    core = _FakeCore(copy_artefact=_copy_artefact(_ORDER_CHANNELS))
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    minted = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+    assert minted.status_code == 200
+    minted_order = [link["channel"] for link in minted.json()["links"]]
+    assert len(minted_order) == 3  # sanity: every channel actually minted
+
+    # Core's list route carries no ORDER BY — the second call must not
+    # depend on whatever order the rows happen to sit in storage.
+    core.links.reverse()
+
+    fetched = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+    assert fetched.status_code == 200
+    fetched_order = [link["channel"] for link in fetched.json()["links"]]
+
+    assert fetched_order == minted_order
+
+
+def test_link_order_is_organic_first_then_alphabetical_within_a_motion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins the actual chosen key (`_link_sort_key`) rather than only its
+    self-consistency: organic before paid — the "reading order the pack
+    otherwise implies" the issue itself names, since copy and creative are
+    organic-first throughout the rest of this pack — then alphabetical by
+    `channel` within a motion."""
+    core = _FakeCore(copy_artefact=_copy_artefact(_ORDER_CHANNELS))
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 200
+    assert [link["channel"] for link in resp.json()["links"]] == [
+        "search_organic",
+        "google_search_paid",
+        "trade_press_paid",
+    ]

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -539,6 +539,36 @@ def test_does_not_remint_a_paid_link_for_a_channel_that_already_has_one(
     assert core.links == [core.links[0]]
 
 
+def test_paid_pack_link_order_agrees_between_the_minting_call_and_a_later_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #94, over this route: `paid_pack_routes.get_paid_pack_route`
+    reuses `pack_routes._ensure_links` verbatim, so it inherits the same
+    mint-vs-fetch ordering fix rather than needing its own. Reorders Core's
+    own storage between the two calls, same as the organic-pack version of
+    this test."""
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META, _PAID_CHANNEL_GOOGLE]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    minted = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+    assert minted.status_code == 200
+    minted_order = [link["channel"] for link in minted.json()["links"]]
+    assert len(minted_order) == 2
+
+    core.links.reverse()
+
+    fetched = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack")
+    assert fetched.status_code == 200
+    fetched_order = [link["channel"] for link in fetched.json()["links"]]
+
+    assert fetched_order == minted_order
+
+
 # ── pure-function unit tests ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #94
Closes #49

## #94 — deterministic pack link order

`_ensure_links` (`pack_routes.py`) built its returned `links` list from two
sources that had no reason to agree on order: `existing` links read back
from Core's list route (no `ORDER BY`, order not guaranteed stable across
calls) and freshly-minted links appended in `channels` iteration order. The
first call for a campaign mints every link and so happens to come back in
`channels` order; every later call is all "existing" and reflects whatever
order Core's storage returns instead — which, per the issue, is a different
order in practice.

Fix: a single `_link_sort_key(link)` — `(is_paid, channel, variant)`,
organic before paid — applied once at the one point `_ensure_links` returns,
regardless of whether a given entry came from `existing` or was just
minted. There is now exactly one code path deciding order, so the mint call
and every later fetch cannot diverge again. `paid_pack_routes.py` reuses
`pack_routes._ensure_links` verbatim (`get_paid_pack_route`), so it inherits
the fix rather than needing its own.

Tests (`test_marketing_pack_routes.py`, `test_marketing_paid_pack_routes.py`):
one per route that mints a multi-channel pack, captures the minted order,
reorders the fake Core's underlying `links` storage, fetches again, and
asserts the two orders are identical — reordering storage in between is what
makes this catch a fix that merely happens to preserve insertion order.
Plus one test pinning the actual chosen key (organic-first, then
alphabetical).

**Proved fail-first**: reverted only the final `sorted(...)` call in
`_ensure_links` back to a bare `return out` and re-ran the three new order
tests — all three failed with a channel-order mismatch (e.g.
`'trade_press_paid' != 'google_search_paid'`), i.e. the exact disagreement
the issue reports. Restored the fix and confirmed the full suite (481
tests) passes again.

## #49 — one shared artefact-body parser

The `json.loads(raw) if isinstance(raw, str) else (raw or {})` ternary was
duplicated at **seven call sites across six files**, not the two named in
the issue title:

- `pack_routes.py` (1)
- `paid_pack_routes.py` (2)
- `copy_routes.py` (1, inside a local `_body` closure that itself contained
  the ternary — the issue's own "already solving this with a one-line
  closure" was one *more* copy, not a fix)
- `channel_plan_routes.py` (1)
- `admin_app.py`'s own `start_positioning_route` (1)
- `user_app.py` (1)

Extracted one `admin_app._parse_artefact_body(raw)` and routed all seven
sites through it (issue #72's lesson — `public_base_url_for` adopted at one
of three call sites, packs 500'd — is exactly the shape a partial sweep
here would repeat). Removed now-unused `import json` from
`pack_routes.py`, `paid_pack_routes.py` and `user_app.py`; kept it in
`copy_routes.py`, `channel_plan_routes.py` and `admin_app.py`, which still
call `json.dumps` elsewhere.

Tests (`test_marketing_admin_app.py`): three direct unit tests on
`_parse_artefact_body` — JSON string, dict passthrough, `None`. **Proved
fail-first**: temporarily deleted the helper and re-ran them — all three
failed with `AttributeError: module 'marketing.admin_app' has no attribute
'_parse_artefact_body'`. Restored and confirmed green.

### Deferred from #49's other review points

None are correctness bugs; each is a separate, larger change than this PR's
scope:

- **Point 2** — the duplicated fetch/404/409 gate block between `copy` and
  `positioning` in `get_paid_pack_route`. Not extracted; the issue itself
  says it's "worth a small helper once a third caller needs the same
  shape" and no third caller exists yet.
- **Point 3** — `_ad_copy_variant`'s three near-identical
  trim-and-build-dict blocks (headline/body/cta). Not looped over field
  names; a real behaviour-preserving refactor worth its own review rather
  than folding into this diff.
- **Point 4** — running the copy/positioning Core fetches concurrently via
  `asyncio.gather`. A real (small) perf win but changes the request
  sequencing of a route with existing tests asserting call order; left
  alone here.
- **Point 5** — `_platform_for_channel`'s keyword-guess heuristic has no
  tracked follow-up issue. Not filed here; flagging for the repo owner
  rather than opening one unilaterally as part of an unrelated PR.

## What I did not change

- No frontend (`web-admin/`) changes — the link array's *contents* are
  unchanged, only its order, and nothing there renders `links[n]`
  positionally.
- `admin_app.py`'s `json.loads(artefact.get("body") or "{}")` sites
  (`_advance_artefact`, three call sites) are a different pattern — always
  assumes a string — and are not the duplication this issue is about; left
  untouched.

## Verification

- `uv run pytest` — 481 passed (full suite, not just the touched files).
- `uv run ruff check src tests` — clean.
- `uv run pyright src/marketing/` — 0 errors.
- Local push gate (`scripts/biffo.sh verify`) — green, including
  `web-admin` lint/typecheck/test (installed `pnpm install` in `web-admin/`
  first; this repo has no root `package.json`).
