### PR TITLE
feat(web-admin): suggest previously-used destination URLs on new campaigns

### DIFF
--- a/web-admin/src/App.test.tsx
+++ b/web-admin/src/App.test.tsx
@@ -82,6 +82,94 @@ describe('creating a campaign', () => {
   })
 })
 
+describe('destination URL suggestions (#129)', () => {
+  // Distinct destination URLs from campaigns already on the page, offered
+  // through the field's own `list` attribute (a <datalist>) — the field
+  // stays free text (nothing here restricts what can be typed/submitted),
+  // it just now suggests what this tenant has used before rather than
+  // requiring every campaign to retype it from scratch.
+  it('offers previously-used destination URLs as suggestions, deduplicated', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (typeof url === 'string' && url.endsWith('/channels')) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { id: '1', name: 'Spring', status: 'draft', destination_url: 'https://x.test/a' },
+            { id: '2', name: 'Summer', status: 'draft', destination_url: 'https://x.test/b' },
+            { id: '3', name: 'Autumn', status: 'draft', destination_url: 'https://x.test/a' },
+          ],
+        })
+      }),
+    )
+    render(<App />)
+    await screen.findByText('Spring')
+
+    const input = screen.getByLabelText('Destination URL')
+    const listId = input.getAttribute('list')
+    expect(listId).not.toBeNull()
+
+    // A <datalist>'s <option>s are not exposed through any accessible-name
+    // query; reading them structurally is the only way to assert on them.
+    const datalist = document.getElementById(listId!)
+    expect(datalist).not.toBeNull()
+    const values = Array.from(datalist!.querySelectorAll('option')).map((o) => o.getAttribute('value'))
+    expect(values).toEqual(['https://x.test/a', 'https://x.test/b'])
+  })
+
+  it('offers nothing when no campaign has a destination URL yet', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => {
+        if (typeof url === 'string' && url.endsWith('/channels')) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: '1', name: 'Spring', status: 'draft', destination_url: null }],
+        })
+      }),
+    )
+    render(<App />)
+    await screen.findByText('Spring')
+
+    const input = screen.getByLabelText('Destination URL')
+    const listId = input.getAttribute('list')
+    const datalist = listId !== null ? document.getElementById(listId) : null
+    expect(datalist?.querySelectorAll('option').length ?? 0).toBe(0)
+  })
+
+  it('still accepts free text outside the suggestion list', async () => {
+    let campaigns: unknown[] = [
+      { id: '1', name: 'Spring', status: 'draft', destination_url: 'https://x.test/a' },
+    ]
+    const user = userEvent.setup()
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.endsWith('/channels')) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      if (typeof url === 'string' && url.endsWith('/campaigns') && init?.method === 'POST') {
+        campaigns = [...campaigns, { id: '2', name: 'New', status: 'draft', destination_url: 'https://x.test/new' }]
+        return Promise.resolve({ ok: true, json: async () => ({ id: '2' }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => campaigns })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+    await screen.findByText('Spring')
+
+    await user.type(screen.getByLabelText('Name'), 'New')
+    await user.type(screen.getByLabelText('Destination URL'), 'https://x.test/new')
+    await user.click(screen.getByRole('button', { name: /create campaign/i }))
+
+    expect(await screen.findByText('New')).toBeInTheDocument()
+  })
+})
+
 describe('opening a campaign studio', () => {
   it('switches to the campaign detail view, and back again', async () => {
     const fetchMock = vi.fn((url: string) => {

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { CampaignDetail } from './components/CampaignDetail'
 import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
+import { destinationSuggestions } from './lib/destinationSuggestions'
 import { useChannelTaxonomy } from './lib/useChannelTaxonomy'
 
 /** The campaign studio's admin surface.
@@ -72,6 +73,12 @@ export default function App() {
 
   const canSubmit = name.trim() !== '' && destination.trim() !== '' && !saving
 
+  // Distinct destination URLs this tenant has already used, most-used first
+  // (#129) — derived from `campaigns`, the same fetch the table below
+  // already renders from. See `destinationSuggestions`'s own doc for why
+  // this is frequency, not recency, and why it needs no new route.
+  const suggestions = destinationSuggestions(campaigns ?? [])
+
   return (
     <main>
       <h1>Campaign studio</h1>
@@ -93,7 +100,19 @@ export default function App() {
           value={destination}
           onChange={(e) => setDestination(e.target.value)}
           placeholder="https://dev.tabsii.com/intake/demo"
+          list="destination-suggestions"
         />
+        {/* A <datalist> keeps the field free text — nothing here restricts
+            what can be typed or submitted — while suggesting what this
+            tenant has already used, so a repeat endpoint is one pick rather
+            than a retyped URL a typo can silently corrupt (#129). Empty
+            when no campaign has a destination_url yet; an empty <datalist>
+            offers nothing, which is the correct empty state. */}
+        <datalist id="destination-suggestions">
+          {suggestions.map((url) => (
+            <option key={url} value={url} />
+          ))}
+        </datalist>
         <p className="hint">
           Where tracked links send people. Every minted link carries this URL with the
           campaign&rsquo;s own id as <code>utm_campaign</code>.

--- a/web-admin/src/lib/destinationSuggestions.test.ts
+++ b/web-admin/src/lib/destinationSuggestions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Campaign } from './api'
+import { destinationSuggestions } from './destinationSuggestions'
+
+function campaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: 'c1',
+    name: 'Campaign',
+    status: 'draft',
+    destination_url: null,
+    ...overrides,
+  }
+}
+
+describe('destinationSuggestions', () => {
+  it('is empty when no campaign has a destination_url', () => {
+    expect(destinationSuggestions([campaign({ destination_url: null })])).toEqual([])
+  })
+
+  it('lists a single used destination', () => {
+    const result = destinationSuggestions([campaign({ destination_url: 'https://x.test/a' })])
+    expect(result).toEqual(['https://x.test/a'])
+  })
+
+  it('deduplicates repeated destinations to one entry', () => {
+    const result = destinationSuggestions([
+      campaign({ id: '1', destination_url: 'https://x.test/a' }),
+      campaign({ id: '2', destination_url: 'https://x.test/a' }),
+    ])
+    expect(result).toEqual(['https://x.test/a'])
+  })
+
+  it('orders by how often a destination has been used, most-used first', () => {
+    const result = destinationSuggestions([
+      campaign({ id: '1', destination_url: 'https://x.test/once' }),
+      campaign({ id: '2', destination_url: 'https://x.test/twice' }),
+      campaign({ id: '3', destination_url: 'https://x.test/twice' }),
+      campaign({ id: '4', destination_url: 'https://x.test/thrice' }),
+      campaign({ id: '5', destination_url: 'https://x.test/thrice' }),
+      campaign({ id: '6', destination_url: 'https://x.test/thrice' }),
+    ])
+    expect(result).toEqual(['https://x.test/thrice', 'https://x.test/twice', 'https://x.test/once'])
+  })
+
+  it('keeps first-seen order between destinations used equally often', () => {
+    const result = destinationSuggestions([
+      campaign({ id: '1', destination_url: 'https://x.test/first' }),
+      campaign({ id: '2', destination_url: 'https://x.test/second' }),
+    ])
+    expect(result).toEqual(['https://x.test/first', 'https://x.test/second'])
+  })
+
+  it('ignores a null destination_url without breaking on the rest', () => {
+    const result = destinationSuggestions([
+      campaign({ id: '1', destination_url: null }),
+      campaign({ id: '2', destination_url: 'https://x.test/a' }),
+    ])
+    expect(result).toEqual(['https://x.test/a'])
+  })
+
+  it('ignores a blank/whitespace-only destination_url', () => {
+    const result = destinationSuggestions([
+      campaign({ id: '1', destination_url: '   ' }),
+      campaign({ id: '2', destination_url: 'https://x.test/a' }),
+    ])
+    expect(result).toEqual(['https://x.test/a'])
+  })
+
+  it('is empty for an empty campaigns array', () => {
+    expect(destinationSuggestions([])).toEqual([])
+  })
+})

--- a/web-admin/src/lib/destinationSuggestions.ts
+++ b/web-admin/src/lib/destinationSuggestions.ts
@@ -1,0 +1,30 @@
+import type { Campaign } from './api'
+
+/** Distinct destination URLs this tenant has already used, for the new-campaign
+ * form's suggestion list (#129).
+ *
+ * Derived entirely from `campaigns` — the same array `App.tsx` already fetches
+ * via `listCampaigns()` to render the table below the form. No new route:
+ * `marketing_campaign.destination_url` on the rows already on the page is the
+ * whole source, and a plugin route is a new surface to secure, test and
+ * version for data that is already in hand.
+ *
+ * Ordered by how often a URL appears, most-used first — NOT by recency.
+ * Recency would need a `created_at` per campaign, and `Campaign` (`api.ts`)
+ * carries none; more fundamentally, Core's generic list-route order "carries
+ * no `ORDER BY` and is not guaranteed stable" (`pack_routes.py`'s own
+ * `_link_sort_key` docstring, of the very `/campaigns` list this reads), so
+ * treating array position as recency would be reading a promise the API does
+ * not make. Frequency is real, and needs nothing from the API beyond what
+ * `listCampaigns` already returns. Ties keep first-seen order, so the result
+ * is stable across renders for a fixed `campaigns` array.
+ */
+export function destinationSuggestions(campaigns: Campaign[]): string[] {
+  const counts = new Map<string, number>()
+  for (const c of campaigns) {
+    const url = c.destination_url?.trim()
+    if (url === undefined || url === '') continue
+    counts.set(url, (counts.get(url) ?? 0) + 1)
+  }
+  return [...counts.keys()].sort((a, b) => counts.get(b)! - counts.get(a)!)
+}


### PR DESCRIPTION
## Summary

- The new-campaign form's **Destination URL** field was plain free text, so every campaign re-typed an endpoint this tenant had already used, repeatedly — a typo produces tracked links that lead somewhere wrong and looks fine until someone follows one.
- Adds a `<datalist>` of distinct, previously-used destination URLs to the field. It stays free text throughout (nothing restricts what can be typed or submitted) — the issue asked for *offer*, not *restrict*, and a new endpoint must not require anything configured first.
- **No new API route.** The distinct URLs are derived client-side from `campaigns`, the same array `App.tsx` already fetches via `listCampaigns()` to render the table below the form. `marketing_campaign.destination_url` on those rows is the whole source, so a new plugin route would have been a new surface to secure, test and version for data already on the page — the issue's own "Where the data already is" section confirms this reading.
- **Ordering: most-used first, not most-recent.** `Campaign` (`web-admin/src/lib/api.ts`) carries no `created_at`, and more fundamentally Core's generic list-route order — the very `/campaigns` list this reads — "carries no `ORDER BY` and is not guaranteed stable" (`pack_routes.py`'s own `_link_sort_key` docstring). Treating array position as a recency signal would be relying on a promise the API does not make. Frequency of use is a real signal derivable purely from the data already fetched, so that's what orders the list; ties keep first-seen order for a stable result across renders.

## Changed

- `web-admin/src/lib/destinationSuggestions.ts` (new) — pure function `destinationSuggestions(campaigns)`: distinct, non-blank `destination_url` values, most-used first.
- `web-admin/src/lib/destinationSuggestions.test.ts` (new) — 8 unit tests.
- `web-admin/src/App.tsx` — wires the suggestions into a `<datalist id="destination-suggestions">`, referenced from the Destination URL input via `list=`.
- `web-admin/src/App.test.tsx` — 3 new tests: suggestions are offered and deduplicated, an empty state when no campaign has a destination yet, and free text outside the suggestion list is still accepted and submitted.

## Fail-first evidence

Unit tests (`destinationSuggestions.ts` temporarily removed):
```
FAIL  src/lib/destinationSuggestions.test.ts [ src/lib/destinationSuggestions.test.ts ]
Error: Failed to resolve import "./destinationSuggestions" from "src/lib/destinationSuggestions.test.ts". Does the file exist?
```
Restored → 8 passed.

`App.tsx` integration test, run against the **unmodified** form (before adding `list=`/`<datalist>`):
```
× destination URL suggestions (#129) > offers previously-used destination URLs as suggestions, deduplicated
AssertionError: expected null not to be null
 ❯ src/App.test.tsx:113:24
    const listId = input.getAttribute('list')
    expect(listId).not.toBeNull()
```
After wiring the datalist into `App.tsx` → full suite green: **144/144 tests passed** (20 files), lint clean, typecheck clean, `pnpm run build` succeeds.

## Test plan

- [x] `pnpm run test` — 144/144 passed
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — succeeds
- [x] Local pre-push `verify` — all applicable checks green (ruff, pyright, pytest, gitleaks, lint/typecheck/test(web-admin), etc.)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)