### PR TITLE
fix(marketing): log retrieval breadth on the failure paths, and guard it

### DIFF
--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -906,8 +906,48 @@ def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | Non
     failing on it would strand a campaign on a condition re-running cannot
     fix — see this module's docstring on why the citation guards fail closed
     and this one does not.
+
+    "Without failing the run over it" is load-bearing on the failure paths
+    this is also called from (issue #101 follow-up): a report that raises
+    while reporting on a failure replaces a diagnosable error with a spurious
+    one, so every step here is wrapped. Nothing this function can do is worth
+    more than the exception the caller is already carrying.
     """
-    profile = evidence_profile(views)
+    try:
+        profile = evidence_profile(views)
+    except Exception:  # pragma: no cover - defensive; a report must not raise
+        logger.warning(
+            "research retrieval breadth: not measured — the profile could not be computed",
+            exc_info=True,
+            extra={"causation_id": chain_id},
+        )
+        return
+
+    if profile.runs_measured == 0:
+        # No view carried `annotations` at all. That is "we do not know what
+        # was retrieved", not "nothing was retrieved" — the same tri-state
+        # `evidence_profile` keeps, and worth keeping here because this is the
+        # branch the all-runs-failed path usually lands on. Emitting
+        # `0 distinct URLs across 0 grounded run(s)` would read as a measured,
+        # catastrophic zero and send an operator hunting a retrieval outage
+        # that never happened. The counts are `None`, not `0`, for the same
+        # reason: a filter on this field must not be able to average unknowns
+        # in as zeroes.
+        logger.info(
+            "research retrieval breadth: not measured — no research run reported "
+            "annotations (%d run view(s) seen)",
+            len(views),
+            extra={
+                "causation_id": chain_id,
+                "research_runs_measured": 0,
+                "research_distinct_urls": None,
+                "research_shared_urls": None,
+                "research_deep_pages": None,
+                "research_site_roots": None,
+            },
+        )
+        return
+
     logger.info(
         "research retrieval breadth: %d distinct URLs across %d grounded run(s) "
         "(%d shared by more than one, %d deep pages, %d site roots)",
@@ -925,6 +965,31 @@ def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | Non
             "research_site_roots": profile.site_roots,
         },
     )
+
+
+async def _log_evidence_profile_for(
+    gateway: AgentGateway, *, chain_id: str, research_run_ids: Collection[str]
+) -> None:
+    """Fetch the research run views purely to report breadth, and swallow
+    anything that goes wrong fetching them.
+
+    Only for the paths that are already raising. On the success path the views
+    are fetched anyway (the citation guard needs them) and a gateway error
+    there is a real error worth propagating; here the caller is about to raise
+    a `RunNotSucceededError` that describes the actual problem, and losing it
+    to a gateway hiccup while gathering a *log line* would be a strictly worse
+    outcome than having no log line.
+    """
+    try:
+        views = [await gateway.get_agent_run(run_id=rid) for rid in research_run_ids]
+    except Exception:  # pragma: no cover - defensive; a report must not raise
+        logger.warning(
+            "research retrieval breadth: not measured — the research run views could not be read",
+            exc_info=True,
+            extra={"causation_id": chain_id},
+        )
+        return
+    _log_evidence_profile(chain_id=chain_id, views=views)
 
 
 async def advance_research(
@@ -959,6 +1024,15 @@ async def advance_research(
     chain retrieved, how many both angles were handed, and how many were bare
     home pages. That is a report, not a gate: it never changes what this
     function returns or raises.
+
+    It is emitted on **every terminal path**, not just the successful one: the
+    synthesis run having failed, and every research run having failed, are the
+    two states in which an operator most needs it. "The research was thin" and
+    "the synthesis failed" produce the same dead artefact, and this line is the
+    only thing that separates them — so logging it only on success withheld it
+    exactly when it was being asked for. It is *not* emitted while the chain is
+    still in flight, because this function is polled and the line would then be
+    a stream of partial snapshots rather than one measurement per chain.
     """
     del synthesis_model  # the engine chooses the synthesis run's model, not us
 
@@ -969,6 +1043,9 @@ async def advance_research(
         if not synthesis_run.is_terminal:
             return None  # synthesis is running; nothing to do yet
         if not synthesis_run.succeeded:
+            await _log_evidence_profile_for(
+                gateway, chain_id=chain_id, research_run_ids=research_run_ids
+            )
             raise RunNotSucceededError("The research-synthesis run did not complete successfully.")
         research_views = [await gateway.get_agent_run(run_id=rid) for rid in research_run_ids]
         _log_evidence_profile(chain_id=chain_id, views=research_views)
@@ -988,6 +1065,11 @@ async def advance_research(
         # react to the completion event rather than racing it to a false
         # failure.
         return None
+    # Terminal, and none succeeded. The views are already in hand, so report
+    # breadth off them directly rather than re-fetching: a failed run can still
+    # have retrieved before it died, and "what did retrieval return?" is the
+    # whole question on this path.
+    _log_evidence_profile(chain_id=chain_id, views=views)
     raise RunNotSucceededError(
         "Every research agent failed to return usable findings. Nothing was found "
         "to synthesise — try running research again."

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -312,6 +312,183 @@ async def test_advance_research_logs_how_broad_the_retrieval_actually_was(
     ]
 
 
+# ── The breadth line reaches a real log record, on every terminal path ────────
+#
+# The tests below use `caplog` rather than a substituted `logger`, because the
+# thing being guarded is that an operator can *find this in CloudWatch*. A
+# monkeypatched logger proves `_log_evidence_profile` was called; it cannot
+# prove the powertools `Logger` actually emitted a record, at INFO, carrying
+# the structured keys somebody has been told to filter on. (The autouse
+# `_reenable_disabled_loggers` fixture in `conftest.py` is what makes `caplog`
+# see anything at all once this plugin is vendored — see commit 657de60.)
+
+
+BREADTH_PREFIX = "research retrieval breadth"
+
+
+def _breadth_records(caplog: pytest.LogCaptureFixture) -> list[Any]:
+    return [r for r in caplog.records if r.getMessage().startswith(BREADTH_PREFIX)]
+
+
+async def _chain_with_retrieval(gateway: _FakeGateway) -> tuple[str, list[str]]:
+    """Two research runs that both succeeded and both retrieved: one shared
+    site root, one deep page seen by a single angle."""
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    shared = {"type": "url_citation", "url": "https://example.com/", "title": "Root"}
+    gateway.complete(run_ids[0], status="completed", annotations=[shared])
+    gateway.complete(
+        run_ids[1],
+        status="completed",
+        annotations=[shared, {"type": "url_citation", "url": "https://example.com/pricing"}],
+    )
+    return chain_id, run_ids
+
+
+@pytest.mark.asyncio
+async def test_breadth_line_reaches_the_real_log_on_the_success_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gateway = _FakeGateway()
+    chain_id, run_ids = await _chain_with_retrieval(gateway)
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_findings_call("audience"),
+    )
+
+    with caplog.at_level("INFO"):
+        result = await pipeline.advance_research(
+            gateway, chain_id=chain_id, research_run_ids=run_ids
+        )
+
+    assert isinstance(result, pipeline.ResearchSynthesis)
+    (record,) = _breadth_records(caplog)  # exactly one, never doubled
+    assert "2 distinct URLs across 2 grounded run(s)" in record.getMessage()
+    assert record.causation_id == chain_id
+    assert record.research_runs_measured == 2
+    assert record.research_distinct_urls == 2
+    assert record.research_shared_urls == 1
+    assert record.research_deep_pages == 1
+    assert record.research_site_roots == 1
+
+
+@pytest.mark.asyncio
+async def test_breadth_line_is_logged_when_the_synthesis_run_failed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The failure path an operator most needs this on. "The research was
+    thin" and "the synthesis failed" produce the same dead artefact, and the
+    breadth line is the only thing that tells them apart — so logging it only
+    on success withholds it exactly when it is being asked for."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await _chain_with_retrieval(gateway)
+    gateway.fire_chain_run(
+        chain_id=chain_id, agent_name=RESEARCH_SYNTHESIS_AGENT_NAME, status="failed"
+    )
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    (record,) = _breadth_records(caplog)
+    assert "2 distinct URLs across 2 grounded run(s)" in record.getMessage()
+    assert record.causation_id == chain_id
+    assert record.research_distinct_urls == 2
+    assert record.research_site_roots == 1
+
+
+@pytest.mark.asyncio
+async def test_breadth_line_is_logged_when_every_research_run_failed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No synthesis run was ever fired, so the success path is never reached —
+    and this is the chain where "what did retrieval actually return?" is the
+    whole question. A failed run can still have retrieved before it died."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(
+        run_ids[0],
+        status="failed",
+        annotations=[{"type": "url_citation", "url": "https://example.com/pricing"}],
+    )
+    gateway.complete(run_ids[1], status="failed", annotations=[])
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    (record,) = _breadth_records(caplog)
+    assert "1 distinct URLs across 2 grounded run(s)" in record.getMessage()
+    assert record.causation_id == chain_id
+    assert record.research_runs_measured == 2
+    assert record.research_distinct_urls == 1
+
+
+@pytest.mark.asyncio
+async def test_breadth_line_says_unmeasured_rather_than_reporting_a_false_zero(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`annotations is None` means "we do not know what this run retrieved",
+    not "it retrieved nothing" — the tri-state `evidence_profile` is careful
+    to keep. Logging `0 distinct URLs across 0 grounded run(s)` here would
+    throw that distinction away at the only point a human reads it, and would
+    read as a measured, catastrophic zero."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    for run_id in run_ids:
+        gateway.complete(run_id, status="failed", annotations=None)
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    (record,) = _breadth_records(caplog)
+    message = record.getMessage()
+    assert "not measured" in message
+    assert "distinct URLs across" not in message  # not a measurement
+    assert record.causation_id == chain_id
+    assert record.research_runs_measured == 0
+    assert record.research_distinct_urls is None  # unknown, not zero
+
+
+@pytest.mark.asyncio
+async def test_breadth_logging_never_replaces_the_real_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A report that throws while reporting on a failure turns a diagnosable
+    error into a spurious one. Whatever the gateway does, the caller must
+    still see `RunNotSucceededError`."""
+
+    class _BrokenGateway(_FakeGateway):
+        async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView | None:
+            raise RuntimeError("run view unavailable")
+
+    gateway = _BrokenGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.fire_chain_run(
+        chain_id=chain_id, agent_name=RESEARCH_SYNTHESIS_AGENT_NAME, status="failed"
+    )
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+
+@pytest.mark.asyncio
+async def test_no_breadth_line_while_the_chain_is_still_in_flight(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`advance_research` is polled. Logging breadth on a non-terminal chain
+    would emit the line once per poll, so the number an operator finds in
+    CloudWatch would be whichever partial snapshot they scrolled to."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+
+    with caplog.at_level("INFO"):
+        assert (
+            await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+            is None
+        )
+
+    assert _breadth_records(caplog) == []
+
+
 @pytest.mark.asyncio
 async def test_advance_research_unions_annotations_when_only_one_research_angle_retrieved() -> None:
     """Decision (issue #90): a chain where one research angle retrieved and


### PR DESCRIPTION
Refs #101. Follow-up to #120 (`627f7e9`), from verifying that PR against `dev`. Deliberately narrow: no changes to the search-query or prompt work.

**Not `Closes`.** #101 keeps a live-run criterion — whether the now-divergent queries actually return divergent, deeper pages — which is the provider's answer to a better query and no code change can satisfy it.

## Gap 1 — the breadth line only fired on the success path

`_log_evidence_profile` had exactly one call site, inside `if synthesis_run is not None:` and *after* both the non-terminal `return None` and the not-succeeded `raise`. So a chain only reported its retrieval breadth if it reached a **successful synthesis run**. The two paths that logged nothing were the two an operator actually investigates:

- the synthesis run ran and failed
- every research run failed, so the engine never fired a synthesis

"The research was thin" and "the synthesis failed" produce the same dead artefact, and this log line is the only thing that separates them — so it was being withheld exactly when it was being asked for. Both paths now emit it, **once each**.

The polled, still-in-flight paths deliberately still do not log: `advance_research` is called repeatedly, so logging there would replace one measurement per chain with a stream of partial snapshots, and the number an operator found would be whichever one they scrolled to. Guarded by a test.

### Two things the failure paths need that the success path did not

**It must not raise.** A report that throws while reporting on a failure replaces a diagnosable error with a spurious one. `_log_evidence_profile` now wraps the profile computation, and the synthesis-failed path fetches its run views through a new `_log_evidence_profile_for`, which swallows a gateway error rather than losing the `RunNotSucceededError` that describes the real problem. The success path still fetches views directly and unguarded — a gateway error *there* is a real error worth propagating, and the citation guard needs those views anyway.

**No data must not read as a measured zero.** These paths often land on views whose `annotations` are `None`, which means "we do not know what this run retrieved", not "it retrieved nothing" — the tri-state `evidence_profile` is careful to keep. Logging `0 distinct URLs across 0 grounded run(s)` would throw that distinction away at the one point a human reads it, and would read as a measured, catastrophic zero. `runs_measured == 0` now logs a `not measured` variant, with the counts as `None` rather than `0` so a filter cannot average unknowns in as zeroes. A genuine measured zero (a run that succeeded with `annotations == []`) is unaffected and still reports as a measurement.

**The stable message and its `extra` keys are unchanged** — a human has been told to grep CloudWatch for `research retrieval breadth`, and both variants still start with that string.

## Gap 2 — nothing tested that the log happens at all

`grep -rn "retrieval breadth\|caplog" tests/` returned nothing. The one existing test substituted `pipeline.logger` with a capturing stub, which proves the helper was *called* but not that the powertools `Logger` actually emitted a record, at INFO, carrying the structured keys somebody has been told to filter on. Six `caplog` tests now cover:

- the success path (message + all six `extra` keys, exactly one record)
- the synthesis-failed path, with research runs that did retrieve — real numbers
- the every-research-run-failed path, including a failed run that retrieved before it died
- the unmeasured variant: `not measured` in the message, `research_distinct_urls is None`
- a gateway whose `get_agent_run` raises — the caller still sees `RunNotSucceededError`
- the still-in-flight path emitting no breadth record at all

They follow the existing logger handling rather than fighting it: the autouse `_reenable_disabled_loggers` fixture from `657de60` is what makes `caplog` see anything once this plugin is vendored, and these tests depend on it.

## Fail-first evidence

Against unmodified `src/`, with only the tests added:

```
FAILED tests/test_marketing_pipeline_orchestration.py::test_breadth_line_is_logged_when_the_synthesis_run_failed
FAILED tests/test_marketing_pipeline_orchestration.py::test_breadth_line_is_logged_when_every_research_run_failed
FAILED tests/test_marketing_pipeline_orchestration.py::test_breadth_line_says_unmeasured_rather_than_reporting_a_false_zero
3 failed, 3 passed, 31 deselected in 0.18s
```

Each failed as `ValueError: not enough values to unpack (expected 1, got 0)` unpacking `(record,) = _breadth_records(caplog)` — i.e. no breadth record was emitted at all. The three that passed are the ones asserting behaviour that was already correct (the success path logs; the in-flight path does not).

After the fix: `6 passed, 31 deselected`, and the full suite `554 passed`. Pre-push `verify` green across ruff, pyright, pytest, terraform-fmt, gitleaks and the web-admin gates.

## What this does NOT claim

Nothing here makes retrieval broader or deeper. It only makes what retrieval returned visible on the paths where somebody is looking for it. The live-run question in #101 is untouched, which is why this is `Refs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)