### PR TITLE
fix(seed): backfill a default channel's never-set field on an existing install

### DIFF
--- a/scripts/seed_marketing_channels.py
+++ b/scripts/seed_marketing_channels.py
@@ -394,6 +394,56 @@ def _request(method: str, url: str, token: str, body: dict | None = None) -> Any
         return json.loads(resp.read() or b"null")
 
 
+#: Fields a later release may add to a default channel, which an already-seeded
+#: instance would otherwise never receive. `publish_url` (#103b) is the first:
+#: it was added to `CHANNELS` after every existing instance had already seeded
+#: its taxonomy, so on those instances the column existed, held NULL on all 32
+#: rows, and the feature that reads it shipped dead.
+_BACKFILLABLE_FIELDS = ("publish_url",)
+
+
+def _backfill_null_fields(url: str, token: str, by_key: dict[str, dict]) -> int:
+    """Fill a default channel's field that is NULL here but set in `CHANNELS`.
+
+    **Strictly fill-if-null, never overwrite.** The module docstring's rule —
+    this script never clobbers an instance's own value — is the reason the
+    seed is insert-only, and it still holds: a row whose `publish_url` an
+    operator has set, or deliberately cleared to something non-NULL, is left
+    exactly as it is. Only a field that has never held a value is written.
+
+    Without this, adding a field to `CHANNELS` reaches new installs only. Every
+    instance that had already seeded its taxonomy — which is every instance
+    that has ever run a channel plan — keeps NULL for ever, and the feature
+    reading that field is silently dead there while its code, its tests and its
+    UI all ship and pass.
+
+    A key absent from `CHANNELS` (an instance-added channel) is never touched:
+    this only ever iterates the defaults.
+    """
+    filled = 0
+    for channel in CHANNELS:
+        row = by_key.get(channel["key"])
+        if row is None:
+            continue
+        patch = {
+            field: channel[field]
+            for field in _BACKFILLABLE_FIELDS
+            if channel.get(field) is not None and row.get(field) is None
+        }
+        if not patch:
+            continue
+        try:
+            _request("PATCH", f"{url}/{row['id']}", token, patch)
+        except urllib.error.HTTPError as exc:
+            print(
+                f"Could not backfill {channel['key']}: {exc.code} {exc.reason}",
+                file=sys.stderr,
+            )
+            continue
+        filled += len(patch)
+    return filled
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="print, change nothing")
@@ -418,10 +468,10 @@ def main() -> int:
 
     # Idempotent by key, and never touches a row it did not just create — see
     # the module docstring's "never clobbers an instance's own additions".
-    have = {row.get("key") for row in existing}
+    by_key = {row.get("key"): row for row in existing}
     created = 0
     for channel in CHANNELS:
-        if channel["key"] in have:
+        if channel["key"] in by_key:
             continue
         try:
             _request("POST", url, token, channel)
@@ -430,8 +480,10 @@ def main() -> int:
             return 1
         created += 1
 
+    filled = _backfill_null_fields(url, token, by_key)
+
     skipped = len(CHANNELS) - created
-    print(f"Created {created} channel(s); {skipped} already present.")
+    print(f"Created {created} channel(s); {skipped} already present; {filled} field(s) backfilled.")
     return 0
 
 

--- a/tests/test_marketing_seed_marketing_channels.py
+++ b/tests/test_marketing_seed_marketing_channels.py
@@ -194,13 +194,17 @@ def test_the_75_case_itself_cannot_occur() -> None:
 class _FakeCore:
     """A minimal in-memory stand-in for the tenant's `marketing_channel` rows,
     behind the exact seam (`seed._request`) the real script calls through.
-    Records every method used, so a test can assert the script never issues a
-    PATCH or DELETE — the structural half of "never clobbers an instance's own
-    additions"."""
+    Records every method used and every PATCH body, so a test can assert both
+    halves of "never clobbers an instance's own additions": the script never
+    DELETEs or PUTs at all, and the only PATCH it may issue is a fill-if-null
+    backfill of a DEFAULT channel's never-set field (#103b)."""
 
     def __init__(self, initial: list[dict[str, Any]] | None = None) -> None:
         self.rows: list[dict[str, Any]] = [dict(row) for row in (initial or [])]
         self.methods_used: list[str] = []
+        #: (row_id, body) for every PATCH, so a test can assert exactly which
+        #: rows were touched and with what — not merely that a PATCH happened.
+        self.patches: list[tuple[str, dict]] = []
 
     def request(self, method: str, url: str, token: str, body: dict | None = None) -> Any:
         self.methods_used.append(method)
@@ -211,6 +215,15 @@ class _FakeCore:
             row = {**body, "id": f"row-{len(self.rows)}"}
             self.rows.append(row)
             return row
+        if method == "PATCH":
+            assert body is not None
+            row_id = url.rsplit("/", 1)[-1]
+            self.patches.append((row_id, dict(body)))
+            for row in self.rows:
+                if row.get("id") == row_id:
+                    row.update(body)
+                    return row
+            raise AssertionError(f"PATCH against unknown row {row_id!r}")
         raise AssertionError(f"unexpected method {method!r} — the seeder must never call this")
 
 
@@ -259,9 +272,14 @@ def test_reseeding_preserves_an_instance_added_channel(monkeypatch) -> None:
 
     assert rc == 0
     assert custom_channel in fake.rows, "the instance-added channel must survive re-seeding"
