### PR TITLE
feat(web-admin): give every pack creative a download control

### DIFF
--- a/web-admin/src/components/CampaignDetail.tsx
+++ b/web-admin/src/components/CampaignDetail.tsx
@@ -84,10 +84,18 @@ export function CampaignDetail({
       <ImageGenerator campaignId={campaign.id} />
 
       <h3>Distribution pack</h3>
-      <DistributionPack campaignId={campaign.id} channelLookup={channelLookup} />
+      <DistributionPack
+        campaignId={campaign.id}
+        campaignName={campaign.name}
+        channelLookup={channelLookup}
+      />
 
       <h3>Paid brief pack</h3>
-      <PaidPack campaignId={campaign.id} channelLookup={channelLookup} />
+      <PaidPack
+        campaignId={campaign.id}
+        campaignName={campaign.name}
+        channelLookup={channelLookup}
+      />
 
       <h3>Results</h3>
       <Results campaignId={campaign.id} />

--- a/web-admin/src/components/DistributionPack.test.tsx
+++ b/web-admin/src/components/DistributionPack.test.tsx
@@ -82,7 +82,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/missing renders for: feed_1x1, story_9x16/i)).toBeInTheDocument()
@@ -110,7 +110,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/no public base url configured/i)).toBeInTheDocument()
@@ -135,7 +135,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/no copy artefact for this campaign yet/i)).toBeInTheDocument()
@@ -154,7 +154,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/^campaign not found\./i)).toBeInTheDocument()
@@ -175,7 +175,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/copy artefact must be approved before this can proceed/i)).toBeInTheDocument()
@@ -206,7 +206,7 @@ describe('DistributionPack', () => {
 
     // An empty taxonomy (not yet loaded any real entries) — a channel_key
     // with nothing to resolve against.
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     const badge = await screen.findByText(/unrecognised channel/i)
@@ -243,7 +243,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([], true)} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([], true)} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
 
     expect(await screen.findByText(/loading channel/i)).toBeInTheDocument()
@@ -284,7 +284,7 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([LINKEDIN])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([LINKEDIN])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
     await screen.findByText('Fast onboarding, done right')
 
@@ -348,10 +348,76 @@ describe('DistributionPack', () => {
       }),
     )
 
-    render(<DistributionPack campaignId={CAMPAIGN} channelLookup={makeLookup([NO_COMPOSER])} />)
+    render(<DistributionPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([NO_COMPOSER])} />)
     await user.click(screen.getByRole('button', { name: /load pack/i }))
     await screen.findByText('Trade press — earned coverage')
 
     expect(screen.queryByRole('link', { name: /publish on/i })).not.toBeInTheDocument()
+  })
+
+  // #117: the pack exists so an operator standing in a venue can get the
+  // creative out of it. Until this, the only affordance was long-pressing
+  // the `<img>` and hoping.
+  it('offers a download per creative asset, named for the campaign rather than the storage key', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          assets: [
+            {
+              id: 'as1',
+              campaign_id: CAMPAIGN,
+              media_kind: 'image',
+              placement: null,
+              media_id: 'm1',
+              is_source: true,
+              url: 'https://bucket.s3.amazonaws.com/plugins/marketing/9f1c.png?X-Amz-Signature=a',
+            },
+            {
+              id: 'as2',
+              campaign_id: CAMPAIGN,
+              media_kind: 'image',
+              placement: 'feed_1x1',
+              media_id: 'm2',
+              is_source: false,
+              url: 'https://bucket.s3.amazonaws.com/plugins/marketing/7b2d.png?X-Amz-Signature=b',
+            },
+          ],
+          missing_placements: [],
+          copy: [],
+          links: [],
+          guidance: '',
+        }),
+      }),
+    )
+
+    render(
+      <DistributionPack
+        campaignId={CAMPAIGN}
+        campaignName="Spring Launch"
+        channelLookup={makeLookup([LINKEDIN])}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /load pack/i }))
+
+    const source = await screen.findByRole('link', { name: /download source creative/i })
+    // Built from the URL the page already holds — a presign is minted per
+    // read and cannot be re-derived here (`pack_routes._asset_with_url`).
+    expect(source).toHaveAttribute(
+      'href',
+      'https://bucket.s3.amazonaws.com/plugins/marketing/9f1c.png?X-Amz-Signature=a',
+    )
+    expect(source).toHaveAttribute('download', 'spring-launch-source.png')
+
+    const placed = screen.getByRole('link', { name: /download feed_1x1 creative/i })
+    expect(placed).toHaveAttribute(
+      'href',
+      'https://bucket.s3.amazonaws.com/plugins/marketing/7b2d.png?X-Amz-Signature=b',
+    )
+    expect(placed).toHaveAttribute('download', 'spring-launch-feed-1x1.png')
   })
 })

