### PR TITLE
test(marketing): derive the run-limits sweep, stop re-typing the runtime's constants

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -12,7 +12,9 @@ converted at every boundary for no gain.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import inspect
+import sys
+from collections.abc import Callable, Mapping
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -789,6 +791,31 @@ POSITIONING_MAX_TURNS = 3
 CHANNEL_PLAN_MAX_TURNS = 3
 COPY_MAX_TURNS = 3
 
+#: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_SECONDS` — the
+#: wall clock a run definition inherits when it declares no `timeout_seconds`
+#: of its own. `agent_runtime` is not a dependency of this plugin (checked
+#: `pyproject.toml`), so this cannot be imported — it is a manually-copied
+#: belief about another repo's constant, not an authority on it. If the real
+#: value ever moves, only `agent_runtime/loop.py` or a live run can prove it;
+#: nothing in this repo can (issue #132).
+RUNTIME_DEFAULT_TIMEOUT_SECONDS = 120.0
+
+#: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING` — the
+#: most any definition's `timeout_seconds` can ask for. Same caveat as
+#: `RUNTIME_DEFAULT_TIMEOUT_SECONDS` above: copied, not imported, not provable
+#: from here.
+#:
+#: **A factual correction, issue #132.** #126 and an earlier version of this
+#: comment both said `AGENT_RUNTIME_MAX_SECONDS` "is set to 240 on tabsii
+#: dev". That is false — grep the instance's `infra/` and there is no such
+#: variable anywhere. 240 is `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING`, the
+#: runtime's **code default**, not anything the instance configured. The
+#: number was right; the provenance claimed for it was not, and a confident
+#: wrong claim about where a limit comes from is worse than none — the next
+#: reader who goes looking for that env var to raise it will conclude the
+#: infrastructure is broken instead of finding out it was never set.
+RUNTIME_TIMEOUT_CEILING_SECONDS = 240.0
+
 #: The wall clock every agent in this plugin may spend, in seconds
 #: (issues #126, #130).
 #:
@@ -806,10 +833,16 @@ COPY_MAX_TURNS = 3
 #: research keeps pushing the failure to whichever stage is next; positioning,
 #: channel plan and copy all consume the research artefact and grow with it.
 #:
-#: **240s is the runtime ceiling, not a guess.** `AGENT_RUNTIME_MAX_SECONDS` is
-#: 240 and `RunLimits.from_snapshot` clamps to it, so asking for more would be
+#: **240s is the runtime ceiling, not a guess** — this deliberately equals
+#: `RUNTIME_TIMEOUT_CEILING_SECONDS` above rather than leaving headroom below
+#: it: every stage already needs the full 240s (that is what #130 measured),
+#: so trading budget away to guard against a hypothetical future ceiling cut
+#: would reintroduce the exact failure #126/#130 exist to fix, for a risk this
+#: repo cannot even observe (see `RUNTIME_TIMEOUT_CEILING_SECONDS`'s
+#: docstring, and issue #132's "what this cannot catch"). `from_snapshot`
+#: clamps silently to the real ceiling, so asking for more than it would be
 #: silently reduced and this constant would claim a budget no run ever gets.
-#: Raising it further is an instance change — the ceiling and the Lambda
+#: Raising it further is an instance change — the real ceiling and the Lambda
 #: timeout together — not a plugin one.
 #:
 #: **Cost is deliberately not the deciding factor.** A campaign built on failed
@@ -947,3 +980,84 @@ def copy_tool_schema() -> dict[str, Any]:
             "parameters": CopySet.model_json_schema(),
         },
     }
