### PR TITLE
fix(agents): give every agent an explicit wall clock, not just the searching ones

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -789,33 +789,32 @@ POSITIONING_MAX_TURNS = 3
 CHANNEL_PLAN_MAX_TURNS = 3
 COPY_MAX_TURNS = 3
 
-#: The wall clock a research run may spend, in seconds (issue #126).
+#: The wall clock every agent in this plugin may spend, in seconds
+#: (issues #126, #130).
 #:
-#: **Why this has to be stated rather than inherited.** `agent_runtime.loop`'s
-#: `DEFAULT_TIMEOUT_SECONDS` is 120, and `RunLimits.from_snapshot` only reads a
-#: per-agent value if the definition supplies one. `research_definition` set
-#: `max_turns` and nothing else, so `RESEARCH_MAX_TURNS = 8` above described a
-#: budget the wall clock forbade: once #120 gave each angle its own search,
-#: every turn carried a real retrieval and the agent died on turn 3.
+#: **Every agent, not only the searching ones.** #126 raised this for research
+#: alone, on the observation that synthesis, positioning, channel plan and copy
+#: all finished inside the runtime's 120s default. That observation was true and
+#: the inference was wrong: synthesis finished quickly only because the audience
+#: angle had failed, so it had half the findings to reconcile. With both angles
+#: restored it produced 8,546 output tokens and died on the same hard stop
+#: (#130) — the failure simply moved one stage downstream.
 #:
-#: Measured, on the run that surfaced this: 225,298 input tokens, $0.63, and
-#: `"Turn 3 exceeded the run's remaining wall clock (120s total)"`. The same
-#: agent cost $0.0298 before #120. The pipeline then synthesised from one
-#: research angle instead of two — honestly disclosed to the operator, but
-#: half the evidence.
+#: The distinguishing factor is **total work**, not retrieval. Generating a
+#: large structured artefact is what exceeds the clock, and every agent here
+#: does exactly that. Raising them one at a time as each fails means richer
+#: research keeps pushing the failure to whichever stage is next; positioning,
+#: channel plan and copy all consume the research artefact and grow with it.
 #:
-#: **240s is the runtime ceiling, not an arbitrary bump.**
-#: `AGENT_RUNTIME_MAX_SECONDS` is 240 and the Lambda timeout is 300, so this
-#: takes the headroom that already exists without touching infrastructure;
-#: `from_snapshot` clamps to that ceiling anyway, so asking for more here would
-#: silently become 240 and read as a bigger budget than it is.
+#: **240s is the runtime ceiling, not a guess.** `AGENT_RUNTIME_MAX_SECONDS` is
+#: 240 and `RunLimits.from_snapshot` clamps to it, so asking for more would be
+#: silently reduced and this constant would claim a budget no run ever gets.
+#: Raising it further is an instance change — the ceiling and the Lambda
+#: timeout together — not a plugin one.
 #:
-#: **Cost is deliberately not the deciding factor.** Raising turns was called a
-#: cost decision above, and this is the same trade answered the other way: the
-#: cost of a campaign run on poor information dwarfs the tokens. If 240s proves
-#: tight, the next step is raising the runtime ceiling and the Lambda timeout
-#: together — an instance change, not a plugin one.
-RESEARCH_TIMEOUT_SECONDS = 240.0
+#: **Cost is deliberately not the deciding factor.** A campaign built on failed
+#: or half-completed research costs far more than the tokens.
+AGENT_TIMEOUT_SECONDS = 240.0
 
 
 def research_definition(*, model: str, instructions: str) -> dict[str, Any]:
@@ -832,11 +831,7 @@ def research_definition(*, model: str, instructions: str) -> dict[str, Any]:
         "model": model,
         "tools": [],
         "max_turns": RESEARCH_MAX_TURNS,
-        # Only the searching agents need this. Synthesis, positioning, channel
-        # plan and copy all completed well inside 120s on the run that killed
-        # this one, so they keep the default rather than being raised on
-        # principle — see RESEARCH_TIMEOUT_SECONDS.
-        "timeout_seconds": RESEARCH_TIMEOUT_SECONDS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
     }
 
 
@@ -848,6 +843,7 @@ def research_synthesis_definition(*, model: str, instructions: str) -> dict[str,
         "model": model,
         "tools": [],
         "max_turns": SYNTHESIS_MAX_TURNS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
     }
 
 
@@ -859,6 +855,7 @@ def positioning_definition(*, model: str, instructions: str) -> dict[str, Any]:
         "model": model,
         "tools": [],
         "max_turns": POSITIONING_MAX_TURNS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
     }
 
 
@@ -870,6 +867,7 @@ def channel_plan_definition(*, model: str, instructions: str) -> dict[str, Any]:
         "model": model,
         "tools": [],
         "max_turns": CHANNEL_PLAN_MAX_TURNS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
     }
 
 