--- a/web-admin/src/components/DistributionPack.tsx
+++ b/web-admin/src/components/DistributionPack.tsx
@@ -25,9 +25,15 @@ import { PublishLink } from './PublishLink'
  */
 export function DistributionPack({
   campaignId,
+  campaignName,
   channelLookup,
 }: {
   campaignId: string
+  /** Only used to name a downloaded creative (#117) — object storage knows
+   * the bytes as a uuid, so the pack has to supply the human name. Threaded
+   * from `CampaignDetail`, which already holds the campaign row, rather than
+   * refetched here. */
+  campaignName: string
   channelLookup: ChannelLookup
 }) {
   const [pack, setPack] = useState<Pack | null>(null)
@@ -60,7 +66,7 @@ export function DistributionPack({
         <div className="pack-body">
           <MissingPlacementsWarning missingPlacements={pack.missing_placements} />
 
-          <PackAssets assets={pack.assets} />
+          <PackAssets assets={pack.assets} campaignName={campaignName} />
 
           <h4>Copy</h4>
           {pack.copy.length === 0 && <p className="empty">No approved copy channels.</p>}

--- a/web-admin/src/components/DownloadButton.test.tsx
+++ b/web-admin/src/components/DownloadButton.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { DownloadButton } from './DownloadButton'
+
+const URL_ = 'https://bucket.s3.amazonaws.com/plugins/marketing/9f1c.png?X-Amz-Signature=abc'
+
+describe('DownloadButton', () => {
+  it('is a real link to the URL the page already holds, not a re-derived one', () => {
+    render(<DownloadButton url={URL_} filename="spring-launch-source.png" />)
+    expect(screen.getByRole('link', { name: 'Download' })).toHaveAttribute('href', URL_)
+  })
+
+  it('asks for a meaningful filename rather than the storage key', () => {
+    render(<DownloadButton url={URL_} filename="spring-launch-source.png" />)
+    expect(screen.getByRole('link', { name: 'Download' })).toHaveAttribute(
+      'download',
+      'spring-launch-source.png',
+    )
+  })
+
+  it('opens in a new context so an expired presign cannot replace the pack', () => {
+    render(<DownloadButton url={URL_} filename="spring-launch-source.png" />)
+    const link = screen.getByRole('link', { name: 'Download' })
+    expect(link).toHaveAttribute('target', '_blank')
+    // No Referer on a presigned URL, and no window.opener handle either.
+    expect(link).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('takes an accessible name, so a grid of them is distinguishable', () => {
+    render(
+      <DownloadButton
+        url={URL_}
+        filename="spring-launch-feed-1x1.png"
+        accessibleName="Download feed_1x1 creative"
+      />,
+    )
+    expect(screen.getByRole('link', { name: 'Download feed_1x1 creative' })).toBeInTheDocument()
+  })
+
+  it('is keyboard-focusable', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    render(<DownloadButton url={URL_} filename="spring-launch-source.png" />)
+    await user.tab()
+    expect(screen.getByRole('link', { name: 'Download' })).toHaveFocus()
+  })
+})

--- a/web-admin/src/components/DownloadButton.tsx
+++ b/web-admin/src/components/DownloadButton.tsx
@@ -1,0 +1,77 @@
+/** A save affordance for one creative asset (#117), sitting alongside
+ * `CopyButton` as the other half of "get the pack's contents out of the
+ * browser" — the distribution pack exists so an operator standing in a venue
+ * with a phone can publish from it, and until this the only way to save the
+ * image was to long-press it and hope.
+ *
+ * ## Why a plain `<a>` and not a fetch-to-blob
+ *
+ * The obvious implementation — `fetch(url)`, `URL.createObjectURL(blob)`,
+ * click a synthetic `<a download>` — is the one that cannot work here, and
+ * it fails invisibly in a way jsdom cannot see:
+ *
+ *   - The asset URL is a **presigned S3 URL**, minted per read by
+ *     `pack_routes._asset_with_url`. It is cross-origin to this app, so the
+ *     fetch is a CORS request.
+ *   - The bucket's CORS rule takes its origins from Terraform's
+ *     `plugin_media_cors_origins` (core: `modules/cloud/aws/storage/main.tf`),
+ *     which **defaults to `[]` and is not set in dev, staging or prod**. No
+ *     origin is permitted, so that fetch is refused by the browser.
+ *
+ * The other candidate — proxying the bytes through a plugin endpoint that
+ * sets its own `Content-Disposition` — is ruled out by this plugin's own
+ * history: `pack_routes.py`'s module docstring records that fetching a
+ * presigned URL server-side is exactly the `py/full-ssrf` sink CodeQL flags,
+ * that **four** different mitigation shapes failed to clear it, and that the
+ * fetch was deliberately removed. Reintroducing it to add a download button
+ * would trade a missing affordance for a blocked security gate.
+ *
+ * ## Why a plain `<a>` nevertheless saves the file
+ *
+ * Core already presigns every GET with
+ * `Content-Disposition: attachment; filename="<stored filename>"`
+ * (`plugin_storage.presign_download`). A response header outranks anything
+ * the markup asks for and needs no CORS at all, so following this link
+ * downloads rather than navigates.
+ *
+ * The `download` attribute is therefore **not** what makes the save happen —
+ * it is what makes the save *well named*. It is ignored on a cross-origin
+ * URL, in which case the file lands under Core's stored filename (a uuid);
+ * where the browser honours it, the operator gets
+ * `<campaign>-<placement>.png` (`lib/assetFilename.ts`). Degrading is the
+ * point: the file is saved either way.
+ *
+ * `target="_blank"` is not cosmetic. A presign is short-lived, and a pack
+ * sits on screen after loading — following an expired one in the same tab
+ * would replace the pack with S3's XML error document. `rel="noreferrer"`
+ * keeps the signed URL out of any Referer header and withholds the
+ * `window.opener` handle.
+ */
+export function DownloadButton({
+  url,
+  filename,
+  label = 'Download',
+  accessibleName,
+  className = '',
+}: {
+  url: string
+  filename: string
+  label?: string
+  /** Overrides the accessible name — a grid of assets otherwise renders
+   * several links all called "Download". */
+  accessibleName?: string
+  className?: string
+}) {
+  return (
+    <a
+      className={`download-btn secondary ${className}`.trim()}
+      href={url}
+      download={filename}
+      target="_blank"
+      rel="noreferrer"
+      aria-label={accessibleName}
+    >
+      {label}
+    </a>
+  )
+}

--- a/web-admin/src/components/PackParts.tsx
+++ b/web-admin/src/components/PackParts.tsx
@@ -1,4 +1,6 @@
 import type { PackAsset, PackLink } from '../lib/api'
+import { assetFilename } from '../lib/assetFilename'
+import { DownloadButton } from './DownloadButton'
 
 /** The organic pack (M5) and paid pack (M9) are the same shape with
  * paid-specific additions on top (`paid_pack_routes.py`'s own module
@@ -9,6 +11,11 @@ import type { PackAsset, PackLink } from '../lib/api'
  * failure path (see `useClipboard`) or to how a missing render is disclosed
  * now lands in one place for both packs, not one and possibly not the
  * other.
+ *
+ * #117's download affordance is why that matters concretely: the creative
+ * grid is one component, so both packs gained the ability to save an asset
+ * in the same change rather than the organic pack getting it and the paid
+ * pack silently keeping a bare `<img>`.
  */
 
 export function MissingPlacementsWarning({ missingPlacements }: { missingPlacements: string[] }) {
@@ -21,7 +28,30 @@ export function MissingPlacementsWarning({ missingPlacements }: { missingPlaceme
   )
 }
 
-export function PackAssets({ assets }: { assets: PackAsset[] }) {
+/** What one asset is, in the operator's words — the label under the
+ * thumbnail and the thing the download control names. `is_source` and
+ * `placement` are the only two things that distinguish assets in a pack
+ * (`pack_routes._existing_assets`). */
+function assetLabel(a: PackAsset): string {
+  if (a.is_source === true) return 'source'
+  return a.placement ?? 'creative'
+}
+
+/** The creative grid, with a save affordance per asset (#117).
+ *
+ * `campaignName` exists solely to name the downloaded file — object storage
+ * knows the bytes only as a uuid, so without it the operator's camera roll
+ * fills with indistinguishable `9f1c….png`s. See `lib/assetFilename.ts` for
+ * how the name is composed and `DownloadButton.tsx` for why this is a plain
+ * link rather than a fetch-to-blob.
+ */
+export function PackAssets({
+  assets,
+  campaignName,
+}: {
+  assets: PackAsset[]
+  campaignName: string
+}) {
   return (
     <>
       <h4>Creative</h4>
@@ -31,6 +61,11 @@ export function PackAssets({ assets }: { assets: PackAsset[] }) {
           <li key={a.id}>
             <img src={a.url} alt={a.placement ?? 'Source creative'} />
             <span>{a.is_source === true ? 'Source' : (a.placement ?? '—')}</span>
+            <DownloadButton
+              url={a.url}
+              filename={assetFilename(a, campaignName)}
+              accessibleName={`Download ${assetLabel(a)} creative`}
+            />
           </li>
         ))}
       </ul>

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -103,7 +103,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([FACEBOOK_PAID])} />)
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([FACEBOOK_PAID])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/missing renders for: feed_1x1/i)).toBeInTheDocument()
@@ -155,7 +155,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/no copy artefact for this campaign yet/i)).toBeInTheDocument()
@@ -174,7 +174,7 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/^campaign not found\./i)).toBeInTheDocument()
@@ -195,11 +195,70 @@ describe('PaidPack', () => {
       }),
     )
 