+
+
+# ── Definition-factory registry (issue #132 hole 1) ──────────────────────────
+#
+# ``tests/test_marketing_agent_run_limits.py`` used to enumerate the five
+# ``*_definition`` factories as a literal tuple. ``definitions.py`` had no
+# registry, so a sixth factory landing tomorrow would sit silently outside the
+# sweep, with the sweep still reporting green — the same "gate reports green
+# over a denominator it never printed" shape as biffo-template#1363, and the
+# same fix as this module's own ``RESEARCH_SEARCH_FRAMING``/
+# ``RESEARCH_AGENT_NAMES`` coverage assert far above (``definitions.py:694``),
+# which raises as a plain module-level expression rather than a function.
+#
+# **This is deliberately a function, not a module-level constant, and that is
+# not the same shape as the ``RESEARCH_SEARCH_FRAMING`` check.** A first draft
+# used a module-level tuple computed by inspecting ``vars(sys.modules[...])``
+# at the point it ran — which only sees names bound *before* that point in the
+# file executes. Placing that block right after ``copy_definition`` missed a
+# fail-first factory added below it, nearer the bottom of the file; moving the
+# block to the literal end of the file then missed a factory *appended after
+# it* — which is exactly where a contributor following the existing pattern of
+# "add the next stage's function near the others" would put one. There is no
+# placement of a module-level constant that is not order-dependent, because a
+# module-level statement can only see names already bound when it runs.
+#
+# A function sidesteps this rather than working around it: called from test
+# code, it runs strictly *after* this whole module has finished importing —
+# Python does not return control to an ``import`` statement until the entire
+# module body has executed — so ``vars(module)`` at call time is the complete,
+# final namespace regardless of where in this file the caller or any factory
+# physically sits.
+#
+# The membership rule — a public, module-level function whose name ends in
+# ``_definition`` — is deliberately precise, not merely convenient: grep this
+# file and nothing else matches that suffix, so this cannot accidentally
+# sweep in a helper. ``obj.__module__ == __name__`` additionally excludes
+# anything merely imported into this namespace.
+#
+# A naming convention alone can still drift silently the OTHER way — a
+# factory renamed to drop the suffix would vanish from the tuple with no
+# error, exactly the failure this exists to prevent — so the count is
+# asserted too. Bump ``_EXPECTED_DEFINITION_FACTORY_COUNT`` deliberately
+# whenever a factory is added, removed or renamed; that is a one-line, loud,
+# reviewable diff, not silent drift.
+_EXPECTED_DEFINITION_FACTORY_COUNT = 5
+
+
+def discover_definition_factories() -> tuple[Callable[..., dict[str, Any]], ...]:
+    """Every ``*_definition`` factory in this module, derived rather than
+    hand-listed. Call this — do not cache its result at import time — see
+    this section's comment for why a snapshot taken during import can miss a
+    factory that a purely order-dependent one silently would.
+
+    Raises ``RuntimeError`` if the derived count disagrees with
+    ``_EXPECTED_DEFINITION_FACTORY_COUNT``, so a factory added, removed or
+    renamed without updating that constant fails loudly rather than the
+    sweep quietly covering fewer (or differently-named) factories than it
+    did yesterday.
+    """
+    module = sys.modules[__name__]
+    factories = tuple(
+        sorted(
+            (
+                obj
+                for name, obj in vars(module).items()
+                if inspect.isfunction(obj)
+                and obj.__module__ == __name__
+                and name.endswith("_definition")
+            ),
+            key=lambda factory: factory.__name__,
+        )
+    )
+    if len(factories) != _EXPECTED_DEFINITION_FACTORY_COUNT:
+        raise RuntimeError(
+            "discover_definition_factories() drifted from the expected "
+            "count — a *_definition factory was added, removed or renamed "
+            "without updating _EXPECTED_DEFINITION_FACTORY_COUNT (found "
+            f"{[f.__name__ for f in factories]}, expected "
+            f"{_EXPECTED_DEFINITION_FACTORY_COUNT})"
+        )
+    return factories

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -800,20 +800,34 @@ COPY_MAX_TURNS = 3
 #: nothing in this repo can (issue #132).
 RUNTIME_DEFAULT_TIMEOUT_SECONDS = 120.0
 