@@ -882,6 +880,7 @@ def copy_definition(*, model: str, instructions: str) -> dict[str, Any]:
         "model": model,
         "tools": [],
         "max_turns": COPY_MAX_TURNS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
     }
 
 

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -21,11 +21,11 @@ the disagreement was invisible until it cost a research angle in production.
 from __future__ import annotations
 
 from marketing.definitions import (
+    AGENT_TIMEOUT_SECONDS,
     CHANNEL_PLAN_MAX_TURNS,
     COPY_MAX_TURNS,
     POSITIONING_MAX_TURNS,
     RESEARCH_MAX_TURNS,
-    RESEARCH_TIMEOUT_SECONDS,
     SYNTHESIS_MAX_TURNS,
     channel_plan_definition,
     copy_definition,
@@ -68,8 +68,8 @@ def test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime() -> None:
     budget the run never has. Raising this past the ceiling is an instance
     change (`AGENT_RUNTIME_MAX_SECONDS` and the Lambda timeout), not a plugin
     one."""
-    assert RESEARCH_TIMEOUT_SECONDS <= _RUNTIME_TIMEOUT_CEILING, (
-        f"{RESEARCH_TIMEOUT_SECONDS}s exceeds the runtime ceiling "
+    assert AGENT_TIMEOUT_SECONDS <= _RUNTIME_TIMEOUT_CEILING, (
+        f"{AGENT_TIMEOUT_SECONDS}s exceeds the runtime ceiling "
         f"({_RUNTIME_TIMEOUT_CEILING}s) and would be clamped silently"
     )
 
@@ -90,32 +90,45 @@ def test_researchs_turn_budget_is_reachable_within_its_wall_clock() -> None:
     cannot happen.
     """
     observed_seconds_per_searching_turn = 40.0
-    reachable_turns = RESEARCH_TIMEOUT_SECONDS / observed_seconds_per_searching_turn
+    reachable_turns = AGENT_TIMEOUT_SECONDS / observed_seconds_per_searching_turn
     assert reachable_turns > 3, (
-        f"{RESEARCH_TIMEOUT_SECONDS}s buys about {reachable_turns:.1f} searching "
+        f"{AGENT_TIMEOUT_SECONDS}s buys about {reachable_turns:.1f} searching "
         f"turns, but RESEARCH_MAX_TURNS is {RESEARCH_MAX_TURNS} — the turn "
         "budget describes a run the wall clock forbids, which is #126"
     )
 
 
-def test_the_non_searching_agents_deliberately_keep_the_default() -> None:
-    """Not an oversight, and worth pinning so nobody 'fixes' it later.
+def test_no_agent_inherits_the_runtime_default_wall_clock() -> None:
+    """The invariant #130 replaced, and the reason it had to be replaced.
 
-    Synthesis, positioning, channel plan and copy do not search — they reason
-    over what they are handed — and all four completed comfortably inside 120s
-    on the same run that killed research. Raising every agent's wall clock on
-    principle would hide the next agent that genuinely needs more.
+    #126 raised the wall clock for the searching agents only, and this test
+    previously asserted the opposite of what it now does: that the
+    non-searching agents deliberately kept the 120s default, because they had
+    all finished well inside it.
+
+    That was measured on a run where the audience research angle had FAILED, so
+    synthesis had half the findings to reconcile. With both angles restored it
+    produced 8,546 output tokens and died on the same hard stop. The old
+    assertion pinned a belief that a single degraded run had made look true.
+
+    The axis is total work, not retrieval — every agent here emits a large
+    structured artefact — so the correct invariant is that none of them relies
+    on a default chosen for smaller calls.
     """
     for factory in (
+        research_definition,
         research_synthesis_definition,
         positioning_definition,
         channel_plan_definition,
         copy_definition,
     ):
-        assert "timeout_seconds" not in _definition(factory), (
-            f"{factory.__name__} does not search; it should inherit the "
-            "runtime default rather than declare a wall clock"
+        definition = _definition(factory)
+        assert "timeout_seconds" in definition, (
+            f"{factory.__name__} must declare its own wall clock — the "
+            f"runtime's {_RUNTIME_DEFAULT_TIMEOUT:g}s default is set for "
+            "smaller calls than this plugin makes (#130)"
         )
+        assert definition["timeout_seconds"] > _RUNTIME_DEFAULT_TIMEOUT
 
 
 def test_every_definition_still_declares_a_turn_budget() -> None:


### PR DESCRIPTION
fix(agents): give every agent an explicit wall clock, not just the searching ones

#127 raised the wall clock for the searching agents and the failure moved
one stage downstream. `marketing-research-synthesis` now dies on the same
hard stop:

    Turn 3 exceeded the run's remaining wall clock (120s total, ADR-0014 §8)
    18,363 in / 8,546 out tokens, $0.305

Research itself is fixed — both angles completed this run (audience
$0.649, competitive $0.190), where audience had previously timed out.

## The reasoning in #127 was wrong

It asserted, and added a test pinning, that only the searching agents
needed a raised budget, because the others "all completed comfortably
inside 120s on the same run".

The observation was true; the inference was not. Synthesis finished
quickly on that run because the audience angle had FAILED, so it had half
the findings to reconcile. Restoring the second angle roughly doubled its
input and produced 8,546 output tokens — and generating that much
structured text is what exceeds the clock. Retrieval was never the
distinguishing factor; total work is.

Fixing synthesis alone would repeat the pattern a third time: positioning,
channel plan and copy all consume the research artefact, so better
research grows their inputs and outputs too.

So every agent in this plugin now declares 240s explicitly. None of them
resembles the small, quick call the runtime's 120s default was chosen for.

`test_the_non_searching_agents_deliberately_keep_the_default` asserted the
belief this issue disproves. It is REPLACED, not deleted, by
`test_no_agent_inherits_the_runtime_default_wall_clock`, whose docstring
records why the old assertion looked true — it was measured on a degraded
run. Verified fail-first.

240s remains the runtime ceiling (`AGENT_RUNTIME_MAX_SECONDS`), which
`from_snapshot` clamps to, so asking for more here would be silently
reduced. Going beyond it is an instance change — ceiling and Lambda
timeout together — not a plugin one.

Closes #130

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