-    render(<PaidPack campaignId={CAMPAIGN} channelLookup={makeLookup([])} />)
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
     await user.click(screen.getByRole('button', { name: /load paid pack/i }))
 
     expect(await screen.findByText(/copy artefact must be approved before this can proceed/i)).toBeInTheDocument()
     expect(screen.queryByText(/^could not load the paid pack \(409\)$/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/"detail"/)).not.toBeInTheDocument()
+  })
+
+  // #117: the same `PackAssets` the organic pack renders, so the download
+  // affordance has to arrive in both packs at once, not one and possibly
+  // not the other (`PackParts.tsx`'s own module docstring).
+  it('offers the same download affordance the organic pack does', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          campaign_id: CAMPAIGN,
+          ad_copy: [],
+          assets: [
+            {
+              id: 'as1',
+              campaign_id: CAMPAIGN,
+              media_kind: 'image',
+              placement: 'story_9x16',
+              media_id: 'm1',
+              is_source: false,
+              url: 'https://bucket.s3.amazonaws.com/plugins/marketing/4c8a.png?X-Amz-Signature=c',
+            },
+          ],
+          missing_placements: [],
+          targeting: [],
+          budget: {
+            currency: 'USD',
+            channel_count: 0,
+            per_channel_daily: 0,
+            total_daily: 0,
+            test_window_days: 7,
+            total_test_budget: 0,
+            basis: 'A fixed starting-point heuristic.',
+          },
+          links: [],
+          guidance: '',
+          spend: { measurable: false, denominator: null, reason: 'Nothing exposes this yet.' },
+        }),
+      }),
+    )
+
+    render(
+      <PaidPack
+        campaignId={CAMPAIGN}
+        campaignName="Spring Launch"
+        channelLookup={makeLookup([])}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    const link = await screen.findByRole('link', { name: /download story_9x16 creative/i })
+    expect(link).toHaveAttribute(
+      'href',
+      'https://bucket.s3.amazonaws.com/plugins/marketing/4c8a.png?X-Amz-Signature=c',
+    )
+    expect(link).toHaveAttribute('download', 'spring-launch-story-9x16.png')
   })
 })