-#: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING` — the
-#: most any definition's `timeout_seconds` can ask for. Same caveat as
-#: `RUNTIME_DEFAULT_TIMEOUT_SECONDS` above: copied, not imported, not provable
-#: from here.
+#: This repo's belief about the most any definition's `timeout_seconds` can
+#: ask for before `RunLimits.from_snapshot` clamps it.
 #:
-#: **A factual correction, issue #132.** #126 and an earlier version of this
-#: comment both said `AGENT_RUNTIME_MAX_SECONDS` "is set to 240 on tabsii
-#: dev". That is false — grep the instance's `infra/` and there is no such
-#: variable anywhere. 240 is `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING`, the
-#: runtime's **code default**, not anything the instance configured. The
-#: number was right; the provenance claimed for it was not, and a confident
-#: wrong claim about where a limit comes from is worse than none — the next
-#: reader who goes looking for that env var to raise it will conclude the
-#: infrastructure is broken instead of finding out it was never set.
+#: **This is genuinely set on tabsii dev, and it is per-deployment
+#: configuration, not a Python code default (issue #132).** Verified directly
+#: against the deployed Lambda:
+#:
+#:     $ aws lambda get-function-configuration \
+#:         --function-name tabsii-platform-dev-plugin-agent-runtime
+#:     "AGENT_RUNTIME_MAX_SECONDS": "240"
+#:
+#: It reaches the Lambda through template-owned Terraform, not through
+#: `agent_runtime`'s Python source: `services/_plugins/agent-runtime/
+#: terraform/main.tf:108` sets
+#: ``AGENT_RUNTIME_MAX_SECONDS = tostring(var.run_timeout_seconds)`` — a
+#: Terraform **variable** that happens to default to 240, the same number
+#: `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING` uses in code for when the env
+#: var is entirely absent.
+#:
+#: The distinction is not academic: **`run_timeout_seconds` is per-deployment
+#: configuration.** An instance can lower it with a Terraform change alone —
+#: no edit to `agent_runtime`'s Python anywhere — and `RunLimits.from_snapshot`
+#: would clamp every agent's real wall clock to the new value **silently**.
+#: This constant would then claim a 240s budget no run actually gets, and
+#: every test in this file would stay green throughout, because none of them
+#: can see the deployed Terraform variable from inside this repo. That is the
+#: live version of the risk this constant's docstring used to describe as
+#: hypothetical — it is not hypothetical, it is one `terraform apply` away.
 RUNTIME_TIMEOUT_CEILING_SECONDS = 240.0
 
 #: The wall clock every agent in this plugin may spend, in seconds
@@ -836,14 +850,15 @@ RUNTIME_TIMEOUT_CEILING_SECONDS = 240.0
 #: **240s is the runtime ceiling, not a guess** — this deliberately equals
 #: `RUNTIME_TIMEOUT_CEILING_SECONDS` above rather than leaving headroom below
 #: it: every stage already needs the full 240s (that is what #130 measured),