-    assert "PATCH" not in fake.methods_used
     assert "PUT" not in fake.methods_used
     assert "DELETE" not in fake.methods_used
+    # The seeder may now PATCH — but only to fill a DEFAULT channel's
+    # never-set field (#103b). It must never touch an instance-added row,
+    # whose key is absent from CHANNELS entirely.
+    assert all(row_id != custom_channel["id"] for row_id, _ in fake.patches), (
+        "an instance-added channel must never be PATCHed"
+    )
 
 
 def test_an_upgrade_adding_a_default_channel_reaches_an_existing_install(monkeypatch) -> None:
@@ -314,3 +332,78 @@ def test_it_hits_the_same_public_crud_mount_the_other_marketing_tables_use() -> 
     which had never once existed (#60). This script targets the same,
     already-proven mount, not a new or guessed one."""
     assert seed._CHANNELS_PATH == "/api/v1/plugins/marketing/channels"
+
+
+def test_a_field_added_to_a_default_channel_reaches_an_already_seeded_install(
+    monkeypatch,
+) -> None:
+    """The gap this backfill closes, and the reason the feature reading it
+    shipped dead.
+
+    `publish_url` (#103b) was added to `CHANNELS` after every existing
+    instance had already seeded its taxonomy. Because the seeder is
+    insert-only — it skips any key it already has — those rows kept NULL for
+    ever: the migration added the column, all 32 rows held NULL, and the UI
+    reading it rendered no links while its code, its tests and its CI all
+    passed. Observed exactly that on tabsii dev: 0 of 32 rows populated.
+    """
+    seeded = [
+        {**channel, "id": f"row-{i}", "publish_url": None} for i, channel in enumerate(CHANNELS)
+    ]
+    fake = _FakeCore(initial=seeded)
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0
+    expected = {c["key"]: c["publish_url"] for c in CHANNELS if c.get("publish_url")}
+    assert expected, "this test is vacuous unless some default channel has a publish_url"
+    for row in fake.rows:
+        if row["key"] in expected:
+            assert row["publish_url"] == expected[row["key"]], (
+                f"{row['key']} should have been backfilled"
+            )
+
+
+def test_backfill_never_overwrites_a_value_an_operator_already_set(monkeypatch) -> None:
+    """Fill-if-null, never overwrite — the same rule that makes the seeder
+    insert-only in the first place, applied at field level rather than row
+    level. An operator who points a channel at their own composer keeps it."""
+    target = next(c for c in CHANNELS if c.get("publish_url"))
+    operator_value = "https://intranet.example.test/our-own-publishing-tool"
+    seeded = [
+        {
+            **channel,
+            "id": f"row-{i}",
+            "publish_url": operator_value if channel["key"] == target["key"] else None,
+        }
+        for i, channel in enumerate(CHANNELS)
+    ]
+    fake = _FakeCore(initial=seeded)
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0
+    kept = next(r for r in fake.rows if r["key"] == target["key"])
+    assert kept["publish_url"] == operator_value, "an operator's own value must survive"
+    assert all(row_id != kept["id"] for row_id, _ in fake.patches), (
+        "a row whose field is already set must not be PATCHed at all"
+    )
+
+
+def test_backfill_leaves_a_channel_with_no_publish_url_alone(monkeypatch) -> None:
+    """A default channel whose `publish_url` is deliberately None — a pitch to
+    a publication, not a composer — must not be PATCHed with a null, which
+    would be a write that changes nothing and muddies the audit trail."""
+    seeded = [
+        {**channel, "id": f"row-{i}", "publish_url": None} for i, channel in enumerate(CHANNELS)
+    ]
+    fake = _FakeCore(initial=seeded)
+
+    _run_seed(monkeypatch, fake)
+
+    no_url_keys = {c["key"] for c in CHANNELS if c.get("publish_url") is None}
+    by_id = {r["id"]: r for r in fake.rows}
+    for row_id, _ in fake.patches:
+        assert by_id[row_id]["key"] not in no_url_keys, (
+            "a channel with no publish_url must never be PATCHed"
+        )


### PR DESCRIPTION
fix(seed): backfill a default channel's never-set field on an existing install

`publish_url` (#103b) was added to `CHANNELS` after every existing
instance had already seeded its taxonomy. The seeder is insert-only — it
skips any key it already has — so those rows kept NULL for ever.

Observed on tabsii dev straight after deploying #105: the migration added
the column, all 32 rows held NULL, and the publish-links feature rendered
nothing. Its code, its tests, its UI and both repos' CI were all green.
The feature shipped dead.

The fix is a strictly fill-if-null pass over DEFAULT channels only. The
rule that makes this seeder insert-only — never clobber an instance's own
value — is unchanged; it now applies at field level as well as row level:

* a field an operator has set is never touched,
* a default channel whose value is deliberately None is never PATCHed
  with a null (a write that changes nothing),
* an instance-added channel, whose key is absent from `CHANNELS`, is
  never touched at all.

`_BACKFILLABLE_FIELDS` names the fields this applies to, so adding a
field to `CHANNELS` in future is a one-line opt-in rather than a silent
no-op on every already-seeded install.

The fake Core previously asserted the seeder issues NO PATCH ever, which
encoded the old invariant. That expectation is now wrong, so it is
REPLACED rather than weakened: it records every PATCH and the tests
assert exactly which rows may be touched and with what. PUT and DELETE
remain forbidden outright.

New tests verified fail-first — with the backfill disabled, the
already-seeded case fails.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
