### PR TITLE
fix(marketing): give each research angle its own search, and measure retrieval breadth

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -12,6 +12,7 @@ converted at every boundary for no gain.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -394,6 +395,16 @@ Every finding must cite a real URL taken from the material you were given.
 Copy those URLs exactly; do not invent one, do not paraphrase one, and do not
 cite a page you were not shown.
 
+**Cite the page the evidence is actually on, not the site it lives on.** A
+claim is checkable only if a reader following your URL lands where the claim
+is: a price belongs to a pricing page, a complaint to the thread it was
+posted in, a feature comparison to the comparison page. If you were shown
+both a site's home page and a deeper page on the same site, cite the deeper
+one. Never attach a specific figure — a price, a percentage, a count, a plan
+name — to a bare home-page URL: if the only URL you have for that claim is a
+site root, either state the finding without the precision that URL cannot
+support, or leave the finding out.
+
 Do not pad the list: two well-evidenced findings beat five speculative ones.
 
 Return an empty findings list ONLY if the retrieved material genuinely
@@ -401,6 +412,29 @@ contains nothing relevant to your angle — not because you could not search,
 which you were not asked to do. If you were given sources and none supports a
 finding on your angle, say so by returning nothing; but if a source does
 support one, it must appear with its URL.
+"""
+
+#: What each research agent is told about the retrieval it was handed.
+#:
+#: The two angles used to be expressed ONLY in these instructions, which the
+#: provider never searches on: retrieval is derived from the run's input
+#: payload, and both agents were sent the identical payload
+#: (``{"campaign_id": ..., "brief": ...}``). So both searches resolved to the
+#: same query and returned the same pages — measured on campaign ``ed7c5bc2``
+#: (issue #101): 5 URLs each, **4 of them shared**, 6 distinct across the pair.
+#: The fan-out paid for two runs and bought one evidence pool.
+#:
+#: ``search_query`` (see :func:`research_search_query`) is now built per angle
+#: and sent as the *first* key of the payload, so the two agents genuinely
+#: search different things. This rule tells the model that, so it does not
+#: re-derive the other angle's ground from its own material.
+_RETRIEVAL_SCOPE_RULE = """\
+Your input begins with a `search_query`: the text the retrieval you were
+given was derived from. It is scoped to YOUR angle and deliberately differs
+from the other researcher's, so the pages in front of you are not the pages
+in front of them. Work your own angle from your own material — the other
+angle is covered by someone else, and restating the market's top-level facts
+duplicates their work instead of adding to it.
 """
 
 AUDIENCE_RESEARCH_INSTRUCTIONS = f"""\
@@ -416,6 +450,7 @@ Prioritise:
   reviews, social threads, Q&A sites.
 - Where they already are, so a later channel plan has somewhere to start.
 
+{_RETRIEVAL_SCOPE_RULE}
 {_EVIDENCE_RULE}
 {_UNTRUSTED_INPUT_RULE}
 Return your findings by calling the `{FINDINGS_TOOL_NAME}` tool exactly once.
@@ -434,6 +469,7 @@ Prioritise:
 - Anything a competitor has been criticised for, in reviews or public
   discussion — a gap this campaign should not repeat.
 
+{_RETRIEVAL_SCOPE_RULE}
 {_EVIDENCE_RULE}
 {_UNTRUSTED_INPUT_RULE}
 Return your findings by calling the `{FINDINGS_TOOL_NAME}` tool exactly once.
@@ -608,6 +644,111 @@ RESEARCH_INSTRUCTIONS: dict[str, str] = {
     RESEARCH_AUDIENCE_AGENT_NAME: AUDIENCE_RESEARCH_INSTRUCTIONS,
     RESEARCH_COMPETITIVE_AGENT_NAME: COMPETITIVE_RESEARCH_INSTRUCTIONS,
 }