-#: so trading budget away to guard against a hypothetical future ceiling cut
-#: would reintroduce the exact failure #126/#130 exist to fix, for a risk this
-#: repo cannot even observe (see `RUNTIME_TIMEOUT_CEILING_SECONDS`'s
-#: docstring, and issue #132's "what this cannot catch"). `from_snapshot`
-#: clamps silently to the real ceiling, so asking for more than it would be
-#: silently reduced and this constant would claim a budget no run ever gets.
-#: Raising it further is an instance change — the real ceiling and the Lambda
-#: timeout together — not a plugin one.
+#: so trading budget away to guard against a ceiling cut would reintroduce the
+#: exact failure #126/#130 exist to fix. `from_snapshot` clamps silently to
+#: whatever `AGENT_RUNTIME_MAX_SECONDS` actually is, so asking for more would
+#: be silently reduced and this constant would claim a budget no run ever
+#: gets. Raising it further is an instance change (raising
+#: `run_timeout_seconds` in Terraform, and the Lambda timeout with it) — not a
+#: plugin one, and likewise **lowering** the ceiling is an instance change
+#: this file cannot see: see `RUNTIME_TIMEOUT_CEILING_SECONDS`'s docstring for
+#: why that is a real, live risk rather than a hypothetical one.
 #:
 #: **Cost is deliberately not the deciding factor.** A campaign built on failed
 #: or half-completed research costs far more than the tokens.

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -26,25 +26,37 @@ from marketing.definitions import (
     COPY_MAX_TURNS,
     POSITIONING_MAX_TURNS,
     RESEARCH_MAX_TURNS,
+    RUNTIME_DEFAULT_TIMEOUT_SECONDS,
+    RUNTIME_TIMEOUT_CEILING_SECONDS,
     SYNTHESIS_MAX_TURNS,
     channel_plan_definition,
     copy_definition,
+    discover_definition_factories,
     positioning_definition,
     research_definition,
     research_synthesis_definition,
 )
 
-#: `agent_runtime.loop.DEFAULT_TIMEOUT_SECONDS`. Duplicated deliberately rather
-#: than imported: the runtime is a separate deployable this plugin does not
-#: depend on, and the number that matters here is the one the plugin will
-#: actually inherit if it stays silent.
-_RUNTIME_DEFAULT_TIMEOUT = 120.0
+#: Derived here, in this test module, rather than imported as a
+#: pre-computed constant from `definitions.py` — deliberately: see
+#: `discover_definition_factories`'s docstring for why a snapshot taken
+#: DURING that module's own import can silently miss a factory depending on
+#: where in the file it is added. By the time the `from marketing.definitions
+#: import ...` above returns, that whole module has finished executing, so
+#: calling the discovery function here sees its complete, final namespace
+#: regardless of factory placement.
+DEFINITION_FACTORIES = discover_definition_factories()
 
-#: `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING`, and the value
-#: `AGENT_RUNTIME_MAX_SECONDS` is set to on tabsii dev. `from_snapshot` clamps
-#: to this, so a definition asking for more is silently reduced — which would
-#: read in the source as a bigger budget than the run actually gets.
-_RUNTIME_TIMEOUT_CEILING = 240.0
+#: `RUNTIME_DEFAULT_TIMEOUT_SECONDS`/`RUNTIME_TIMEOUT_CEILING_SECONDS` (issue
+#: #132 hole 2) used to be re-typed here as this file's OWN literals
+#: (`_RUNTIME_DEFAULT_TIMEOUT = 120.0`, `_RUNTIME_TIMEOUT_CEILING = 240.0`),
+#: independently of `definitions.py`'s copy of the same belief — two places
+#: that were free to drift from EACH OTHER even though both live in this repo
+#: and neither can see the real upstream value. Importing collapses that to
+#: one place; it does not (and cannot, from this repo — see their docstrings)
+#: make either number provably correct against `agent_runtime` itself.
+_RUNTIME_DEFAULT_TIMEOUT = RUNTIME_DEFAULT_TIMEOUT_SECONDS
+_RUNTIME_TIMEOUT_CEILING = RUNTIME_TIMEOUT_CEILING_SECONDS
 
 
 def _definition(factory):
