### PR TITLE
test(ci): enumerate CI-uncovered project directories (issue #115 item 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ dev = [
   "pytest>=8.3.4",
   "pytest-asyncio>=0.25.2",
   "pytest-cov>=6.0.0",
+  # Dev/test-only — used solely by
+  # tests/test_marketing_ci_coverage_sweep.py to parse .github/workflows/*.yml
+  # structurally (#115), rather than grepping raw workflow text, which would
+  # match a directory name sitting in a comment and prove nothing. Never
+  # imported by src/marketing, so it does not ship in the Lambda bundle.
+  "pyyaml>=6.0",
   "ruff>=0.8.0",
   "pyright>=1.1.0",
   "jsonschema>=4.23.0",

--- a/tests/test_marketing_ci_coverage_sweep.py
+++ b/tests/test_marketing_ci_coverage_sweep.py
@@ -1,0 +1,389 @@
+"""The meta-check issue #115 (item 1) calls for: for every directory in this
+repo containing a `package.json`/`pyproject.toml`, assert some CI job in
+`.github/workflows/` actually references it.
+
+## Why this exists
+
+`class:fail-open` (#115) names three instances found in this repo within two
+days, in three different mechanisms, none caught by the others. #97 is the one
+this check targets directly: `web-admin/` carried 94 tests, a typecheck and a
+lint config, and **no CI job at all** ran any of them — nothing in `ci.yml`
+walked outside the repo root, so a PR could break every one of them and merge
+green. Nobody found it by the gate going red; someone found it by reading
+`ci.yml` and noticing what it didn't do.
+
+The shape is general, not specific to `web-admin/`: a project directory and a
+CI job are two independently-maintained things, and nothing forced them to
+agree. #97 was instance one; this is the check that makes instance four
+impossible instead of merely instance-one-fixed. Same enumeration shape as
+`biffo-template`'s `cli/src/lib/guard-wiring-sweep.test.ts` (discover from the
+filesystem, never a hand-maintained list — a manifest is one more thing to
+forget to update, which is exactly how #97 happened: nothing was lying, ci.yml
+just never grew a `web-admin` job when the directory was born).
+
+## Parse, don't grep (#956's class, applied here)
+
+`ci.yml` carries **extensive prose comments** naming `web-admin/` — the
+`admin-frontend` job's own header explains, in English, why it exists and what
+#97 was. A raw `grep -r web-admin .github/workflows/` is satisfied by those
+comments alone, whether or not any job's steps actually touch the directory —
+proving nothing, the same shape `test_marketing_core_paths_guard.py`'s module
+docstring warns about for a text-based check in this repo. This module uses
+`yaml.safe_load` instead: YAML comments are discarded during parsing, so only
+a directory token appearing in a real field (a job's `working-directory`, a
+step's `run:` script, or a `with:` value such as `cache-dependency-path`)
+counts as a reference.
+
+## Denominator
+
+`discover_project_dirs()` walks the repo from the filesystem and prints what
+it found — the failure mode this whole class is about is a gate that is green
+over a set it never enumerated, so the set itself has to be visible, not just
+the verdict. As of this writing that denominator is exactly two: the repo
+root (`.`, `pyproject.toml`) and `web-admin` (`package.json`) — small, but the
+point is that it is asserted rather than assumed, so a third project directory
+added later cannot join the estate unrefereed the way `web-admin` once did.
+
+## Exclusions
+
+Pruned directory names are listed explicitly below, each with why — not a
+glob that could later swallow a real project directory without anyone
+noticing (that is `#115`'s own warning: the exclusion list is where instance
+four hides). Every excluded name already appears in this repo's own
+`.gitignore`, plus `.git` and `.worktrees` (also gitignored) — nothing here
+invents a new exclusion the repo doesn't already treat as non-content.
+
+## Negative control
+
+A check that can only pass proves nothing (the same reasoning
+`guard-wiring-sweep.test.ts` states directly). `test_flags_a_synthetic_unreferenced_directory`
+below builds a throwaway directory tree with its own `package.json` and an
+empty `.github/workflows/`, and asserts the reference check returns `False` —
+proving this can fail, not just that it happens not to today. Before writing
+this file, the real check was also fail-first-verified by hand: temporarily
+deleting the `admin-frontend` job's `working-directory`/`cache-dependency-path`
+lines from a scratch copy of `ci.yml` and confirming
+`test_every_project_directory_is_referenced_by_some_ci_job` goes red on
+`web-admin`, then reverting. See this repo's PR for #115 for that transcript.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+#: Filenames that mark a directory as a "project" for this sweep's purposes.
+_PROJECT_MARKERS = ("package.json", "pyproject.toml")
+
+#: Directory NAMES pruned wherever they occur, each because it can never
+#: legitimately be a project root of ours — every one of these is already
+#: declared content-free by this repo's own `.gitignore` (or, for `.git`,
+#: is never content at all). Explicit and commented, on purpose: a broad
+#: pattern (e.g. "anything starting with a dot", "anything called build*")
+#: is exactly how a real project directory added later could get silently
+#: swallowed and never discovered by this check again (#115's own warning).
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        "node_modules",  # vendored JS deps (.gitignore) — third-party, never ours
+        "dist",  # build output (.gitignore) — generated, never hand-authored
+        ".venv",  # this repo's own Python virtualenv (.gitignore)
+        ".pytest_cache",  # pytest's cache (.gitignore)
+        "__pycache__",  # compiled Python bytecode cache (.gitignore)
+        ".ruff_cache",  # ruff's cache (.gitignore)
+        ".worktrees",  # nested git-worktree checkouts of this repo (.gitignore) —
+        # each one carries its own copy of every marker file, which
+        # would be re-discovered relative to the wrong root entirely
+        ".git",  # git internals — never content, not something .gitignore need say
+    }
+)
+
+
+def discover_project_dirs(root: Path = _REPO_ROOT) -> list[str]:
+    """Every directory under `root` containing a `package.json` or
+    `pyproject.toml`, as POSIX-style paths relative to `root` ("." for the
+    root itself), sorted. Walked from the filesystem, never a hand-maintained
+    list — see this module's docstring for why that matters."""
+    found: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune BEFORE descending, so an excluded directory's contents are
+        # never even visited (a node_modules/some-pkg/package.json must not
+        # surface here).
+        dirnames[:] = sorted(d for d in dirnames if d not in _EXCLUDED_DIR_NAMES)
+        if any(marker in filenames for marker in _PROJECT_MARKERS):
+            rel = Path(dirpath).relative_to(root)
+            found.append("." if rel == Path(".") else rel.as_posix())
+    return sorted(found)
+
+
+def _load_workflow_jobs(
+    workflows_dir: Path = _WORKFLOWS_DIR,
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """Every `(workflow filename, job name, job dict)` triple across every
+    `.github/workflows/*.yml` — real YAML parsing (`yaml.safe_load`), so a
+    directory name that appears only in a comment is invisible here, exactly
+    as it should be (this module's docstring explains why that distinction
+    matters for this repo's `ci.yml` specifically)."""
+    triples: list[tuple[str, str, dict[str, Any]]] = []
+    if not workflows_dir.is_dir():
+        return triples
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text())
+        if not isinstance(doc, dict):
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if isinstance(job, dict):
+                triples.append((path.name, str(job_name), job))
+    return triples
+
+
+def _step_texts(step: Any) -> list[str]:
+    """String values worth searching on one step: its `run:` script and every
+    string value under `with:` (this is where `cache-dependency-path:
+    web-admin/pnpm-lock.yaml` lives). Deliberately NOT `name:` — a step's
+    display name is free-text prose, the same category of thing as a YAML
+    comment, and treating it as a reference would reopen the grep trap this
+    module's docstring describes, just one field over."""
+    if not isinstance(step, dict):
+        return []
+    texts: list[str] = []
+    run = step.get("run")
+    if isinstance(run, str):
+        texts.append(run)
+    with_block = step.get("with")
+    if isinstance(with_block, dict):
+        texts.extend(v for v in with_block.values() if isinstance(v, str))
+    return texts
+
+
+def _job_working_directories(job: dict[str, Any]) -> set[str]:
+    """Every explicit working-directory this job sets — job-level `defaults`
+    plus any per-step override — with trailing slashes normalised."""
+    dirs: set[str] = set()
+    default_wd = job.get("defaults", {})
+    if isinstance(default_wd, dict):
+        default_run = default_wd.get("run", {})
+        if isinstance(default_run, dict):
+            wd = default_run.get("working-directory")
+            if isinstance(wd, str):
+                dirs.add(wd.rstrip("/"))
+    for step in job.get("steps", []) or []:
+        if isinstance(step, dict):
+            wd = step.get("working-directory")
+            if isinstance(wd, str):
+                dirs.add(wd.rstrip("/"))
+    return dirs
+
+
+def is_directory_referenced(dir_rel: str, jobs: list[tuple[str, str, dict[str, Any]]]) -> bool:
+    """Does some job in `jobs` reference `dir_rel` (a path relative to the
+    repo root, or "." for the root itself)?
+
+    Two independent ways a job can reference a NESTED directory (`dir_rel !=
+    "."`):
+
+      1. It sets `working-directory` (job-level `defaults` or a step) equal
+         to `dir_rel` exactly — `admin-frontend`'s
+         `defaults.run.working-directory: web-admin`.
+      2. `dir_rel` appears as a whole path segment in a step's `run:` text or
+         a `with:` value — `cache-dependency-path: web-admin/pnpm-lock.yaml` —
+         matched with word/path boundaries so `web-admin` cannot false-match
+         inside `web-admin-old` or similar.
+
+    The repo ROOT (`dir_rel == "."`) is different in kind: nothing sensible
+    sets `working-directory: .`, because "no override" already means "runs at
+    the checkout root". So root counts as referenced when some job runs a
+    real step (a `run:` command — not just checkout/setup) with no
+    working-directory override anywhere in that job.
+    """
+    if dir_rel == ".":
+        for _file, _name, job in jobs:
+            if _job_working_directories(job):
+                continue  # this job's steps run somewhere else, not root
+            steps = job.get("steps", []) or []
+            if any(isinstance(s, dict) and isinstance(s.get("run"), str) for s in steps):
+                return True
+        return False
+
+    # Boundary-matched, not `\b`: `-` is a non-word character, so `\b` would
+    # treat the gap inside "web-admin" itself as a boundary and let a search
+    # for "web" match the "web" in "web-admin". Instead: neither side of the
+    # match may be a character that could extend a path segment
+    # (`[\w.-]` — letters, digits, underscore, dot, hyphen). A leading/
+    # trailing `/`, whitespace, quote or end-of-string all count as a real
+    # boundary; another path-segment character does not.
+    pattern = re.compile(rf"(?<![\w./-]){re.escape(dir_rel)}(?![\w.-])")
+    for _file, _name, job in jobs:
+        if dir_rel in _job_working_directories(job):
+            return True
+        for step in job.get("steps", []) or []:
+            if any(pattern.search(text) for text in _step_texts(step)):
+                return True
+    return False
+
+
+def test_discovers_the_known_project_directories() -> None:
+    """A sweep that can't find anything real is not sweeping. Pins today's
+    known denominator (root + `web-admin`) so a rename or a directory quietly
+    dropping its marker file fails loudly here rather than by this whole
+    check going silently vacuous."""
+    found = discover_project_dirs()
+    print(f"ci-coverage-sweep: {len(found)} project directory(s) discovered: {found}")
+    assert found == [".", "web-admin"], (
+        f"discover_project_dirs() found {found!r} — if this repo genuinely "
+        "gained or lost a project directory, update this pinned list; if not, "
+        "the walk or the exclusion list broke."
+    )
+
+
+def test_every_project_directory_is_referenced_by_some_ci_job() -> None:
+    """The actual meta-check (#115 item 1): every discovered project
+    directory must be referenced by at least one job across
+    `.github/workflows/*.yml`."""
+    found = discover_project_dirs()
+    jobs = _load_workflow_jobs()
+    assert jobs, "no CI jobs were parsed at all — .github/workflows/*.yml is empty or unreadable"
+
+    unreferenced = [d for d in found if not is_directory_referenced(d, jobs)]
+
+    print(
+        f"ci-coverage-sweep: {len(found)} project directory(s) checked against "
+        f"{len(jobs)} job(s) across {_WORKFLOWS_DIR}/*.yml — "
+        f"{len(found) - len(unreferenced)} referenced, {len(unreferenced)} not."
+    )
+
+    assert not unreferenced, (
+        f"{unreferenced} contain a package.json/pyproject.toml but no CI job in "
+        f"{_WORKFLOWS_DIR} references them (checked working-directory and "
+        "run/with text in every parsed job, real YAML parsing not text "
+        "matching — see this file's module docstring). This is #97's exact "
+        "shape: code with tests, a typecheck and a lint config that no PR "
+        "ever actually ran. Add a CI job (or a working-directory / "
+        "cache-dependency-path reference inside an existing one) that covers "
+        f"it: {unreferenced}."
+    )
+
+
+# ── Negative control: prove this can fail, not just that it happens not to
+# (#115's own requirement — a check that only ever passes is exactly the
+# class this issue is about) ────────────────────────────────────────────
+
+
+def test_flags_a_synthetic_unreferenced_directory() -> None:
+    """A project directory with no CI job anywhere naming it must be
+    reported as unreferenced — the #97 shape, reproduced synthetically so
+    this doesn't depend on ever having a real uncovered directory to test
+    against."""
+    jobs = (
+        _load_workflow_jobs()
+    )  # this repo's REAL jobs — none of them can know about a directory that doesn't exist
+    assert not is_directory_referenced("totally-unwired-project", jobs)
+
+
+def test_recognises_a_working_directory_reference() -> None:
+    """The positive counterpart: a job whose `defaults.run.working-directory`
+    names the directory exactly must be recognised."""
+    jobs = [
+        (
+            "fake.yml",
+            "some-job",
+            {
+                "defaults": {"run": {"working-directory": "some-project"}},
+                "steps": [{"run": "npm test"}],
+            },
+        )
+    ]
+    assert is_directory_referenced("some-project", jobs)
+    assert not is_directory_referenced("some-other-project", jobs)
+
+
+def test_recognises_a_with_value_reference_without_a_working_directory() -> None:
+    """The shape `cache-dependency-path: web-admin/pnpm-lock.yaml` actually
+    takes in this repo's real ci.yml: no job-level working-directory is set
+    on the step that carries it, only a `with:` value naming the path."""
+    jobs = [
+        (
+            "fake.yml",
+            "some-job",
+            {
+                "steps": [
+                    {
+                        "uses": "actions/setup-node@v4",
+                        "with": {"cache-dependency-path": "some-project/pnpm-lock.yaml"},
+                    }
+                ]
+            },
+        )
+    ]
+    assert is_directory_referenced("some-project", jobs)
+
+
+def test_does_not_false_match_a_directory_name_that_is_a_prefix_of_another() -> None:
+    """`web-admin` must not be considered a reference to a directory literally
+    named `web`, and vice versa — this is the boundary the word/path-boundary
+    regex in `is_directory_referenced` exists for."""
+    jobs = [("fake.yml", "job", {"steps": [{"run": "cd web-admin && pnpm build"}]})]
+    assert is_directory_referenced("web-admin", jobs)
+    assert not is_directory_referenced("web", jobs)
+
+
+def test_ignores_a_directory_name_that_only_appears_in_a_yaml_comment() -> None:
+    """The load-bearing case: this repo's real `ci.yml` mentions `web-admin`
+    repeatedly in prose comments above the job that actually covers it. Parse
+    that same shape directly here — a comment-only mention must NOT count —
+    proving the parse-don't-grep claim in this module's docstring rather than
+    just asserting it."""
+    import tempfile
+
+    workflow_text = """\
+# This whole file is about web-admin/, mentioned here five more times:
+# web-admin web-admin web-admin web-admin web-admin
+name: fake
+on: push
+jobs:
+  unrelated-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        workflows_dir = Path(tmp)
+        (workflows_dir / "fake.yml").write_text(workflow_text)
+        jobs = _load_workflow_jobs(workflows_dir)
+        assert not is_directory_referenced("web-admin", jobs), (
+            "a directory name that appears only inside YAML comments must not "
+            "count as a reference — if it does, real YAML parsing has "
+            "regressed into the grep trap this check exists to avoid"
+        )
+
+
+def test_exclusion_list_entries_are_all_actually_gitignored_or_git_itself() -> None:
+    """Guard vs. authority, on the exclusion list itself: every pruned
+    directory name must independently be declared content-free by this
+    repo's own `.gitignore` (or be `.git`, which is never content). If a name
+    is ever added to `_EXCLUDED_DIR_NAMES` without also being gitignored,
+    this fails loudly — the exclusion list is where #115 warns instance four
+    would hide, and this is the two-line disagreement check that keeps it
+    honest rather than trusting the comment beside each entry to stay true."""
+    gitignore_text = (_REPO_ROOT / ".gitignore").read_text()
+    gitignored = {
+        line.strip().rstrip("/")
+        for line in gitignore_text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+
+    for name in _EXCLUDED_DIR_NAMES:
+        assert name == ".git" or name in gitignored, (
+            f"{name!r} is pruned by this sweep but is not in .gitignore — "
+            "either add it there (so git itself agrees it is never content) "
+            "or remove it from _EXCLUDED_DIR_NAMES with a real justification."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -92,6 +92,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 
@@ -112,6 +113,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
 
@@ -1044,6 +1046,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refs #115 (item 1 of the class — the meta-check). Not the whole issue: item 2
(`publish-registry`'s missing-credential fail-open) is deliberately left alone
here, see below. This PR leaves issue 115 open on purpose — item 2 is still unresolved upstream.

## What this adds

A pytest meta-check, `tests/test_marketing_ci_coverage_sweep.py`: for every
directory in this repo containing a `package.json`/`pyproject.toml`
(discovered from the filesystem, never a hand-maintained list), assert some
job across `.github/workflows/*.yml` actually references it.

This is the check that would have made **#97** impossible: `web-admin/`
carried 94 tests, a typecheck and a lint config, and no CI job at all ran any
of them, because nothing ever asked "is there code here no job covers?"

## Where it lives, and why pytest rather than its own CI job

Placed as a pytest test rather than a standalone workflow job, for three
reasons:

1. **It matches this repo's own convention.** Every other meta-check here
   (`test_marketing_core_paths_guard.py`'s AST sweep over Core-call paths,
   `test_marketing_dual_auth_wiring.py`, etc.) is a pytest test with a
   docstring, an explicit baseline, and a negative control — not a bespoke
   workflow job. A standalone job would be a second, inconsistent mechanism
   next to an established one, for no functional gain.
2. **It runs locally, not only in CI.** `sh scripts/biffo.sh verify` (the
   pre-push gate) runs `uv run pytest`, so this fires *before* a PR is even
   opened — closer to the actual goal (catch it before it ships) than a
   CI-only job, which only ever catches it after the fact.
3. **The recursion is real but not new, and not worse here.** If the `Test`
   job that runs pytest were ever removed, this check disappears with it —
   but so would all ~30 other pytest-based guards in this repo, and `Test` is
   one of this repo's own *required* status checks (see README's branch
   protection table). Removing it doesn't fail silently: every future PR
   would then be blocked forever waiting on a required check that never
   reports (the same "a required check that reports nothing blocks the PR for
   ever" shape AGENTS.md already documents elsewhere) — so the failure mode
   for silently dropping `Test` is loud and estate-wide, not this one guard
   quietly vanishing. A dedicated job would face the identical risk one level
   up (nothing stops `ci.yml` from losing *that* job either), so it buys no
   real independence, only a second pattern to maintain.

## Denominator today

Exactly two directories: the repo root (`.`, `pyproject.toml`) and
`web-admin` (`package.json`) — both currently referenced. Small, but the
point is it's asserted, not assumed: a third project directory added later
cannot join the estate unrefereed the way `web-admin` once did. The test
prints the denominator and the checked/covered counts on every run
(`ci-coverage-sweep: N project directory(s) checked against M job(s)...`).

## Parse, don't grep

`ci.yml`'s `admin-frontend` job carries extensive prose *comments* naming
`web-admin/` — a raw `grep -r web-admin .github/workflows/` would be
satisfied by those alone. This uses `yaml.safe_load` and only inspects real
job fields (`working-directory`, step `run:` text, `with:` values), so a
comment-only mention doesn't count. Covered by its own test
(`test_ignores_a_directory_name_that_only_appears_in_a_yaml_comment`), which
reproduces that exact shape synthetically.

## Negative control / fail-first evidence

- `test_flags_a_synthetic_unreferenced_directory` and three more unit tests
  prove `is_directory_referenced()` can return `False`, not just that it
  happens not to today.
- By hand, before writing the test: took a scratch copy of `ci.yml`, deleted
  the `admin-frontend` job's `working-directory: web-admin` and
  `cache-dependency-path: web-admin/pnpm-lock.yaml` lines (its prose comments
  mentioning `web-admin` were left in place, untouched), and re-ran
  `test_every_project_directory_is_referenced_by_some_ci_job` — it failed,
  correctly reporting `web-admin` unreferenced, with the comments present and
  not fooling it. Reverted before committing; `git diff` on `ci.yml` is
  clean.

## Exclusion list

`_EXCLUDED_DIR_NAMES` (`node_modules`, `dist`, `.venv`, `.pytest_cache`,
`__pycache__`, `.ruff_cache`, `.worktrees`, `.git`) is explicit and commented
per-entry rather than a glob, per the issue's own warning that the exclusion
list is where instance four would hide. Every entry is independently checked
against this repo's own `.gitignore` by
`test_exclusion_list_entries_are_all_actually_gitignored_or_git_itself` — so
a name added to the exclusion list without also being gitignored fails
loudly, rather than trusting the comment beside each entry to stay true.
Nothing excluded here is a genuine project directory; I didn't find one I was
uneasy about, but the guard-vs-authority test above is there so a future
change to either list can't drift unnoticed.

## Explicitly NOT in this PR

Issue #115's item 2 — `publish-registry.yml` reporting `success` on a missing
`REGISTRY_PUBLISH_TOKEN` — belongs upstream (`biffo-template#1450`), because
every plugin repo inherits that workflow verbatim. A local patch here would
diverge this repo from the template and hide the shared problem rather than
fix it; leaving it alone on purpose.

## Gates run

- `uv run pytest` — 584 passed (full suite, including the 8 new tests).
- `uv run ruff check` / `ruff format --check`, `uv run pyright` — clean.
- `sh scripts/biffo.sh verify` — full pass, including `web-admin`'s
  lint/typecheck/test lane (installed `web-admin`'s pnpm deps to get a real
  verdict rather than "dependencies not installed"; `web-admin` itself is
  untouched by this PR).

## New dependency

Added `pyyaml>=6.0` to `[dependency-groups].dev` — used only by the new test,
never imported by `src/marketing`, so it does not ship in the Lambda bundle.
