### PR TITLE
fix(web-admin): render measurable results metrics, and a standing denominator

### DIFF
--- a/web-admin/src/components/Results.test.tsx
+++ b/web-admin/src/components/Results.test.tsx
@@ -15,6 +15,16 @@ function stubSession(jwt = 'test-jwt') {
   } as never)
 }
 
+/** Matches a whole metric line — label included.
+ *
+ * `getByText`'s default matcher sees only an element's *direct* text-node
+ * children, so a `<p><strong>Leads:</strong> 3</p>` never matches
+ * `/Leads: 3/` and a negative assertion written that way passes for the
+ * wrong reason. Matching on `textContent` is what ties the label to the
+ * figure beside it, which is the whole claim under test (issue #114). */
+const line = (pattern: RegExp) => (_: string, el: Element | null) =>
+  el?.tagName === 'P' && pattern.test(el.textContent ?? '')
+
 describe('Results', () => {
   it('shows real clicks, and leads/conversions/cost as not measurable — never as zero', async () => {
     stubSession()
@@ -49,6 +59,122 @@ describe('Results', () => {
     expect(screen.getByText(/denominator: 12/)).toBeInTheDocument()
     // Never render "0" for an unmeasurable count.
     expect(screen.queryByText(/^0$/)).not.toBeInTheDocument()
+  })
+
+  it('renders a measurable leads figure as its value, never as "not measurable"', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            {
+              campaign_id: 'c1',
+              campaign_name: 'Spring',
+              clicks: { total: 12, paid: 5, organic: 7, unknown_channel_type: 0 },
+              // The shape `results_routes.py`'s `Metric` actually serialises when
+              // the instance-configured leads source answered: a real number, a
+              // denominator, and `reason: null` — the `null` that used to be read
+              // as text and rendered as "not measurable — undefined".
+              leads: { value: 3, measurable: true, denominator: 12, reason: null },
+              conversions: {
+                value: null,
+                measurable: false,
+                denominator: null,
+                reason: 'demo_requests.status has no mutation path',
+              },
+              cost: { value: 250, measurable: true, denominator: null, reason: null },
+            },
+          ],
+          unattributed_clicks: 0,
+        }),
+      }),
+    )
+
+    render(<Results campaignId="c1" />)
+
+    // The measurable branch: the value, and its denominator alongside it.
+    expect(await screen.findByText(line(/^Leads: 3 \(denominator: 12\)$/))).toBeInTheDocument()
+    expect(screen.getByText(line(/^Cost: 250$/))).toBeInTheDocument()
+    // The unmeasurable branch survives, honestly, with the real reason.
+    expect(
+      screen.getByText(line(/^Conversions: not measurable — demo_requests\.status has no mutation path$/)),
+    ).toBeInTheDocument()
+    // Nothing measurable is described as unmeasurable, and no `undefined` leaks
+    // out of a `reason` that is `null` precisely because the metric measured.
+    expect(screen.queryByText(line(/Leads: not measurable/))).not.toBeInTheDocument()
+    expect(screen.queryByText(line(/Cost: not measurable/))).not.toBeInTheDocument()
+    expect(screen.queryByText(line(/undefined/))).not.toBeInTheDocument()
+  })
+
+  it('renders a measurable zero as a zero, distinct from unmeasurable', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            {
+              campaign_id: 'c1',
+              campaign_name: 'Spring',
+              clicks: { total: 9, paid: 9, organic: 0, unknown_channel_type: 0 },
+              leads: { value: 0, measurable: true, denominator: 9, reason: null },
+              conversions: { value: null, measurable: false, denominator: null, reason: 'no signal' },
+              cost: { value: null, measurable: false, denominator: null, reason: 'no cost source' },
+            },
+          ],
+          unattributed_clicks: 0,
+        }),
+      }),
+    )
+
+    render(<Results campaignId="c1" />)
+
+    expect(await screen.findByText(line(/^Leads: 0 \(denominator: 9\)$/))).toBeInTheDocument()
+    expect(screen.queryByText(line(/Leads: not measurable/))).not.toBeInTheDocument()
+  })
+
+  it('states the excluded-clicks denominator whether or not the metrics are measurable', async () => {
+    stubSession()
+    const campaign = (leads: unknown) => ({
+      campaign_id: 'c1',
+      campaign_name: 'Spring',
+      clicks: { total: 12, paid: 5, organic: 7, unknown_channel_type: 0 },
+      leads,
+      conversions: { value: null, measurable: false, denominator: null, reason: 'no signal' },
+      cost: { value: null, measurable: false, denominator: null, reason: 'no cost source' },
+    })
+
+    // Measurable — the denominator must not vanish just because leads resolved.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [campaign({ value: 3, measurable: true, denominator: 12, reason: null })],
+          unattributed_clicks: 4,
+        }),
+      }),
+    )
+    const measurable = render(<Results campaignId="c1" />)
+    expect(await screen.findByText(/4 clicks could not be attributed to any campaign/)).toBeInTheDocument()
+    measurable.unmount()
+
+    // Unmeasurable — the same standing count, on the same terms.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [campaign({ value: null, measurable: false, denominator: 12, reason: 'no leads source' })],
+          unattributed_clicks: 4,
+        }),
+      }),
+    )
+    render(<Results campaignId="c1" />)
+    expect(await screen.findByText(/4 clicks could not be attributed to any campaign/)).toBeInTheDocument()
   })
 
   it('says plainly when this campaign has no results yet', async () => {

--- a/web-admin/src/components/Results.tsx
+++ b/web-admin/src/components/Results.tsx
@@ -1,17 +1,35 @@
 import { useEffect, useState } from 'react'
 
-import { getResults, type CampaignResults, type UnmeasuredMetric } from '../lib/api'
+import { getResults, type CampaignResults, type Metric } from '../lib/api'
 
-/** One unmeasurable metric, rendered so it can never be mistaken for a zero.
+/** One leads/conversions/cost figure — measured, or explicitly not.
+ *
  * `results_routes.py`'s own discipline: "no data" is a structurally distinct
  * thing from "zero" — a confident number that is wrong in a systematic
- * direction is worse than a missing one. Every share carries its
- * denominator, when one is known here. */
-function UnmeasuredCell({ label, metric }: { label: string; metric: UnmeasuredMetric }) {
+ * direction is worse than a missing one. So the two branches read
+ * differently on purpose, and a measured `0` renders as `0` rather than
+ * borrowing the unmeasurable wording.
+ *
+ * The denominator is printed the same way in **both** branches. Showing it
+ * only when a metric was unmeasurable (the pre-#114 behaviour) inverted the
+ * requirement: the population vanished at exactly the moment there was a
+ * share to state it for. */
+function MetricCell({ label, metric }: { label: string; metric: Metric }) {
+  const denominator = metric.denominator !== null && <> (denominator: {metric.denominator})</>
+
+  if (metric.measurable) {
+    return (
+      <p className="measured">
+        <strong>{label}:</strong> {metric.value}
+        {denominator}
+      </p>
+    )
+  }
+
   return (
     <p className="unmeasurable">
       <strong>{label}:</strong> not measurable — {metric.reason}
-      {metric.denominator !== null && <> (denominator: {metric.denominator})</>}
+      {denominator}
     </p>
   )
 }
@@ -21,13 +39,20 @@ function UnmeasuredCell({ label, metric }: { label: string; metric: UnmeasuredMe
  * the campaign this detail view is showing, rather than adding a
  * per-campaign route that does not exist server-side.
  *
- * Clicks are real, measured rows. Leads, conversions and cost are not — this
- * plugin has no reachable transport to `demo_requests`/`lead_source_costs`
- * (issue #31) — and are rendered as explicitly unmeasurable, never as a
- * silent zero.
+ * Clicks are real, measured rows. Leads, conversions and cost come from the
+ * instance-configured leads source (issue #31): a real figure where that
+ * source answered, and an explicit reason where it could not — never a
+ * silent zero, and never a measured figure disguised as unmeasurable.
+ *
+ * `unattributed_clicks` is tenant-wide rather than per-campaign, so it is
+ * rendered once for the whole section: it is the count excluded from every
+ * campaign's total above, and stating it is what stops a share here being
+ * computed over a filtered population and read as if it covered the whole
+ * one.
  */
 export function Results({ campaignId }: { campaignId: string }) {
   const [results, setResults] = useState<CampaignResults | null>(null)
+  const [unattributed, setUnattributed] = useState(0)
   const [found, setFound] = useState(true)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -41,6 +66,7 @@ export function Results({ campaignId }: { campaignId: string }) {
         if (cancelled) return
         const mine = all.campaigns.find((c) => c.campaign_id === campaignId) ?? null
         setResults(mine)
+        setUnattributed(all.unattributed_clicks)
         setFound(mine !== null)
       })
       .catch((e: unknown) => {
@@ -71,9 +97,14 @@ export function Results({ campaignId }: { campaignId: string }) {
         )}
       </p>
 
-      <UnmeasuredCell label="Leads" metric={results.leads} />
-      <UnmeasuredCell label="Conversions" metric={results.conversions} />
-      <UnmeasuredCell label="Cost" metric={results.cost} />
+      <MetricCell label="Leads" metric={results.leads} />
+      <MetricCell label="Conversions" metric={results.conversions} />
+      <MetricCell label="Cost" metric={results.cost} />
+
+      <p className="excluded">
+        {unattributed} click{unattributed === 1 ? '' : 's'} could not be attributed to any campaign
+        {unattributed > 0 ? ' — excluded from every campaign total above.' : '.'}
+      </p>
     </section>
   )
 }

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -823,6 +823,24 @@ details.mint-toggle[open] > .mint {
   font-style: italic;
 }
 
+/* A measured figure reads as a figure — upright and in the body colour, so a
+ * real number is never mistaken for the italic, muted "not measurable" line
+ * sitting next to it (issue #114). */
+.measured {
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+/* The standing excluded-clicks denominator. Always rendered, including at
+ * zero: "nothing was excluded" is a claim worth making explicitly. */
+.excluded {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
+  margin-top: 0.75rem;
+  padding-top: 0.6rem;
+}
+
 .trimmed {
   color: var(--warning-text);
   font-style: italic;

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -406,4 +406,36 @@ describe('getResults', () => {
     expect(results.campaigns[0].clicks.total).toBe(4)
     expect(results.campaigns[0].leads.measurable).toBe(false)
   })
+
+  it('can represent a measurable metric — the shape the API sends when the leads source answered', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            {
+              campaign_id: 'c1',
+              campaign_name: 'Spring',
+              clicks: { total: 12, paid: 5, organic: 7, unknown_channel_type: 0 },
+              leads: { value: 3, measurable: true, denominator: 12, reason: null },
+              conversions: { value: null, measurable: false, denominator: null, reason: 'no signal' },
+              cost: { value: 250.5, measurable: true, denominator: null, reason: null },
+            },
+          ],
+          unattributed_clicks: 2,
+        }),
+      }),
+    )
+    const results = await getResults()
+    const leads = results.campaigns[0].leads
+    // Narrowing on the discriminant must reach a branch that HAS a value — with
+    // `measurable: false` as a literal type this branch is unreachable and
+    // `.value` does not typecheck at all, which is the defect (issue #114).
+    if (!leads.measurable) throw new Error('expected leads to be measurable')
+    expect(leads.value).toBe(3)
+    expect(leads.denominator).toBe(12)
+    expect(results.unattributed_clicks).toBe(2)
+  })
 })

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -660,20 +660,54 @@ export interface ClickBreakdown {
  * itself known; `null` when it isn't. Render "not measurable" distinctly from
  * zero — this plugin has no reachable transport to `demo_requests`/
  * `lead_source_costs` (issue #31), so reporting zero would claim "we looked,
- * and nothing happened," which is not a claim it can make today. */
+ * and nothing happened," which is not a claim it can make today.
+ *
+ * Still the exact shape of the paid pack's `spend`, which really is
+ * unmeasurable on every instance. It is NOT the shape of the results
+ * dashboard's leads/conversions/cost — see {@link Metric}. */
 export interface UnmeasuredMetric {
   measurable: false
   denominator: number | null
   reason: string
 }
 
+/** A leads/conversions/cost figure the instance-configured leads source
+ * answered (issue #31). Mirrors `results_routes.py`'s `Metric` when
+ * `measurable` is `True`: `value` is a real number — a real zero is
+ * `value: 0, measurable: true`, distinguishable from unmeasurable by
+ * `measurable` alone and never by `value` being falsy — and `reason` is
+ * `null`, because there is nothing to excuse. */
+export interface MeasuredMetric {
+  value: number
+  measurable: true
+  denominator: number | null
+  reason: null
+}
+
+/** The other half of `results_routes.py`'s `Metric`: the source could not
+ * answer, and `reason` says why, verbatim from upstream where it gave one.
+ * `value` is `null` — the server sends the key, and it is never a zero. */
+export interface UnmeasurableMetric {
+  value: null
+  measurable: false
+  denominator: number | null
+  reason: string
+}
+
+/** Exactly the union `results_routes.py`'s `Metric` serialises, discriminated
+ * on `measurable`. Typing only the unmeasurable half made the measurable one
+ * unrepresentable, so the dashboard rendered a real leads figure as "not
+ * measurable — undefined" (issue #114). Both halves always carry
+ * `denominator`, measurable or not. */
+export type Metric = MeasuredMetric | UnmeasurableMetric
+
 export interface CampaignResults {
   campaign_id: string
   campaign_name: string
   clicks: ClickBreakdown
-  leads: UnmeasuredMetric
-  conversions: UnmeasuredMetric
-  cost: UnmeasuredMetric
+  leads: Metric
+  conversions: Metric
+  cost: Metric
 }
 
 export interface ResultsResponse {


### PR DESCRIPTION
Closes #114

## The defect

The results dashboard **could not display a measurable figure at all**.

`web-admin/src/lib/api.ts` typed `leads`/`conversions`/`cost` as `UnmeasuredMetric` with `measurable: false` as a **literal** type, so the shape the server actually sends when the instance-configured leads source answers was *unrepresentable* — and `Results.tsx` rendered all three through the unmeasurable branch with no conditional. On an instance with a leads source configured, the operator saw:

> Leads: not measurable — undefined

That `undefined` is the UI reading `.reason` off a payload whose `reason` is `null` **precisely because the metric measured**.

## The server's real response shape

Checked against `src/marketing/results_routes.py` rather than invented. `Metric` (`:211-230`) is a pydantic model with **four always-present keys**, in exactly one of two states — `_metric_from_raw` (`:383-407`) is what guarantees it:

| | `value` | `measurable` | `denominator` | `reason` |
|---|---|---|---|---|
| measured | a real `int`/`float` (never a bool) | `true` | `int` or `null` | `null` |
| unmeasured | `null` | `false` | `int` or `null` | non-empty `string` |

`denominator` is populated on **both** states, and only for `leads` (`_metrics_for_campaign`, `:410-449`) — a click-to-lead rate's population is this campaign's click count either way.

## The fix

1. **The measurable branch now exists.** `Metric = MeasuredMetric | UnmeasurableMetric`, discriminated on `measurable`, mirroring the table above. `Results.tsx` renders both. A measured `0` renders as `0` — distinct from unmeasurable, never falsy-tested. Unmeasurable keeps rendering honestly with its real reason: **conversions stay unmeasurable at the source** (`demo_requests.status` has no mutation path) and must.
2. **The denominator is standing, not conditional.** `unattributed_clicks` was computed, returned (`results_routes.py:481-486,503`) and typed — and rendered nowhere. Worse, the per-metric denominator showed *only* on the unmeasurable branch, so a share lost its population at exactly the moment there was a share to state it for — the inversion of M8's own criterion. Both now render regardless of measurability, including at zero ("nothing was excluded" is a claim worth making).

`UnmeasuredMetric` is left untouched and still types the paid pack's `spend`, which genuinely is unmeasurable on every instance.

## Tests — written first, proven failing

The measurable branch had **no coverage**, which is how a green suite shipped a broken dashboard. Four new cases, all failing on the pre-fix code:

```
× Results > renders a measurable leads figure as its value, never as "not measurable"
  → Unable to find an element with the text: /^Leads: 3 \(denominator: 12\)$/
× Results > renders a measurable zero as a zero, distinct from unmeasurable
  → Unable to find an element with the text: /^Leads: 0 \(denominator: 9\)$/
× Results > states the excluded-clicks denominator whether or not the metrics are measurable
  → Unable to find an element with the text: /4 clicks could not be attributed to any campaign/
 Tests  3 failed | 113 passed (116)

$ pnpm typecheck
src/lib/api.test.ts(437,18): error TS2339: Property 'value' does not exist on type 'UnmeasuredMetric'.
```

The DOM dump from that run shows the reported bug directly: `<p class="unmeasurable"><strong>Leads:</strong> not measurable — (denominator: 12)</p>` — the reason simply missing, because it is `null`.

After the fix: `Test Files 17 passed (17) · Tests 116 passed (116)`, `typecheck` exit 0, `lint` exit 0.

One test-only note: the new assertions match on `textContent` via a small `line()` helper, because `getByText`'s default matcher sees only an element's **direct** text-node children — a `<p><strong>Leads:</strong> 3</p>` never matches `/Leads: 3/`, so a negative assertion written the naive way would pass for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)