+
+
+# ── What each angle actually searches for (issue #101) ───────────────────────
+#
+# An ``:online`` run's retrieval is derived from the run's *input*, not from
+# its instructions — the provider searches before the model is invoked and has
+# only the payload to search on. Every prompt difference between the two
+# research agents was therefore invisible to retrieval, and both were sent the
+# byte-identical payload. Measured on campaign ``ed7c5bc2``: 5 URLs each, 4
+# shared, **6 distinct across both agents, every one of them a site root**.
+#
+# So the angle has to live in what gets searched. Two things are encoded
+# below, and only these two — neither is a prompt tweak:
+#
+# 1. **Divergence.** The audience angle searches for where people TALK (forum
+#    threads, independent review pages, Q&A answers); the competitive angle
+#    searches for what vendors PUBLISH (pricing, plans, comparisons, case
+#    studies). Those retrieve from different corners of the web by
+#    construction, so the pool stops being one search paid for twice.
+# 2. **Depth.** Both framings name page *types* rather than vendors, and both
+#    say the specific page rather than the home page — a query for "pricing
+#    page" resolves to a pricing page far more often than a query naming a
+#    market does.
+#
+# What is NOT here, deliberately: the number of results per search. ``:online``
+# is a routing suffix that takes no parameters, and OpenRouter's per-request
+# ``plugins: [{"id": "web", "max_results": N}]`` form is not reachable from
+# this repo — the definition snapshot this plugin sends Core carries
+# ``instructions``/``model``/``tools``/``max_turns``/``output_tools``, and
+# widening the pool that way needs Core to pass web-plugin options through.
+# More searches, likewise, means more agent runs (one search per run), which
+# is a cost and a fan-in decision, not a prompt one — see this module's
+# ``RESEARCH_AGENT_NAMES`` and ``scripts/seed_fan_in_workflow.py``'s
+# ``expect_agents``, which must be re-seeded if that tuple ever changes.
+RESEARCH_SEARCH_FRAMING: dict[str, str] = {
+    RESEARCH_AUDIENCE_AGENT_NAME: (
+        "what buyers and users say about this in their own words — forum threads, "
+        "independent review-site pages, Q&A answers, community discussions and "
+        "complaint threads; the specific discussion or review page, not a vendor "
+        "home page"
+    ),
+    RESEARCH_COMPETITIVE_AGENT_NAME: (
+        "how competing vendors sell against this — pricing pages, plan and feature "
+        "comparison pages, product and case-study pages, and independent head-to-head "
+        "comparisons; the specific page carrying the claim, not a vendor home page"
+    ),
+}
+if set(RESEARCH_SEARCH_FRAMING) != set(RESEARCH_AGENT_NAMES):
+    raise RuntimeError(
+        "RESEARCH_SEARCH_FRAMING must cover exactly RESEARCH_AGENT_NAMES "
+        f"(got {sorted(RESEARCH_SEARCH_FRAMING)} against {sorted(RESEARCH_AGENT_NAMES)})"
+    )
+
+#: How much of the campaign brief rides in the searched query line.
+#:
+#: The whole brief still travels in the payload for the *model* to read — this
+#: bounds only the part retrieval derives a query from. A search query built
+#: from several hundred words of brief is a worse query than one built from
+#: its opening: the angle framing is what should dominate it, and it cannot if
+#: it is appended to an essay.
+SEARCH_QUERY_BRIEF_CHARS = 240
+
+
+def _brief_topic(brief: Mapping[str, Any] | None) -> str:
+    """The searchable topic inside a research ``brief`` payload, truncated on a
+    word boundary and stripped of newlines.
+
+    Tolerant by construction: the payload is assembled by
+    ``admin_app.start_research_route`` as ``{"campaign_id": ..., "brief":
+    <the campaign's brief text>}``, but a campaign's ``brief`` column is free
+    text a human wrote, so it may be empty, absent, or not a string at all.
+    None of those is worth failing a research run over — an empty topic simply
+    leaves the angle framing to stand on its own.
+    """
+    if not isinstance(brief, Mapping):
+        return ""
+    text = brief.get("brief")
+    if not isinstance(text, str):
+        return ""
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= SEARCH_QUERY_BRIEF_CHARS:
+        return collapsed
+    head = collapsed[:SEARCH_QUERY_BRIEF_CHARS]
+    cut = head.rfind(" ")
+    return head[:cut] if cut > 0 else head
+
+
+def research_search_query(*, agent_name: str, brief: Mapping[str, Any] | None) -> str:
+    """The text THIS angle's retrieval is derived from.
+
+    Sent as the first key of the research run's ``input_payload`` (see
+    ``marketing.pipeline.start_research``) so that the provider's pre-invocation
+    search sees the angle before it sees anything else. Two agents, two
+    different strings — which is the whole point: identical payloads produced
+    a 4-of-5 overlap between the two angles (issue #101).
+
+    Raises ``KeyError`` for an unknown ``agent_name``, exactly as
+    ``RESEARCH_INSTRUCTIONS[agent_name]`` already does one line up in
+    ``start_research``: a research agent with no framing would silently fall
+    back to searching the brief alone, which is the defect this exists to fix.
+    """
+    framing = RESEARCH_SEARCH_FRAMING[agent_name]
+    topic = _brief_topic(brief)
+    return f"{topic} — {framing}" if topic else framing
+
 
 #: Every stage runs on the Claude 5 family (issue #62). The tier is chosen per
 #: stage rather than uniformly: research is the fan-out, reading-heavy leg and

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -53,6 +53,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 from urllib.parse import urlsplit, urlunsplit
 