--- a/web-admin/src/components/PaidPack.tsx
+++ b/web-admin/src/components/PaidPack.tsx
@@ -28,9 +28,13 @@ import { PublishLink } from './PublishLink'
  */
 export function PaidPack({
   campaignId,
+  campaignName,
   channelLookup,
 }: {
   campaignId: string
+  /** Only used to name a downloaded creative (#117) — see
+   * `DistributionPack`'s own copy of this prop. */
+  campaignName: string
   channelLookup: ChannelLookup
 }) {
   const [pack, setPack] = useState<PaidPackData | null>(null)
@@ -169,7 +173,7 @@ export function PaidPack({
           <h4>Spend</h4>
           <p className="unmeasurable">Not measurable — {pack.spend.reason}</p>
 
-          <PackAssets assets={pack.assets} />
+          <PackAssets assets={pack.assets} campaignName={campaignName} />
 
           <PackLinks links={pack.links} copied={copied} onCopy={copy} />
 

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -867,6 +867,42 @@ details.mint-toggle[open] > .mint {
   margin-bottom: 0.25rem;
 }
 
+/* ── Download affordance on a creative asset (#117) ───────────────────────
+ *
+ * An `<a download>`, not a `<button>` — see `DownloadButton.tsx` for why the
+ * fetch-to-blob shape cannot work against a presigned URL here — so it needs
+ * its own rules: the `button.secondary` block above is element-scoped and an
+ * anchor picks up none of it, including the focus ring.
+ */
+
+.download-btn {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.download-btn:hover {
+  background: var(--neutral-bg);
+  border-color: var(--text-muted);
+}
+
+.download-btn:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--surface),
+    0 0 0 4px var(--focus-ring);
+}
+
 .stills .cost {
   margin: 0.15rem 0 0;
   color: var(--text-muted);

--- a/web-admin/src/lib/assetFilename.test.ts
+++ b/web-admin/src/lib/assetFilename.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PackAsset } from './api'
+import { assetFilename, slugify } from './assetFilename'
+
+function asset(overrides: Partial<PackAsset> = {}): PackAsset {
+  return {
+    id: 'as1',
+    campaign_id: 'c1',
+    media_kind: 'image',
+    placement: null,
+    media_id: 'm1',
+    is_source: true,
+    url: 'https://bucket.s3.amazonaws.com/plugins/marketing/9f1c.png?X-Amz-Signature=abc',
+    ...overrides,
+  }
+}
+
+describe('slugify', () => {
+  it('lowercases, strips punctuation and collapses separators', () => {
+    expect(slugify('Spring Launch — 2026!')).toBe('spring-launch-2026')
+  })
+
+  it('turns a placement key into readable path-safe words', () => {
+    expect(slugify('feed_1x1')).toBe('feed-1x1')
+  })
+
+  it('is empty for a value with nothing sluggable in it', () => {
+    expect(slugify('!!!')).toBe('')
+    expect(slugify('   ')).toBe('')
+  })
+
+  it('caps length, and never ends on a separator after the cap', () => {
+    const slug = slugify(`${'a'.repeat(58)} bbbbbbbbbb`)
+    expect(slug.length).toBeLessThanOrEqual(60)
+    expect(slug.endsWith('-')).toBe(false)
+  })
+})
+
+describe('assetFilename', () => {
+  it('names a placement render after the campaign and the placement', () => {
+    expect(assetFilename(asset({ placement: 'feed_1x1', is_source: false }), 'Spring Launch')).toBe(
+      'spring-launch-feed-1x1.png',
+    )
+  })
+
+  it('names the source creative "source" rather than a storage key', () => {
+    expect(assetFilename(asset(), 'Spring Launch')).toBe('spring-launch-source.png')
+    // The storage key (a uuid) must not leak into what the operator sees.
+    expect(assetFilename(asset(), 'Spring Launch')).not.toContain('9f1c')
+  })
+
+  it('keeps the real extension from the URL path, ignoring the presign query', () => {
+    const jpeg = asset({ url: 'https://bucket.s3.amazonaws.com/x/y.jpeg?X-Amz-Expires=900' })
+    expect(assetFilename(jpeg, 'Spring Launch')).toBe('spring-launch-source.jpeg')
+  })
+
+  it('falls back to .png when the URL carries no usable extension', () => {
+    const bare = asset({ url: 'https://bucket.s3.amazonaws.com/x/9f1c?X-Amz-Expires=900' })
+    expect(assetFilename(bare, 'Spring Launch')).toBe('spring-launch-source.png')
+  })
+
+  it('falls back to "campaign" when the campaign name slugs to nothing', () => {
+    expect(assetFilename(asset(), '   ')).toBe('campaign-source.png')
+  })
+
+  it('falls back to "creative" for an asset that is neither source nor placed', () => {
+    expect(assetFilename(asset({ is_source: null }), 'Spring Launch')).toBe(
+      'spring-launch-creative.png',
+    )
+  })
+})

--- a/web-admin/src/lib/assetFilename.ts
+++ b/web-admin/src/lib/assetFilename.ts
@@ -1,0 +1,81 @@
+import type { PackAsset } from './api'
+
+/** The filename a downloaded creative arrives under.
+ *
+ * The bytes are named by a uuid in object storage (`image_provider.py`:
+ * `filename=f"{uuid.uuid4()}.png"`), and Core presigns every GET with
+ * `Content-Disposition: attachment; filename="<that uuid>"`
+ * (`plugin_storage.presign_download`). An operator who saves three
+ * placements for two campaigns therefore ends up with six indistinguishable
+ * uuids in their camera roll. This composes the name a person can actually
+ * pick out of a list — `<campaign>-<placement>.<ext>` — for the `download`
+ * attribute to ask for instead.
+ *
+ * Pure, and deliberately separate from the component: the filename is the
+ * part of #117 a test can genuinely prove, so it should not need a DOM to
+ * exercise.
+ */
+
+/** Cap on the campaign portion of a filename. Long enough to stay
+ * recognisable, short enough that the whole name survives a mobile
+ * filesystem and a share sheet. */
+const MAX_SLUG = 60
+
+/**
+ * A lowercase, path-safe, hyphen-separated form of `value` — `''` if there
+ * is nothing sluggable in it, so a caller can fall back rather than emit a
+ * filename beginning with a stray separator.
+ *
+ * Accents are folded rather than dropped (`Café` → `cafe`, not `caf`), so a
+ * non-ASCII campaign name still produces something recognisable.
+ */
+export function slugify(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG)
+    .replace(/-+$/g, '')
+}
+
+/**
+ * The file extension implied by a presigned URL's *path*, ignoring its query.
+ *
+ * The query is where the whole SigV4 presign lives (`X-Amz-Signature`,
+ * `X-Amz-Expires`, …), so a naive "text after the last dot" reads the tail of
+ * a signature as an extension. Anything that is not a short alphanumeric run
+ * falls back to `png`, which is what this plugin's own generation path
+ * produces (`image_provider.py`).
+ */
+function extensionFrom(url: string): string {
+  try {
+    // A base is supplied so a relative or malformed URL still parses rather
+    // than throwing — the host is never read.
+    const { pathname } = new URL(url, 'https://asset.invalid')
+    const last = pathname.slice(pathname.lastIndexOf('/') + 1)
+    const dot = last.lastIndexOf('.')
+    if (dot > 0) {
+      const ext = last.slice(dot + 1).toLowerCase()
+      if (/^[a-z0-9]{2,4}$/.test(ext)) return ext
+    }
+  } catch {
+    // Fall through to the default — an unparseable URL is still downloadable.
+  }
+  return 'png'
+}
+
+/**
+ * `<campaign>-<placement|source>.<ext>` for one pack asset.
+ *
+ * `is_source` and `placement` are the only two things that distinguish one
+ * asset from another in a pack (`pack_routes._existing_assets` guarantees at
+ * most one source row survives), so they are what the name has to carry.
+ */
+export function assetFilename(asset: PackAsset, campaignName: string): string {
+  const campaign = slugify(campaignName) || 'campaign'
+  const placement = slugify(asset.placement ?? '')
+  const part = placement || (asset.is_source === true ? 'source' : 'creative')
+  return `${campaign}-${part}.${extensionFrom(asset.url)}`
+}


### PR DESCRIPTION
Refs #117

## What was wrong

`PackParts.tsx:32` rendered each creative as a bare `<img src={a.url}>`, and
`grep -rn "download" web-admin/src/` found no `<a download>` anywhere. The
distribution pack exists so an operator standing in a venue with a phone can
publish from it — and there was no way to get the image out of the browser
except a long-press.

Both packs render the same `PackAssets`, so the control lands in the organic
pack and the paid pack at once rather than one and possibly not the other.

## Which download mechanism, and why

The issue named two candidates and warned that the naive one fails silently
and device-specifically. Both candidates were checked against the actual
configuration rather than assumed, and **both turned out to be unavailable**:

**Fetch-to-blob is refused by the browser here.** The asset URL is a presigned
S3 URL minted per read (`src/marketing/pack_routes.py`, `_asset_with_url`), so
the fetch is cross-origin. The bucket's CORS rule takes its origins from
Terraform's `plugin_media_cors_origins`
(`biffo-platform: modules/cloud/aws/storage/main.tf:189-197`), which **defaults
to `[]` and is passed by none of the three environments** — `infra/environments/{dev,staging,prod}/main.tf`
all instantiate `module "storage"` with `project_name`/`environment`/`tags`
only. No origin is permitted, so a `fetch()` of the presign is blocked. This is
precisely the shape that passes in jsdom and fails on a real page.

**Proxying the bytes through a plugin endpoint would reopen a closed security
finding.** `pack_routes.py`'s own module docstring records that a server-side
fetch of a presigned URL is exactly the `py/full-ssrf` sink CodeQL flags, that
**four** different mitigation shapes left the finding unchanged (the taint
source is the `Depends()`-injected `core_client` itself), and that the fetch was
deliberately removed. Adding it back to serve a download button would trade a
missing affordance for a blocked gate.

**So: a plain `<a download>` on the URL the page already holds.** This works
because of something already true in Core that neither the issue nor the
original design accounted for: `plugin_storage.presign_download` already signs
every GET with `Content-Disposition: attachment; filename="<stored filename>"`.
A response header needs no CORS and outranks anything the markup asks for, so
following the link **saves rather than navigates**.

That reframes the `download` attribute's job. It is not what makes the save
happen — it is what makes the save *well named*. Cross-origin it is ignored, and
the file lands under Core's stored filename (a uuid); where a browser honours it,
the operator gets `spring-launch-feed-1x1.png`. It degrades rather than fails:
the file is saved either way.

`target="_blank"` is not cosmetic here. A presign is short-lived and a loaded
pack sits on screen indefinitely, so following an expired one in the same tab
would replace the pack with S3's XML error document. `rel="noreferrer"` keeps
the signed URL out of any `Referer` and withholds the `window.opener` handle.

## What changed

| File | Change |
| --- | --- |
| `web-admin/src/lib/assetFilename.ts` | New. Pure `<campaign>-<placement\|source>.<ext>`. Reads the extension from the URL **path**, never the presign query — otherwise the tail of an `X-Amz-Signature` reads as an extension. |
| `web-admin/src/components/DownloadButton.tsx` | New. Mirrors `CopyButton`'s shape (#105) rather than inventing a control. Carries the whole mechanism rationale above in its docstring, since the failure it avoids is invisible. |
| `web-admin/src/components/PackParts.tsx` | `PackAssets` renders one download per asset, with a distinct accessible name (`Download feed_1x1 creative`) so a grid of them is navigable. |
| `DistributionPack.tsx` / `PaidPack.tsx` / `CampaignDetail.tsx` | `campaignName` threaded from the campaign row `CampaignDetail` already holds — used solely to name the file. No refetch, and nothing re-presigned. |
| `web-admin/src/index.css` | `.download-btn`. The existing `button.secondary` rules are element-scoped, so an anchor inherits none of them, focus ring included. |

## Fail-first evidence

Tests written before the implementation, run against unchanged `PackParts.tsx`:

```
 ❯ src/components/PaidPack.test.tsx (5 tests | 1 failed)
 ❯ src/components/DistributionPack.test.tsx (10 tests | 1 failed)
 FAIL  src/components/DownloadButton.test.tsx  [ Failed to resolve import "./DownloadButton" ]
 FAIL  src/lib/assetFilename.test.ts           [ Failed to resolve import "./assetFilename" ]

 FAIL DistributionPack > offers a download per creative asset, named for the
      campaign rather than the storage key
      → Unable to find an accessible element with the role "link" and name
        /download source creative/i
 FAIL PaidPack > offers the same download affordance the organic pack does
      → Unable to find an accessible element with the role "link" and name
        /download story_9x16 creative/i

 Test Files  4 failed | 15 passed (19)
      Tests  2 failed | 112 passed (114)
```

After the implementation:

```
 Test Files  19 passed (19)
      Tests  129 passed (129)
```

Plus `pnpm typecheck`, `pnpm lint` and `pnpm build` clean, and the full
pre-push `verify` gate green (ruff, pyright, pytest, terraform-fmt, gitleaks,
web-admin lint/typecheck/test).

## Not verified

**No test here, and no CI job that exists, can tell you the file lands in the
camera roll.** What the 15 new tests prove is bounded and worth stating plainly:

- ✅ The control exists, once per asset, in **both** packs.
- ✅ Its `href` is the URL the page already holds — not re-derived, not re-presigned.
- ✅ Its `download` value is the intended filename, across placement / source /
  odd campaign names / missing extensions.
- ✅ It is a focusable link with a distinct accessible name.

- ❌ **Whether the file actually saves to Files/Photos on iOS Safari.** jsdom has
  no download manager. Not checked on a device.
- ❌ **Whether Android Chrome honours the `download` attribute on this
  cross-origin URL** (expected: it does not, so the file arrives under Core's
  uuid filename — the degraded path, still a saved file). Not checked on a device.
- ❌ **The iOS `<a download>`-on-video hazard M5 names specifically.** The pack
  renders every asset as an `<img>` today, so no video reaches this control;
  the hazard is untouched, neither triggered nor cleared.

#117 and #4 both carry a real-phone criterion. Those belong to a human with a
device, and should stay open until someone has done it and written down what
they saw. That is also why this PR says `Refs #117` rather than a closing
keyword: a green suite here is not the evidence the issue asks for.

## Follow-up worth filing

The cross-origin filename is decided at **upload** time, not download time:
`image_provider.py` uploads as `f"{uuid.uuid4()}.png"`, and that string is what
Core signs into `Content-Disposition`. Uploading with a meaningful filename
would make the degraded path well-named too, for every consumer, with no client
machinery. Out of scope here — it touches the generation path and only affects
newly generated assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