@@ -66,8 +78,19 @@ def test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime() -> None:
     """Asking for more than the ceiling is worse than asking for the ceiling:
     `from_snapshot` reduces it without complaint, so the source would claim a
     budget the run never has. Raising this past the ceiling is an instance
-    change (`AGENT_RUNTIME_MAX_SECONDS` and the Lambda timeout), not a plugin
-    one."""
+    change (setting `AGENT_RUNTIME_MAX_SECONDS` for the first time, or
+    changing the runtime's own default upstream), not a plugin one.
+
+    **What this assertion cannot catch (issue #132 hole 2).** Both sides here
+    are this repo's OWN copies of numbers that live in `agent_runtime`, which
+    is not a dependency of this plugin and so cannot be imported. If the real
+    ceiling is ever lowered, `_RUNTIME_TIMEOUT_CEILING` does not move with
+    it — nothing tells this test the number it is comparing against is stale
+    — so this proves internal self-consistency between two beliefs held in
+    this repo, never agreement with `agent_runtime` itself. That gap needs an
+    upstream contract test that can read both sides (biffo-template#1364) or
+    a loud clamp in `from_snapshot`; neither is buildable from here.
+    """
     assert AGENT_TIMEOUT_SECONDS <= _RUNTIME_TIMEOUT_CEILING, (
         f"{AGENT_TIMEOUT_SECONDS}s exceeds the runtime ceiling "
         f"({_RUNTIME_TIMEOUT_CEILING}s) and would be clamped silently"
@@ -114,14 +137,17 @@ def test_no_agent_inherits_the_runtime_default_wall_clock() -> None:
     The axis is total work, not retrieval — every agent here emits a large
     structured artefact — so the correct invariant is that none of them relies
     on a default chosen for smaller calls.
+
+    Sweeps `DEFINITION_FACTORIES` rather than a hand-listed tuple (issue #132
+    hole 1): that tuple is derived from `definitions.py` itself via
+    `discover_definition_factories()`, which raises if the count disagrees
+    with what it expects — see that function's docstring for why the
+    discovery is a function called here rather than a constant computed
+    inside `definitions.py`. Either way, a sixth factory added tomorrow is
+    swept here automatically rather than needing this test remembered and
+    updated.
     """
-    for factory in (
-        research_definition,
-        research_synthesis_definition,
-        positioning_definition,
-        channel_plan_definition,
-        copy_definition,
-    ):
+    for factory in DEFINITION_FACTORIES:
         definition = _definition(factory)
         assert "timeout_seconds" in definition, (
             f"{factory.__name__} must declare its own wall clock — the "
@@ -133,7 +159,15 @@ def test_no_agent_inherits_the_runtime_default_wall_clock() -> None:
 
 def test_every_definition_still_declares_a_turn_budget() -> None:
     """Guards the other half: `from_snapshot` defaults `max_turns` to 1, so a
-    definition that stopped declaring one would quietly become single-turn."""
+    definition that stopped declaring one would quietly become single-turn.
+
+    The exact turns-per-stage mapping below cannot itself be derived — there
+    is no naming convention tying e.g. `research_synthesis_definition` to
+    `SYNTHESIS_MAX_TURNS` — but the same coverage-assert shape as
+    `definitions.py:694` still applies to what CAN be checked mechanically:
+    that this hand-written mapping has not quietly fallen out of step with
+    `DEFINITION_FACTORIES` itself (issue #132 hole 1, same shape as the sweep
+    above)."""
     expected = {
         research_definition: RESEARCH_MAX_TURNS,
         research_synthesis_definition: SYNTHESIS_MAX_TURNS,
@@ -141,5 +175,11 @@ def test_every_definition_still_declares_a_turn_budget() -> None:
         channel_plan_definition: CHANNEL_PLAN_MAX_TURNS,
         copy_definition: COPY_MAX_TURNS,
     }
+    assert set(expected) == set(DEFINITION_FACTORIES), (
+        "expected must cover exactly DEFINITION_FACTORIES — a *_definition "
+        f"factory was added, removed or renamed without updating this "
+        f"mapping (expected covers {sorted(f.__name__ for f in expected)}, "
+        f"DEFINITION_FACTORIES has {sorted(f.__name__ for f in DEFINITION_FACTORIES)})"
+    )
     for factory, turns in expected.items():
         assert _definition(factory)["max_turns"] == turns

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -52,9 +52,11 @@ DEFINITION_FACTORIES = discover_definition_factories()
 #: (`_RUNTIME_DEFAULT_TIMEOUT = 120.0`, `_RUNTIME_TIMEOUT_CEILING = 240.0`),
 #: independently of `definitions.py`'s copy of the same belief — two places
 #: that were free to drift from EACH OTHER even though both live in this repo
-#: and neither can see the real upstream value. Importing collapses that to
-#: one place; it does not (and cannot, from this repo — see their docstrings)
-#: make either number provably correct against `agent_runtime` itself.
+#: and neither can see what is actually deployed (the ceiling in particular
+#: is a Terraform variable, `run_timeout_seconds`, not a Python constant —
+#: see `RUNTIME_TIMEOUT_CEILING_SECONDS`'s docstring). Importing collapses
+#: that to one place; it does not (and cannot, from this repo) make either
+#: number provably correct against the deployed value.
 _RUNTIME_DEFAULT_TIMEOUT = RUNTIME_DEFAULT_TIMEOUT_SECONDS
 _RUNTIME_TIMEOUT_CEILING = RUNTIME_TIMEOUT_CEILING_SECONDS
 
@@ -77,19 +79,25 @@ def test_research_declares_its_own_wall_clock_rather_than_inheriting() -> None:
 def test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime() -> None:
     """Asking for more than the ceiling is worse than asking for the ceiling:
     `from_snapshot` reduces it without complaint, so the source would claim a
-    budget the run never has. Raising this past the ceiling is an instance
-    change (setting `AGENT_RUNTIME_MAX_SECONDS` for the first time, or
-    changing the runtime's own default upstream), not a plugin one.
+    budget the run never has. `AGENT_RUNTIME_MAX_SECONDS` IS set on tabsii dev
+    (verified against the deployed Lambda — see `RUNTIME_TIMEOUT_CEILING_
+    SECONDS`'s docstring in `definitions.py`), via template-owned Terraform's
+    `run_timeout_seconds` variable, not a Python default. Raising this past
+    the ceiling is therefore an instance change — raising that Terraform
+    variable, and the Lambda timeout with it — not a plugin one.
 
     **What this assertion cannot catch (issue #132 hole 2).** Both sides here
-    are this repo's OWN copies of numbers that live in `agent_runtime`, which
-    is not a dependency of this plugin and so cannot be imported. If the real
-    ceiling is ever lowered, `_RUNTIME_TIMEOUT_CEILING` does not move with
-    it — nothing tells this test the number it is comparing against is stale
-    — so this proves internal self-consistency between two beliefs held in
-    this repo, never agreement with `agent_runtime` itself. That gap needs an
-    upstream contract test that can read both sides (biffo-template#1364) or
-    a loud clamp in `from_snapshot`; neither is buildable from here.
+    are this repo's OWN copies of numbers that are actually configured in a
+    DIFFERENT repo's Terraform, which is not a dependency of this plugin and
+    so cannot be imported or read from here. `run_timeout_seconds` is
+    per-deployment configuration: an instance CAN lower it with a Terraform
+    change alone, no code edit anywhere, and `_RUNTIME_TIMEOUT_CEILING` would
+    not move with it — nothing tells this test the number it is comparing
+    against has gone stale. So this proves internal self-consistency between
+    two beliefs held in this repo, never agreement with the deployed
+    Terraform variable. That gap needs an upstream contract test that can
+    read both sides (biffo-template#1364) or a loud clamp in `from_snapshot`
+    (today it clamps silently); neither is buildable from here.
     """
     assert AGENT_TIMEOUT_SECONDS <= _RUNTIME_TIMEOUT_CEILING, (
         f"{AGENT_TIMEOUT_SECONDS}s exceeds the runtime ceiling "


### PR DESCRIPTION
Closes #132

## What this closes

Issue #132 named two holes left in the guard that closed #126/#130 (the
research-agent turn-budget/wall-clock disagreement class):

**Hole 1 — the sweep's denominator was hand-maintained.** The five
`*_definition` factories were enumerated as a literal tuple in
`tests/test_marketing_agent_run_limits.py`, so a sixth factory added tomorrow
would sit silently outside the sweep, still reporting green.

Fixed by adding `discover_definition_factories()` to `definitions.py`: it
derives the set of `*_definition` factories from the module's own namespace
(public, module-level functions whose name ends `_definition` — precise
enough that nothing else in the file matches), and raises if the derived
count disagrees with `_EXPECTED_DEFINITION_FACTORY_COUNT`, so a rename that
drops a factory out of the naming convention fails loudly rather than
silently shrinking the sweep. The test imports and calls it instead of
hand-listing.

**A real bug found along the way, not just theorised.** My first draft
computed this as a plain module-level constant inside `definitions.py`,
mirroring the existing `RESEARCH_SEARCH_FRAMING`/`RESEARCH_AGENT_NAMES`
coverage assert at `definitions.py:694`. A fail-first check — appending a
sixth `*_definition` factory below that constant in the file — proved it
invisible to the sweep, silently. Moving the constant to the literal end of
the file just moved the blind spot: a factory appended *after* it (the
natural place to add one, following the file's existing pattern) was still
invisible. There is no placement of a module-level constant that isn't
order-dependent, because it can only see names already bound when it
executes. The fix is to make it a **function**, called from test code after
`definitions.py` has fully imported — by then Python has executed the whole
module body regardless of where anything sits in the file. Proven fail-first
in the worst position (appended after everything, including the discovery
code itself): the suite now fails loudly with the missing factory named in
the error, and second-order (count bumped honestly but the new factory
forgets `timeout_seconds`) the wall-clock sweep still catches it.

**Hole 2 — the ceiling was a hand-copied value with no headroom.**
`AGENT_TIMEOUT_SECONDS = 240.0` sits exactly at the runtime's timeout
ceiling, which `RunLimits.from_snapshot` clamps to *silently*. `agent_runtime`
is genuinely not a dependency of this plugin (checked `pyproject.toml`), so
the real value cannot be imported — only copied and believed.

What I did:
- Collapsed the two independently-hardcoded literals in the test file
  (`_RUNTIME_DEFAULT_TIMEOUT = 120.0`, `_RUNTIME_TIMEOUT_CEILING = 240.0`)
  into named constants defined once in `definitions.py`
  (`RUNTIME_DEFAULT_TIMEOUT_SECONDS`, `RUNTIME_TIMEOUT_CEILING_SECONDS`),
  each with a docstring naming exactly where the real value lives. There
  used to be two independent copies of "the ceiling is 240" *within this
  repo alone*, free to drift from each other even though neither can see
  what is actually deployed — now there is one.
- **Deliberately did NOT add headroom below the ceiling.** I considered
  lowering `AGENT_TIMEOUT_SECONDS` a few seconds below
  `RUNTIME_TIMEOUT_CEILING_SECONDS` so a small reduction couldn't silently
  bite. I concluded that's a bad trade: #130 measured that every stage
  already needs the full 240s, so buying "headroom" against a ceiling cut
  means reintroducing, on purpose, the exact hard-stop failure #126/#130
  exist to fix — for a risk this repo cannot detect from in here regardless
  (see below). Kept `AGENT_TIMEOUT_SECONDS == RUNTIME_TIMEOUT_CEILING_SECONDS`
  and said so in the comment. The coordinator confirmed this reasoning holds
  independently of the correction below.

## A correction to this PR's own first commit

The first commit here claimed `AGENT_RUNTIME_MAX_SECONDS` "is not set
anywhere on tabsii dev" and that 240 is only `agent_runtime.loop.
DEFAULT_TIMEOUT_CEILING`'s Python code default — based on grepping
tabsii-platform's `infra/`, which is real but not the whole picture. The
coordinator caught this by checking the deployed Lambda directly:

```
$ aws lambda get-function-configuration --function-name tabsii-platform-dev-plugin-agent-runtime
  "AGENT_RUNTIME_MAX_SECONDS": "240"
```

It **is** set — via template-owned Terraform,
`services/_plugins/agent-runtime/terraform/main.tf:108`
(`AGENT_RUNTIME_MAX_SECONDS = tostring(var.run_timeout_seconds)`), a
Terraform **variable** that defaults to 240. A second commit on this branch
fixes the docstrings in `definitions.py` and the test file to say this
correctly, and — this is the part that actually mattered — corrects the
risk assessment that followed from the wrong premise: because
`run_timeout_seconds` is per-deployment configuration, an instance CAN
lower it with a Terraform-only change and no code edit anywhere, and
`from_snapshot` would clamp every agent's real budget below what this
constant claims, silently. That is a live risk, one `terraform apply` away,
not the hypothetical my first commit implied. `AGENT_TIMEOUT_SECONDS` is
unaffected — still 240.0, still no headroom, for the reasons above.

I have not touched issue #126 itself; the coordinator is correcting that
separately since the error there is theirs to fix, not mine to relitigate
in this repo.

## What this still cannot catch, from inside this repo

Both `RUNTIME_DEFAULT_TIMEOUT_SECONDS` and `RUNTIME_TIMEOUT_CEILING_SECONDS`
are this repo's **beliefs** about values that live in a different repo's
Terraform and Python — not an import of them. `agent_runtime` is not a
dependency here and cannot become one without this plugin depending on a
separate deployable. So:

- `test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime` proves
  `AGENT_TIMEOUT_SECONDS <= RUNTIME_TIMEOUT_CEILING_SECONDS` — i.e. internal
  self-consistency between two numbers held in this repo. It does **not**
  prove agreement with whatever `run_timeout_seconds` actually is on a given
  deployment. If an instance lowers it, nothing here moves with it and
  nothing here notices — every plugin test stays green while
  `from_snapshot` clamps every agent's real budget below what this file
  claims.
- This is stated explicitly in both docstrings I touched, not left implicit.

**I believe this needs an upstream change**, not a plugin-side workaround:
either a contract test that can read both a plugin's declared budget and the
runtime's actual configured ceiling, or `RunLimits.from_snapshot` **logging
when it clamps** rather than doing so silently — which would at least make
a silent Terraform-level reduction observable from the logs, even without a
cross-repo test. Both are out of scope for this repo; the contract test is
already tracked (biffo-template#1364). I have not built either here — this
PR narrows the window (one place for the belief instead of two, an accurate
comment, a sweep that can't silently shrink) and says plainly what it
doesn't guarantee.

## Verification

- `uv run pytest` — 576 passed.
- `sh scripts/biffo.sh verify` — all applicable checks green (ruff, pyright,
  pytest, terraform-fmt, plugin checks, gitleaks, web-admin lint/typecheck/
  test — `pnpm install` run in `web-admin/` first per AGENTS.md). Re-run
  after the correction commit; still green.
- Fail-first, twice: (1) a sixth `*_definition` factory with no
  `timeout_seconds`, appended at the literal end of the file, made the test
  suite fail to even collect (`RuntimeError` from the count assertion) —
  confirmed this is not a placement-dependent false negative by trying it in
  three positions during development. (2) with the count bumped honestly to
  admit the sixth factory, `test_no_agent_inherits_the_runtime_default_wall_
  clock` failed on exactly the missing `timeout_seconds`, naming the factory.
  Both reverted before the final commit.

## Not verified

I have not re-run the marketing pipeline live against tabsii dev. This PR is
a test/guard change only — no production code path (`pipeline.py`, the
agent-run definitions' actual values) changed behaviour; `AGENT_TIMEOUT_SECONDS`
stays at 240.0. #132 itself was found by grooming, not a live failure, so
there is no live symptom to re-check here.