+from aws_lambda_powertools import Logger
 from pydantic import BaseModel, ValidationError
 
 from .definitions import (
@@ -89,7 +90,10 @@ from .definitions import (
     positioning_definition,
     positioning_tool_schema,
     research_definition,
+    research_search_query,
 )
+
+logger = Logger(child=True)
 
 
 class PipelineError(Exception):
@@ -745,7 +749,20 @@ async def start_research(
                 model=research_model, instructions=RESEARCH_INSTRUCTIONS[agent_name]
             ),
             output_tool=findings_tool_schema(),
-            input_payload={"brief": brief},
+            # `search_query` FIRST, and per agent (issue #101). An `:online`
+            # run's retrieval is derived from this payload — the provider
+            # searches before the model is invoked — so the payload, not the
+            # instructions, is the only place an angle can affect what is
+            # retrieved. Both agents used to be sent the identical
+            # `{"brief": brief}` and duly received the same pages (4 of 5
+            # shared on campaign `ed7c5bc2`). `brief` is unchanged and still
+            # carries the full brief for the model to read; the query line is
+            # additive, and first because JSON key order is preserved and the
+            # angle should lead the text a query is derived from.
+            input_payload={
+                "search_query": research_search_query(agent_name=agent_name, brief=brief),
+                "brief": brief,
+            },
             causation_id=chain_id,
         )
         research_run_ids.append(run_id)
@@ -800,6 +817,116 @@ def _aggregate_research_annotations(
     return []
 
 
+def _annotation_url(entry: Any) -> str | None:
+    """The URL inside one ``annotations`` entry, whichever shape it arrived in.
+
+    Core stores what the runtime recorded, and OpenRouter's ``url_citation``
+    annotation has been seen both flattened (``{"type": "url_citation",
+    "url": ...}`` — the shape every fixture in this repo uses and the shape
+    Core writes today) and nested (``{"url_citation": {"url": ...}}``, the
+    upstream OpenAI-compatible form). Reading only one of them would make the
+    breadth measurement below silently report zero the day the other appears,
+    which is exactly the kind of quiet blindness issue #101 was filed about.
+    """
+    if not isinstance(entry, dict):
+        return None
+    url = entry.get("url")
+    if not isinstance(url, str) or not url:
+        nested = entry.get("url_citation")
+        url = nested.get("url") if isinstance(nested, dict) else None
+    return url if isinstance(url, str) and url else None
+
+
+def _is_site_root(url: str) -> bool:
+    """True for a bare origin — ``https://example.com`` or
+    ``https://example.com/`` — and false for anything carrying a path or a
+    query. The distinction issue #101 measured by hand: a homepage citation
+    cannot substantiate a claim about a price on a pricing page."""
+    parts = urlsplit(url.strip())
+    return parts.path.strip("/") == "" and not parts.query
+
+
+@dataclass(frozen=True)
+class EvidenceProfile:
+    """How broad and how deep one research chain's retrieval actually was.
+
+    Every number here was measured **by hand**, off provider annotations, to
+    file issue #101 — 5 URLs per agent, 4 shared, 6 distinct, 0 deep pages.
+    That is the argument for computing it on every run instead: the evidence
+    base being thin is not visible in any artefact an operator reads, and
+    nothing failed, so the only way to notice was for somebody to go looking.
+
+    ``runs_measured`` is deliberately separate from the count of runs asked
+    about: a run whose ``annotations`` are ``None`` (not a grounded run, or a
+    vanished view) contributes nothing and must not be read as one that
+    retrieved zero URLs — the same tri-state distinction
+    :func:`_aggregate_research_annotations` keeps one level up.
+    """
+
+    runs_measured: int
+    distinct_urls: int
+    shared_urls: int
+    deep_pages: int
+    site_roots: int
+
+
+def evidence_profile(views: Collection[AgentRunView | None]) -> EvidenceProfile:
+    """Measure the retrieval pool the research runs actually drew on.
+
+    ``shared_urls`` counts distinct URLs returned to more than one run — the
+    fan-out's redundancy, and the number that says whether running two angles
+    bought two evidence pools or one. ``site_roots`` counts distinct URLs with
+    no path at all, which is the depth question: a pool of home pages cannot
+    support a finding that quotes a figure, however many home pages it holds.
+    """
+    per_run: list[set[str]] = []
+    for view in views:
+        if view is None or view.annotations is None:
+            continue
+        urls = {u for u in (_annotation_url(a) for a in view.annotations) if u}
+        per_run.append({_url_key(u) for u in urls})
+    distinct: set[str] = set().union(*per_run) if per_run else set()
+    shared = {url for url in distinct if sum(url in run for run in per_run) > 1}
+    roots = {url for url in distinct if _is_site_root(url)}
+    return EvidenceProfile(
+        runs_measured=len(per_run),
+        distinct_urls=len(distinct),
+        shared_urls=len(shared),
+        deep_pages=len(distinct) - len(roots),
+        site_roots=len(roots),
+    )
+
+
+def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | None]) -> None:
+    """Record this chain's retrieval breadth where an operator investigating a
+    thin artefact will find it, without failing the run over it.
+
+    Not a guard, on purpose. Thin, homepage-only retrieval is a property of
+    what the provider returned, not of anything the model did wrong, so
+    failing on it would strand a campaign on a condition re-running cannot
+    fix — see this module's docstring on why the citation guards fail closed
+    and this one does not.
+    """
+    profile = evidence_profile(views)
+    logger.info(
+        "research retrieval breadth: %d distinct URLs across %d grounded run(s) "
+        "(%d shared by more than one, %d deep pages, %d site roots)",
+        profile.distinct_urls,
+        profile.runs_measured,
+        profile.shared_urls,
+        profile.deep_pages,
+        profile.site_roots,
+        extra={
+            "causation_id": chain_id,
+            "research_runs_measured": profile.runs_measured,
+            "research_distinct_urls": profile.distinct_urls,
+            "research_shared_urls": profile.shared_urls,
+            "research_deep_pages": profile.deep_pages,
+            "research_site_roots": profile.site_roots,
+        },
+    )
+
+
 async def advance_research(
     gateway: AgentGateway,
     *,
@@ -826,6 +953,12 @@ async def advance_research(
     issue #90: the synthesis run is never a grounded (``:online``) run, so its
     ``.annotations`` can never answer "did retrieval find anything"; the two
     research runs named in ``research_run_ids`` are the ones that retrieved.
+
+    Those same annotations are also measured and logged
+    (:func:`_log_evidence_profile`, issue #101) — how many distinct URLs the
+    chain retrieved, how many both angles were handed, and how many were bare
+    home pages. That is a report, not a gate: it never changes what this
+    function returns or raises.
     """
     del synthesis_model  # the engine chooses the synthesis run's model, not us
 
@@ -838,6 +971,7 @@ async def advance_research(
         if not synthesis_run.succeeded:
             raise RunNotSucceededError("The research-synthesis run did not complete successfully.")
         research_views = [await gateway.get_agent_run(run_id=rid) for rid in research_run_ids]
+        _log_evidence_profile(chain_id=chain_id, views=research_views)
         return extract_research_synthesis(
             synthesis_run.messages,
             annotations=_aggregate_research_annotations(research_views),

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -266,6 +266,53 @@ async def test_advance_research_reads_annotations_from_research_runs_not_synthes
 
 
 @pytest.mark.asyncio
+async def test_advance_research_logs_how_broad_the_retrieval_actually_was(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #101: the evidence base being thin and duplicated across the two
+    angles was invisible — nothing failed, and the numbers existed only in
+    provider annotations somebody had to go and read. Every research chain
+    now states its own breadth, and this asserts it is a *report*: the run
+    still succeeds, and the synthesis still comes back."""
+    logged: list[dict[str, Any]] = []
+
+    class _CapturingLogger:
+        def info(self, *args: Any, **kwargs: Any) -> None:
+            logged.append(kwargs.get("extra") or {})
+
+    monkeypatch.setattr(pipeline, "logger", _CapturingLogger())
+
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    shared = {"type": "url_citation", "url": "https://example.com/", "title": "Root"}
+    gateway.complete(run_ids[0], status="completed", annotations=[shared])
+    gateway.complete(
+        run_ids[1],
+        status="completed",
+        annotations=[shared, {"type": "url_citation", "url": "https://example.com/pricing"}],
+    )
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_findings_call("audience"),
+    )
+
+    result = await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    assert isinstance(result, pipeline.ResearchSynthesis)  # a report, not a gate
+    assert logged == [
+        {
+            "causation_id": chain_id,
+            "research_runs_measured": 2,
+            "research_distinct_urls": 2,
+            "research_shared_urls": 1,
+            "research_deep_pages": 1,
+            "research_site_roots": 1,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_advance_research_unions_annotations_when_only_one_research_angle_retrieved() -> None:
     """Decision (issue #90): a chain where one research angle retrieved and
     the other found nothing is not distinguished from "both retrieved" — the

--- a/tests/test_marketing_research_evidence.py
+++ b/tests/test_marketing_research_evidence.py
@@ -1,0 +1,291 @@
+"""What the two research angles actually search for, and how broad the pool
+they came back with was (issue #101).
+
+The defect these cover is not a wrong answer — every run was green. Both
+research agents were sent the byte-identical `input_payload`, and an
+`:online` run's retrieval is derived from its input, not from its
+instructions: the provider searches *before* the model is invoked, so every
+difference between the audience and competitive prompts was invisible to the
+search. Measured on campaign `ed7c5bc2`: 5 URLs each, **4 of them the same**,
+6 distinct across both agents, and **zero** of the six a page rather than a
+site root.
+
+Two things are asserted here, matching the two halves of the fix:
+
+1. The angles diverge in what gets *searched* — a property of
+   `research_search_query` and of what `start_research` puts on the wire,
+   both of which are checkable without a live model.
+2. The breadth of what came back is measured on every run
+   (`evidence_profile`), so nobody has to read provider annotations by hand
+   to notice a thin evidence base again.
+
+What these tests deliberately do NOT claim: that retrieval now returns deeper
+or more numerous pages. That is the provider's answer to a better query and
+only a live run can show it — see the PR body.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from marketing import pipeline
+from marketing.definitions import (
+    RESEARCH_AGENT_NAMES,
+    RESEARCH_AUDIENCE_AGENT_NAME,
+    RESEARCH_COMPETITIVE_AGENT_NAME,
+    RESEARCH_INSTRUCTIONS,
+    RESEARCH_SEARCH_FRAMING,
+    SEARCH_QUERY_BRIEF_CHARS,
+    research_search_query,
+)
+from marketing.pipeline import AgentRunView, evidence_profile
+
+
+class _RecordingGateway:
+    """Records the payload of every requested run — the only thing these
+    tests care about, since the payload IS what gets searched."""
+
+    def __init__(self) -> None:
+        self.payloads: dict[str, dict[str, Any]] = {}
+        self._next_id = 0
+
+    async def request_agent_run(
+        self,
+        *,
+        agent_name: str,
+        definition: dict[str, Any],
+        output_tool: dict[str, Any],
+        input_payload: dict[str, Any],
+        causation_id: str,
+    ) -> str:
+        del definition, output_tool, causation_id
+        self._next_id += 1
+        self.payloads[agent_name] = input_payload
+        return f"run-{self._next_id}"
+
+    async def find_chain_run(self, *, chain_id: str, agent_name: str) -> AgentRunView | None:
+        del chain_id, agent_name
+        return None
+
+    async def get_agent_run(self, *, run_id: str) -> AgentRunView | None:
+        del run_id
+        return None
+
+
+# ── The angle has to live in what gets searched ──────────────────────────────
+
+
+def test_every_research_agent_has_its_own_search_framing() -> None:
+    """The drift guard, matching `RESEARCH_INSTRUCTIONS`'s own coverage: an
+    agent in the fan-out with no framing would silently search the brief
+    alone, which is the state this issue reported."""
+    assert set(RESEARCH_SEARCH_FRAMING) == set(RESEARCH_AGENT_NAMES)
+    assert set(RESEARCH_INSTRUCTIONS) == set(RESEARCH_AGENT_NAMES)
+
+
+def test_the_two_angles_search_for_different_things() -> None:
+    brief = {"campaign_id": "c1", "brief": "Franchise management software for UK operators"}
+
+    audience = research_search_query(agent_name=RESEARCH_AUDIENCE_AGENT_NAME, brief=brief)
+    competitive = research_search_query(agent_name=RESEARCH_COMPETITIVE_AGENT_NAME, brief=brief)
+
+    assert audience != competitive
+    # Not merely different strings: different *corners of the web*. One asks
+    # for where people talk, the other for what vendors publish.
+    assert "forum" in audience and "review" in audience
+    assert "pricing" in competitive and "comparison" in competitive
+    assert "pricing" not in audience
+    assert "forum" not in competitive
+
+
+def test_both_angles_ask_for_pages_rather_than_home_pages() -> None:
+    """Zero of the six URLs the reported run retrieved carried a path. Naming
+    the page type is the only lever this repo has on that."""
+    for agent_name in RESEARCH_AGENT_NAMES:
+        query = research_search_query(agent_name=agent_name, brief={"brief": "anything"})
+        assert "home page" in query
+        assert "page" in query
+
+
+def test_the_search_query_leads_with_the_campaign_topic() -> None:
+    query = research_search_query(
+        agent_name=RESEARCH_AUDIENCE_AGENT_NAME,
+        brief={"campaign_id": "c1", "brief": "Franchise management software"},
+    )
+
+    assert query.startswith("Franchise management software —")
+
+
+def test_a_long_brief_is_truncated_on_a_word_boundary() -> None:
+    """The full brief still reaches the model; only the searched line is
+    bounded, so the angle framing is not appended to an essay."""
+    words = " ".join(["operators"] * 200)
+
+    query = research_search_query(agent_name=RESEARCH_AUDIENCE_AGENT_NAME, brief={"brief": words})
+
+    topic = query.split(" — ")[0]
+    assert len(topic) <= SEARCH_QUERY_BRIEF_CHARS
+    assert not topic.endswith("operat")  # no mid-word cut
+    assert topic.endswith("operators")
+
+
+def test_newlines_in_a_brief_do_not_reach_the_query() -> None:
+    query = research_search_query(
+        agent_name=RESEARCH_AUDIENCE_AGENT_NAME, brief={"brief": "one\n\n  two\tthree"}
+    )
+
+    assert query.startswith("one two three —")
+
+
+@pytest.mark.parametrize("brief", [None, {}, {"campaign_id": "c1"}, {"brief": ""}, {"brief": 7}])
+def test_a_brief_with_no_usable_text_still_yields_the_angle_framing(brief: Any) -> None:
+    """A campaign's brief is free text a human wrote. None of these shapes is
+    worth failing a research run over — the angle simply stands alone."""
+    query = research_search_query(agent_name=RESEARCH_COMPETITIVE_AGENT_NAME, brief=brief)
+
+    assert query == RESEARCH_SEARCH_FRAMING[RESEARCH_COMPETITIVE_AGENT_NAME]
+
+
+def test_an_unknown_research_agent_is_a_hard_error() -> None:
+    """Falling back to "search the brief alone" for an unrecognised agent
+    would reintroduce the identical-payload defect silently."""
+    with pytest.raises(KeyError):
+        research_search_query(agent_name="marketing-research-nonexistent", brief={})
+
+
+@pytest.mark.asyncio
+async def test_start_research_sends_each_agent_a_different_search_query() -> None:
+    """The regression test for the reported defect itself: the two runs used
+    to go out with identical payloads, so the provider ran the same search
+    twice."""
+    gateway = _RecordingGateway()
+
+    await pipeline.start_research(
+        gateway,  # type: ignore[arg-type]
+        brief={"campaign_id": "c1", "brief": "Franchise management software"},
+    )
+
+    queries = [payload["search_query"] for payload in gateway.payloads.values()]
+    assert len(queries) == len(RESEARCH_AGENT_NAMES)
+    assert len(set(queries)) == len(RESEARCH_AGENT_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_start_research_still_sends_the_whole_brief_to_every_agent() -> None:
+    """The query line is additive. The model still reads the full brief — the
+    truncation is only to the text retrieval derives a query from."""
+    brief = {"campaign_id": "c1", "brief": "A very long brief " * 50}
+    gateway = _RecordingGateway()
+
+    await pipeline.start_research(gateway, brief=brief)  # type: ignore[arg-type]
+
+    for agent_name in RESEARCH_AGENT_NAMES:
+        payload = gateway.payloads[agent_name]
+        assert payload["brief"] == brief
+        # First key: JSON key order is preserved, and the angle should lead
+        # the text a search query is derived from.
+        assert next(iter(payload)) == "search_query"
+
+
+# ── Measuring what came back ─────────────────────────────────────────────────
+
+
+def _run(*urls: str) -> AgentRunView:
+    return AgentRunView(
+        id="r",
+        status="completed",
+        annotations=[{"type": "url_citation", "url": u, "title": "t"} for u in urls],
+    )
+
+
+def test_evidence_profile_reports_the_reported_campaigns_shape() -> None:
+    """The numbers from issue #101, fed back in: 5 URLs each, 4 shared, 6
+    distinct, every one a site root. This is the state the measurement has to
+    be able to describe, or it cannot show an improvement on it either."""
+    audience = _run(
+        "https://gorilladash.com/",
+        "https://subsuite.co.uk/",
+        "https://www.franchise360.co.uk/",
+        "https://www.franchisebase.uk/",
+        "https://www.franchisesystems.ai/",
+    )
+    competitive = _run(
+        "https://gorilladash.com/",
+        "https://subsuite.co.uk/",
+        "https://www.franchise360.co.uk/",
+        "https://www.franchisebase.uk/",
+        "https://www.boundaryiq.co.uk/",
+    )
+
+    profile = evidence_profile([audience, competitive])
+
+    assert profile.runs_measured == 2
+    assert profile.distinct_urls == 6
+    assert profile.shared_urls == 4
+    assert profile.deep_pages == 0
+    assert profile.site_roots == 6
+
+
+def test_evidence_profile_counts_pages_with_a_path_or_query_as_deep() -> None:
+    profile = evidence_profile(
+        [
+            _run("https://example.com/", "https://example.com/pricing"),
+            _run("https://example.com/search?q=reviews"),
+        ]
+    )
+
+    assert profile.distinct_urls == 3
+    assert profile.deep_pages == 2
+    assert profile.site_roots == 1
+    assert profile.shared_urls == 0
+
+
+def test_evidence_profile_treats_the_same_page_written_two_ways_as_one() -> None:
+    """Same normalisation the provenance guard uses (`_url_key`) — a trailing
+    slash or a differently-cased host is the same document, and counting it
+    twice would report a broader pool than there is."""
+    profile = evidence_profile(
+        [_run("https://Example.com/Pricing"), _run("https://example.com/Pricing/")]
+    )
+
+    assert profile.distinct_urls == 1
+    assert profile.shared_urls == 1
+
+
+def test_evidence_profile_reads_the_nested_url_citation_shape_too() -> None:
+    view = AgentRunView(
+        id="r",
+        status="completed",
+        annotations=[{"type": "url_citation", "url_citation": {"url": "https://example.com/a"}}],
+    )
+
+    assert evidence_profile([view]).distinct_urls == 1
+
+
+def test_evidence_profile_ignores_runs_that_never_grounded() -> None:
+    """`annotations=None` is "not known", never "retrieved nothing" — the
+    same tri-state the citation guard keeps. A chain of unknowns must report
+    zero runs measured, not two runs that found nothing."""
+    profile = evidence_profile([None, AgentRunView(id="r", status="completed", annotations=None)])
+
+    assert profile.runs_measured == 0
+    assert profile.distinct_urls == 0
+
+
+def test_evidence_profile_of_a_genuinely_empty_retrieval() -> None:
+    profile = evidence_profile([AgentRunView(id="r", status="completed", annotations=[])])
+
+    assert profile.runs_measured == 1
+    assert profile.distinct_urls == 0
+
+
+def test_evidence_profile_skips_annotation_entries_with_no_url() -> None:
+    # `list[Any]`, not `list[dict]`: the point of the test is that a row Core
+    # handed back in an unexpected shape is skipped rather than crashing the
+    # measurement, and one of these entries is deliberately not a dict at all.
+    annotations: list[Any] = [{"type": "url_citation"}, "not-a-dict", {"url": ""}]
+    view = AgentRunView(id="r", status="completed", annotations=annotations)
+
+    assert evidence_profile([view]).distinct_urls == 0


### PR DESCRIPTION
Refs #101 — deliberately `Refs`, not `Closes`: the two halves of this change that matter most (what a search query retrieves, and whether the model cites the deeper page) are only observable in a live run against the real provider. A green suite cannot evidence them, so the issue stays open until someone runs research on a real campaign and reads the numbers (see **How to verify for real** below).

## What was actually wrong

Not the prompts, and not the model — the issue's own diagnosis, and it holds up in the code. `start_research` sent **both** research agents the byte-identical `input_payload`:

```python
input_payload={"brief": brief}     # identical for audience and competitive
```

An `:online` run's retrieval is derived from that payload: the provider searches *before* the model is invoked (this repo already established that in #82/#90 — the model has no search tool to call). So every difference between the audience and competitive instructions was invisible to the search. Two agents, one query, one pool: 5 URLs each, **4 shared**, 6 distinct, **0 with a path**, on campaign `ed7c5bc2`.

## What this changes, and which of the three levers each one is

**1. Differentiating what each agent searches for — done, structurally.** `definitions.research_search_query(agent_name=..., brief=...)` builds a per-angle query line, and `start_research` sends it as the **first** key of each run's payload (JSON key order is preserved, so the angle leads the text a query is derived from). `brief` is unchanged and still carries the whole brief for the model to read.

| Angle | What its search now asks for |
|---|---|
| `marketing-research-audience` | where people *talk* — forum threads, independent review-site pages, Q&A answers, community discussions, complaint threads |
| `marketing-research-competitive` | what vendors *publish* — pricing pages, plan/feature comparison pages, product and case-study pages, independent head-to-head comparisons |

Those pull from different corners of the web by construction, which is the point: the fan-out was paying for two runs and buying one pool.

**2. Getting deeper pages rather than homepages — attempted, honestly partial.** Two pushes, neither of which can force the provider's hand:
- Both query framings name **page types** rather than vendors, and both say "the specific page… not a vendor home page". A query for "pricing page" resolves to a pricing page far more often than one naming a market does.
- `_EVIDENCE_RULE` now tells the model to cite the page the evidence is on, to prefer the deeper URL when it was shown both, and to **never attach a specific figure to a bare site root** — state the finding without the precision that URL cannot support, or leave it out. That is aimed squarely at the reported "£24.99 Per Store / Per Month" cited to `https://subsuite.co.uk/`.

**3. Widening the result set — NOT done, and it cannot be done from this repo.** `:online` is a routing suffix that takes no parameters. OpenRouter's per-request `plugins: [{"id": "web", "max_results": N}]` form is the lever for pool size, and this plugin cannot reach it: the definition snapshot it sends Core carries `instructions`/`model`/`tools`/`max_turns`/`output_tools`, and nothing passes web-plugin options through. Widening that way needs a **Core** change. The other way to get more searches is more agent runs (one search per run) — a cost decision, and one that also requires re-seeding `scripts/seed_fan_in_workflow.py`'s `expect_agents`, so it is not a drive-by. Both are written down in `definitions.py` next to the framing table rather than left for the next person to rediscover.

**4. The measurement, so this cannot go unnoticed again.** Every number in issue #101 was gathered *by hand* off provider annotations, because nothing failed and the artefact an operator reads never showed how thin its evidence was. `pipeline.evidence_profile()` now computes distinct URLs / shared-across-angles / deep pages / site roots from the research runs' own annotations, and `advance_research` logs it on every chain (`causation_id` plus five structured fields).

It is a **report, not a gate**, on purpose: thin homepage-only retrieval is a property of what the provider returned, not of anything the model did wrong, so failing on it would strand a campaign on a condition that re-running cannot fix. That is also why the issue's fourth suggestion — a hard specificity guard — is not implemented as a hard guard here; the model-facing half of it is in `_EVIDENCE_RULE`, and the detection half is the log line. Happy to make it fatal in a follow-up once a live run shows deep pages are actually reachable.

## Cost

**Unchanged.** Same two agent runs, same one search each, same provider default result count. `:online` is billed per result and the number of results is exactly what this change does *not* touch — only what each search asks for. Prompt/payload growth is a few hundred tokens per research run, which is noise next to the retrieved page content already injected.

## Provenance guard (#113) — checked, not broken

`research` has no `allowed_source_urls` (the web is its source), and this change touches neither `flatten_citations` nor `citation_source_urls` nor the `research` artefact's `citations` column, so the closed set positioning is checked against is populated exactly as before. The one shape change is an extra key in the research run's *input*, which never reaches a citations column. `test_marketing_pipeline.py` (the provenance/`UncitedSourceError` suite) passes untouched, as does the whole orchestration suite.

## Tests

New: `tests/test_marketing_research_evidence.py` (24 tests) — the two angles search different things and neither's terms leak into the other; both ask for pages rather than home pages; the query leads with the campaign topic, truncates a long brief on a word boundary, collapses newlines, and degrades to bare angle framing for every unusable brief shape; an unknown agent is a hard `KeyError` rather than a silent fallback to searching the brief alone; `start_research` sends a *different* query per agent and still sends the whole brief to each; and `evidence_profile` reproduces issue #101's exact shape (6 distinct, 4 shared, 0 deep) from its real URLs, counts paths and queries as deep, normalises the same page written two ways, reads both `url_citation` shapes, and keeps the `annotations=None` / `[]` tri-state distinct.

Added to `tests/test_marketing_pipeline_orchestration.py`: `advance_research` logs the breadth **and still returns the synthesis** — proving it is a report and not a gate.

Fail-first proof: with `src/marketing/{definitions,pipeline}.py` stashed, the new module fails collection on `ImportError: cannot import name 'RESEARCH_SEARCH_FRAMING'`.

```
$ uv run pytest -q
548 passed, 4 warnings in 6.87s

$ uv run ruff check . && uv run ruff format --check src tests
All checks passed!
51 files already formatted

$ uv run pyright
0 errors, 0 warnings, 0 informations

$ pnpm -C web-admin test
 Test Files  17 passed (17)
      Tests  112 passed (112)
```

Pre-push `verify` gate: all 12 applicable checks OK.

## How to verify for real

Run research on a live campaign and read the run annotations the way the issue's author did:

1. Start research on a campaign with a real brief; wait for the `research` artefact to leave `pending`.
2. Read the two research runs' `annotations` and compare the URL sets — the numbers to beat are **6 distinct / 4 shared / 0 deep**. Or just read the new CloudWatch line: `research retrieval breadth: N distinct URLs across 2 grounded run(s) (S shared by more than one, D deep pages, R site roots)`.
3. Success looks like `shared` well below 4 and `deep_pages` above 0. If `deep_pages` is still 0 with divergent queries, that is the provider's ceiling rather than this repo's, and the next move is the Core-side `max_results`/web-plugin passthrough named above.
4. Check the synthesised findings: any finding quoting a price or percentage should now cite a URL with a path, or should have dropped the figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)