### PR TITLE
fix(copy): make brevity a measured constraint, not a preference

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 #: What an operator can ask a campaign to produce.
 #:
@@ -313,6 +314,101 @@ class ChannelPlan(BaseModel):
     channels: list[ChannelRecommendation] = Field(default_factory=list)
 
 
+# ── How long a piece of copy is allowed to be (issue #128) ───────────────────
+#
+# Copy that is accurate, grounded and three sentences long is still bad copy:
+# it reads as competent explanation rather than persuasion. Issue #128 quotes a
+# real run (campaign ``fa6590f1``) whose organic-search entry led with a
+# rhetorical warm-up, spent two sentences arriving at its point, and closed with
+# a CTA that restated the headline instead of asking for anything.
+#
+# ## Why a number, and not only an instruction
+#
+# The prompt asks for brevity in `COPY_INSTRUCTIONS`; this is the number that
+# asking is measured against. The two are the SAME constant deliberately —
+# quoted into the instructions, quoted into the field descriptions the model
+# reads while filling each field, and read back by
+# ``pipeline.measure_copy_length`` when the output returns. A prompt that says
+# "keep it short" and a checker that decides what short means are two places for
+# the same rule to drift; there is one here.
+#
+# ## Where these numbers come from — NOT from `paid_pack_routes._PLATFORM_LIMITS`
+#
+# Those are ad-form limits: what Meta or Google will accept in a text input.
+# They answer "does this fit the box?". These answer a different question —
+# "was this written to be read in one glance?" — so they are derived from
+# reading behaviour rather than from any platform's API:
+#
+#   - ``headline`` 60 — the width at which a lead line is still taken in as one
+#     unit rather than read. It is also, not coincidentally, roughly where a
+#     search-result title and an email subject line get clipped: those products
+#     converged on the same number because they are solving the same problem.
+#   - ``body`` 200 — two sentences of plain English (~15-18 words each). This
+#     is issue #128's rule expressed as a length: *earn the second sentence or
+#     do not get one*. It sits below where the widest organic feeds clip a post
+#     and above the narrowest, on purpose: this artefact is the hook, not the
+#     whole post.
+#   - ``cta`` 40 — an imperative verb phrase and its object ("Book a 20-minute
+#     walkthrough" is 28). Past about six words a CTA stops instructing and
+#     starts being a second sentence, which is exactly the failure #128 reports.
+#
+# ## One number per field, not one per channel
+#
+# Tempting to size these per channel — an Instagram caption is not a LinkedIn
+# post. The blocker is structural, not aesthetic: at the point this is checked
+# (``pipeline.extract_copy``) the only channel fact available is the
+# ``{channel_key: motion}`` map, and deriving a channel's *shape* from its key
+# means matching substrings against it. `paid_pack_routes._platform_for_channel`
+# deleted exactly that guess in #76 increment 2 ("the keyword table itself is
+# deleted, not kept as an unreachable fallback"), and reintroducing it one
+# module over would be a worse version of the thing that was removed. Per-channel
+# ceilings need the taxonomy to carry a shape, which is a taxonomy change.
+#
+# That costs less than it looks like it does, because these are ceilings and not
+# targets. Tone still varies per channel — `COPY_INSTRUCTIONS` still says a
+# LinkedIn post and an Instagram caption must not read the same — and nothing
+# obliges any channel to spend its whole allowance.
+#
+# ## Paid channels are measured too
+#
+# One copy agent writes for both motions, and the budget and the platform limit
+# do not conflict because they ask different questions: a 100-character TikTok
+# headline fits the ad form and still is not written short, and a 45-character
+# CTA is inside this budget while Google's 30-character field will trim it. A
+# paid field that arrives inside the budget arrives with less to truncate, which
+# shows up as fewer `*_truncated` flags on the paid pack — a side benefit, not
+# the reason.
+#: The three fields a length budget applies to. Named once so the budget's
+#: keys, `LengthOverage.field` and every reader agree by construction rather
+#: than by three matching string literals.
+CopyField = Literal["headline", "body", "cta"]
+
+COPY_LENGTH_BUDGET: Mapping[CopyField, int] = {"headline": 60, "body": 200, "cta": 40}
+
+#: How far past its budget a field has to be before the copy set is rejected
+#: outright rather than flagged (``pipeline.CopyTooLongError``).
+#:
+#: Three times is not a second opinion about the right length. Between the
+#: budget and this ceiling sits copy that a person can still judge — the #128
+#: example is over budget on all three fields and nowhere near this ceiling, and
+#: rejecting that run would have thrown away copy an operator called "accurate,
+#: well-grounded and on-message". Past 3x, the constraint was not applied at all:
+#: a 180-character headline is not a headline, whatever channel it is for, so
+#: there is nothing for an operator to weigh up.
+COPY_LENGTH_CEILING_MULTIPLE: int = 3
+
+
+class LengthOverage(BaseModel):
+    """One copy field that came back longer than `COPY_LENGTH_BUDGET` allows —
+    what it was, how long it is and what it was allowed. Carries the budget
+    alongside the length so every reader of the artefact (including the admin
+    UI) can render the finding without a second copy of the numbers."""
+
+    field: CopyField
+    length: int
+    budget: int
+
+
 class ChannelCopy(BaseModel):
     """Publish-ready copy for one channel from the approved channel plan.
     Same citation discipline as every other stage output: `sources` has no
@@ -340,13 +436,57 @@ class ChannelCopy(BaseModel):
             "be overridden."
         ),
     )
-    headline: str = Field(description="The lead line, sized for this channel.")
-    body: str = Field(description="The body copy, sized for this channel.")
-    cta: str = Field(description="The call to action, drawn from the approved positioning.")
+    # The three lengths below are hard ceilings, quoted from
+    # `COPY_LENGTH_BUDGET` rather than written out, so the number the model is
+    # shown at the moment it fills the field is the same number
+    # `pipeline.measure_copy_length` measures it against. They are stated here
+    # AS WELL AS in `COPY_INSTRUCTIONS` on purpose: a length rule three
+    # paragraphs up a system prompt is a thing to remember, and a length rule in
+    # the field's own description is a thing to obey while typing it.
+    #
+    # Deliberately NOT `max_length`. A `max_length` here would be enforced by
+    # pydantic inside `_extract_cited_artefact`, so one long field would fail
+    # `model_validate`, surface as a `MalformedOutputError` carrying a raw
+    # pydantic traceback, and discard every other channel's copy along with it.
+    # Worse, it rewards the wrong behaviour: the cheapest way for a model to
+    # satisfy a hard `max_length` is to write the long sentence and stop typing,
+    # which is a wordy headline with the end cut off — the exact thing #128 says
+    # is not the same as copy written to be short.
+    headline: str = Field(
+        description=(
+            f"The lead line, sized for this channel. At most "
+            f"{COPY_LENGTH_BUDGET['headline']} characters — a ceiling, not a target to "
+            "fill. One idea, scanned in a glance, strongest claim first."
+        )
+    )
+    body: str = Field(
+        description=(
+            f"The body copy, sized for this channel. At most {COPY_LENGTH_BUDGET['body']} "
+            "characters — a ceiling, not a target to fill. One sentence; write a second "
+            "only if it carries a fact the first does not."
+        )
+    )
+    cta: str = Field(
+        description=(
+            "The call to action, drawn from the approved positioning. At most "
+            f"{COPY_LENGTH_BUDGET['cta']} characters — a ceiling, not a target to fill. "
+            "Ask for the action; do not restate the headline."
+        )
+    )
     sources: list[Source] = Field(
         min_length=1,
         description="Positioning sources (pillar/CTA) this copy was grounded in.",
     )
+    # Derived at extract time by `pipeline.measure_copy_length`, never supplied
+    # by the agent — and, unlike `motion` above, hidden from the tool schema
+    # entirely (`SkipJsonSchema`) rather than described as "will be overridden".
+    # `motion` is part of what the artefact says; this is a record of the agent
+    # having missed a rule, and showing the model the field it will be marked
+    # down in adds tokens to a prompt with no timeout headroom left (#131) while
+    # offering a place to assert compliance it has not achieved. It stays in
+    # `model_dump()`, which is what reaches `marketing_artefact.body` and the
+    # approval-gate UI.
+    over_budget: SkipJsonSchema[list[LengthOverage]] = Field(default_factory=list)
 
 
 class CopySet(BaseModel):
@@ -598,6 +738,15 @@ Return your answer by calling the `{CHANNEL_PLAN_TOOL_NAME}` tool exactly
 once. Do not answer in prose.
 """
 
+# Bound to short names purely so the length rules read as numbers inside
+# `COPY_INSTRUCTIONS`'s f-string. The values are `COPY_LENGTH_BUDGET`'s — the
+# prompt must never carry a second, hand-written copy of a number the checker
+# enforces, which is the drift this indirection exists to make impossible.
+_HEADLINE_BUDGET = COPY_LENGTH_BUDGET["headline"]
+_BODY_BUDGET = COPY_LENGTH_BUDGET["body"]
+_CTA_BUDGET = COPY_LENGTH_BUDGET["cta"]
+_CEILING_MULTIPLE = COPY_LENGTH_CEILING_MULTIPLE
+
 COPY_INSTRUCTIONS = f"""\
 You are the campaign studio's copywriter. You are given one **approved**
 positioning artefact (audience segments, message pillars and calls to
@@ -621,6 +770,43 @@ each channel:
    invented fresh.
 3. Ground every line in the positioning's segments, pillars and CTAs — never
    in generic marketing copy that could belong to any campaign.
+
+## Length is a constraint, not a preference
+
+These are hard ceilings. They are not targets to fill, and copy that reaches
+one is usually still too long:
+
+- **Headline: at most {_HEADLINE_BUDGET} characters.**
+- **Body: at most {_BODY_BUDGET} characters.**
+- **CTA: at most {_CTA_BUDGET} characters.**
+
+Your output is measured against these numbers after you return it. Every
+field over its ceiling is recorded on the artefact and shown to the operator
+who has to approve it, right next to the line that broke it. Copy more than
+{_CEILING_MULTIPLE}x over is rejected outright and the whole set is thrown away with it.
+Count the characters before you submit.
+
+Four rules decide what survives the cut:
+
+1. **Lead with the sharp end.** The first thing the reader sees is the
+   strongest, most specific claim you have. Do not set the scene, and do not
+   describe the reader's situation back to them before saying something they
+   could not have written themselves.
+2. **One idea, one action.** A second idea in the body is a second piece of
+   copy; write the first one properly instead.
+3. **The CTA asks for the click.** It names the action and stops. A CTA that
+   summarises the headline has spent the reader's last line saying something
+   they have already read.
+4. **Cut the throat-clearing.** Rhetorical opening questions, "Looking
+   for...", "Most companies...", and any clause whose removal changes nothing
+   are warm-up. The reader already knows why they are there.
+
+**Shorter must never mean vaguer.** The specific, checkable detail you took
+from the positioning — a number, a price, a named constraint, a stated
+limitation of the alternatives — is the part that persuades; the connective
+prose around it is what the ceiling is for. "Built for growth" is short and
+worth nothing. If the choice is between dropping a fact and dropping a
+clause, drop the clause.
 
 Every channel's copy must carry `sources`: copy the `url` of each relevant
 `Source` from the positioning pillar(s) or CTA(s) you drew from, exactly as

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 from urllib.parse import urlsplit, urlunsplit
@@ -62,6 +62,8 @@ from .definitions import (
     CHANNEL_PLAN_TOOL_NAME,
     COPY_AGENT_NAME,
     COPY_INSTRUCTIONS,
+    COPY_LENGTH_BUDGET,
+    COPY_LENGTH_CEILING_MULTIPLE,
     COPY_TOOL_NAME,
     DEFAULT_CHANNEL_PLAN_MODEL,
     DEFAULT_COPY_MODEL,
@@ -76,8 +78,10 @@ from .definitions import (
     RESEARCH_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_AGENT_NAME,
     RESEARCH_SYNTHESIS_TOOL_NAME,
+    ChannelCopy,
     ChannelPlan,
     CopySet,
+    LengthOverage,
     Positioning,
     ResearchFindingSet,
     ResearchSynthesis,
@@ -184,6 +188,92 @@ class StaleChannelPlanError(PipelineError):
     :class:`UnknownChannelError` (which fires when the *agent* invents a key)
     because the cause here is upstream data, not agent behaviour: the fix is
     re-running channel planning on this campaign, not retrying copy."""
+
+
+class CopyTooLongError(PipelineError):
+    """A copy run returned a field more than
+    :data:`~marketing.definitions.COPY_LENGTH_CEILING_MULTIPLE` times its
+    :data:`~marketing.definitions.COPY_LENGTH_BUDGET` (issue #128) — the copy
+    equivalent of :class:`UnknownChannelError`: not a judgement call about
+    style, but evidence the constraint was not applied at all.
+
+    Deliberately the *only* fatal half of the length rule, and deliberately
+    not a ``max_length`` on the model — see
+    :func:`measure_copy_length` for where the line is drawn and why."""
+
+
+# ── Length: measured, recorded, and only fatal at the far end (issue #128) ───
+
+
+def measure_copy_length(channels: Sequence[ChannelCopy]) -> None:
+    """Record every field over :data:`COPY_LENGTH_BUDGET` on its own
+    :class:`ChannelCopy`, and raise :class:`CopyTooLongError` for anything
+    past :data:`COPY_LENGTH_CEILING_MULTIPLE` times that budget. Mutates in
+    place, exactly as :func:`extract_copy`'s ``motion`` carry-over does.
+
+    ## Why over-budget is recorded rather than rejected
+
+    Issue #128 asks for brevity as a constraint rather than a preference, and
+    the obvious reading of that is a hard limit — a ``max_length`` on the
+    field, or this check raising on the first character over. Both are worse
+    than what they replace, for two separate reasons:
+
+    1. **Truncating a wordy headline gives you a wordy headline with the end
+       cut off.** The paid pack trims to platform limits (`_fit_to_limit`)
+       because an Ads Manager field genuinely cannot hold more; that is
+       fitting, not writing. Nothing equivalent is available here, because the
+       thing being asked for is a different sentence, not the same sentence
+       shortened.
+    2. **The run is expensive and the failure is cheap to survive.** One long
+       headline failing ``model_validate`` discards every other channel's copy
+       with it, from an agent already running close to its 240s ceiling
+       (#131), to fix something an operator can read and judge in seconds.
+
+    So the budget is enforced where a length problem is actually decidable:
+    the approval gate this artefact already has to pass. ``over_budget`` rides
+    into ``marketing_artefact.body`` and the admin UI renders it against the
+    offending line, so the operator approving the copy sees "94 characters,
+    budget 60" beside the headline itself. That is what stops it being
+    advisory — not that the model was asked nicely, but that its drift is
+    measured, attributed per field, and on screen at the moment someone
+    decides whether to ship it.
+
+    ## Why the ceiling is fatal anyway
+
+    Past ``COPY_LENGTH_CEILING_MULTIPLE`` there is nothing left to judge, so
+    handing it to an operator wastes their time instead of saving the run's.
+    An operator who hits this sees the :class:`CopyTooLongError` message —
+    which names the channel, the field, its length and its budget, and says to
+    run copy generation again — as the ``detail`` of a 502 from the advance
+    route, exactly like an uncited source or an unknown channel
+    (``admin_app._pipeline_error_to_http``, which maps the BASE class so a new
+    error type cannot fall through as a bare 500).
+    """
+    for channel_copy in channels:
+        overages: list[LengthOverage] = []
+        for field_name, budget in COPY_LENGTH_BUDGET.items():
+            length = len(getattr(channel_copy, field_name))
+            if length > budget:
+                overages.append(LengthOverage(field=field_name, length=length, budget=budget))
+        channel_copy.over_budget = overages
+
+    fatal = [
+        (channel_copy, overage)
+        for channel_copy in channels
+        for overage in channel_copy.over_budget
+        if overage.length > overage.budget * COPY_LENGTH_CEILING_MULTIPLE
+    ]
+    if fatal:
+        detail = "; ".join(
+            f"{channel_copy.channel_key} {overage.field} is {overage.length} characters "
+            f"(budget {overage.budget})"
+            for channel_copy, overage in fatal
+        )
+        raise CopyTooLongError(
+            f"The copy run returned copy more than {COPY_LENGTH_CEILING_MULTIPLE}x over its "
+            f"length budget, so it was not written to the brief at all: {detail}. Nothing "
+            "was produced — try running copy generation again."
+        )
 
 
 def _tool_call_arguments(messages: list[dict[str, Any]], tool_name: str) -> Any:
@@ -596,6 +686,12 @@ def extract_copy(
                 "approved channel plan did not include."
             )
         channel_copy.motion = channel_plan_channels[channel_copy.channel_key]  # derived
+    # Last, and after the citation guards on purpose: length is the least
+    # serious thing that can be wrong with a piece of copy, and a run that
+    # fabricated a source should be reported as having fabricated a source, not
+    # as having written a long headline. See :func:`measure_copy_length` for why
+    # only the far end of this is fatal (issue #128).
+    measure_copy_length(result.channels)
     return result
 
 

--- a/tests/test_marketing_copy_brevity.py
+++ b/tests/test_marketing_copy_brevity.py
@@ -1,0 +1,229 @@
+"""Brevity as a constraint rather than a preference (issue #128).
+
+The copy this pipeline produced was accurate, grounded, on-message — and three
+sentences where one would land harder, closing with a CTA that restated the
+headline instead of asking for anything. Nothing in the codebase disagreed
+with it: `COPY_INSTRUCTIONS` said nothing about length, `ChannelCopy`'s fields
+had no size, and the only character limits anywhere lived on the PAID path
+(`paid_pack_routes._PLATFORM_LIMITS`), which is a different question — what
+fits an Ads Manager form, not what was written to be read.
+
+These tests are the fail-first proof. Before the fix they fail on the absence
+of `COPY_LENGTH_BUDGET` itself; after it they pin the three properties that
+make the constraint real rather than requested:
+
+1. The number is **one** number — quoted into the prompt, into the schema the
+   model fills, and into the checker. A prompt asking for brevity and a
+   checker deciding what brevity means are two places for one rule to drift.
+2. Over budget is **recorded on the artefact**, not rejected: the #128 example
+   is over on all three fields and is still worth an operator's judgement.
+3. Grossly over IS rejected, because past that point there is nothing left to
+   judge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from marketing.definitions import (
+    COPY_INSTRUCTIONS,
+    COPY_LENGTH_BUDGET,
+    COPY_LENGTH_CEILING_MULTIPLE,
+    copy_tool_schema,
+)
+from marketing.pipeline import CopyTooLongError, extract_copy
+
+_SOURCE = {"url": "https://example.com/thread", "note": "A forum thread."}
+
+#: The copy issue #128 actually reports, from campaign `fa6590f1`, verbatim.
+#: Its lengths (63 / 254 / 57) are the calibration argument for both halves of
+#: this rule at once: over budget on every field, nowhere near the ceiling on
+#: any of them.
+_REPORTED_HEADLINE = "Franchise management pricing you can see before you book a demo"
+_REPORTED_BODY = (
+    "Comparing UK franchise-management platforms? Most make you request a demo just to "
+    "learn what it costs. We publish clear per-location pricing you can plan a budget "
+    "around — no demo gate. See exactly what running 5–50 units on one platform costs, "
+    "up front."
+)
+_REPORTED_CTA = "See our per-location pricing up front — no demo required."
+
+
+def _copy_call(**overrides: Any) -> list[dict[str, Any]]:
+    channel = {
+        "channel_key": "organic_search",
+        "headline": "Pricing, published.",
+        "body": "Per-location pricing on the website. No demo gate.",
+        "cta": "See the pricing",
+        "sources": [_SOURCE],
+    }
+    channel.update(overrides)
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "submit_copy", "arguments": {"channels": [channel]}}}
+            ],
+        }
+    ]
+
+
+def _extract(**overrides: Any) -> Any:
+    return extract_copy(
+        _copy_call(**overrides), channel_plan_channels={"organic_search": "organic"}
+    )
+
+
+# ── One number, three readers ────────────────────────────────────────────────
+
+
+def test_the_budget_is_quoted_into_the_prompt() -> None:
+    """The instructions must carry the SAME numbers the checker enforces.
+
+    A hand-written "keep headlines under 70 characters" in the prompt beside a
+    checker that measures 60 is a rule the model can satisfy and still be
+    marked down for, which is how a constraint decays back into a preference.
+    """
+    for budget in COPY_LENGTH_BUDGET.values():
+        assert str(budget) in COPY_INSTRUCTIONS
+    assert str(COPY_LENGTH_CEILING_MULTIPLE) in COPY_INSTRUCTIONS
+
+
+def test_the_budget_is_quoted_into_the_field_descriptions_the_model_fills() -> None:
+    """The number must also reach the tool schema, not only the system prompt.
+
+    The schema description is what the model is reading at the moment it fills
+    that specific field; a length rule three paragraphs up a prompt is a thing
+    to remember instead."""
+    properties = copy_tool_schema()["function"]["parameters"]["$defs"]["ChannelCopy"]["properties"]
+    for field, budget in COPY_LENGTH_BUDGET.items():
+        assert str(budget) in properties[field]["description"], field
+
+
+def test_the_length_fields_carry_no_max_length() -> None:
+    """Deliberately NOT enforced by pydantic.
+
+    A `max_length` fails `model_validate` inside `_extract_cited_artefact`,
+    which discards every other channel's copy over one long field and reports
+    it as a raw `MalformedOutputError`. It also rewards the wrong behaviour:
+    the cheapest way to satisfy it is to write the long sentence and stop
+    typing, which is a wordy headline with the end cut off — not copy written
+    to be short."""
+    properties = copy_tool_schema()["function"]["parameters"]["$defs"]["ChannelCopy"]["properties"]
+    for field in COPY_LENGTH_BUDGET:
+        assert "maxLength" not in properties[field], field
+
+
+def test_the_overage_record_is_hidden_from_the_agent() -> None:
+    """`over_budget` is derived, and unlike `motion` it is not even shown to
+    the agent: it records the agent having missed a rule, so offering it a
+    field to assert compliance in is worse than useless, and the copy agent
+    has no prompt-size headroom to spend on it (#131)."""
+    properties = copy_tool_schema()["function"]["parameters"]["$defs"]["ChannelCopy"]["properties"]
+    assert "over_budget" not in properties
+
+
+# ── Over budget: recorded, and the run survives ──────────────────────────────
+
+
+def test_copy_within_budget_records_no_overage() -> None:
+    copy = _extract()
+
+    assert copy.channels[0].over_budget == []
+
+
+def test_the_reported_copy_is_flagged_on_every_field_and_still_returned() -> None:
+    """#128's own example. Every field is over; the run still produces an
+    artefact, because an operator called this copy "accurate, well-grounded and
+    on-message" — rejecting it outright would throw that away to fix wordiness
+    a human can judge in seconds."""
+    copy = _extract(headline=_REPORTED_HEADLINE, body=_REPORTED_BODY, cta=_REPORTED_CTA)
+
+    overages = copy.channels[0].over_budget
+    assert [o.field for o in overages] == ["headline", "body", "cta"]
+    assert [o.length for o in overages] == [63, 254, 57]
+    assert [o.budget for o in overages] == [
+        COPY_LENGTH_BUDGET["headline"],
+        COPY_LENGTH_BUDGET["body"],
+        COPY_LENGTH_BUDGET["cta"],
+    ]
+    # The artefact body is what the approval gate renders, so the finding has
+    # to survive the dump — this is the whole mechanism by which a non-fatal
+    # check stays visible rather than advisory.
+    dumped = copy.model_dump()["channels"][0]["over_budget"]
+    assert dumped[0] == {"field": "headline", "length": 63, "budget": 60}
+
+
+def test_a_field_exactly_on_its_budget_is_not_flagged() -> None:
+    """The budget is a ceiling, not an exclusive bound — off-by-one here would
+    flag copy that obeyed the instruction it was given."""
+    copy = _extract(headline="x" * COPY_LENGTH_BUDGET["headline"])
+
+    assert copy.channels[0].over_budget == []
+
+
+# ── Grossly over: rejected ───────────────────────────────────────────────────
+
+
+def test_copy_far_past_the_ceiling_is_rejected() -> None:
+    """Past `COPY_LENGTH_CEILING_MULTIPLE` the constraint was not applied at
+    all, so there is nothing for an operator to weigh up."""
+    runaway = "x" * (COPY_LENGTH_BUDGET["headline"] * COPY_LENGTH_CEILING_MULTIPLE + 1)
+
+    with pytest.raises(CopyTooLongError) as exc:
+        _extract(headline=runaway)
+
+    message = str(exc.value)
+    # A guard that says only "no" gets worked around: the operator must be able
+    # to see which channel, which field, how long, and what to do next.
+    assert "organic_search" in message
+    assert "headline" in message
+    assert str(len(runaway)) in message
+    assert "copy generation again" in message
+
+
+def test_the_fatal_case_reaches_the_operator_as_a_502_rather_than_a_500() -> None:
+    """`admin_app._pipeline_error_to_http` maps the BASE class deliberately,
+    "so a new pipeline error type cannot silently fall through as a 500". This
+    IS a new pipeline error type — this is the test that says so."""
+    from fastapi import status
+
+    from marketing.admin_app import _pipeline_error_to_http
+    from marketing.pipeline import PipelineError
+
+    assert issubclass(CopyTooLongError, PipelineError)
+    http = _pipeline_error_to_http(CopyTooLongError("the headline is 400 characters"))
+    assert http.status_code == status.HTTP_502_BAD_GATEWAY
+    assert http.detail == "the headline is 400 characters"
+
+
+def test_copy_exactly_at_the_ceiling_is_flagged_rather_than_rejected() -> None:
+    """The fatal case is the one that is unambiguously not copy — the boundary
+    itself still belongs to the operator."""
+    at_ceiling = "x" * (COPY_LENGTH_BUDGET["headline"] * COPY_LENGTH_CEILING_MULTIPLE)
+
+    copy = _extract(headline=at_ceiling)
+
+    assert [o.field for o in copy.channels[0].over_budget] == ["headline"]
+
+
+# ── What must not have changed ───────────────────────────────────────────────
+
+
+def test_length_is_checked_after_the_citation_guards() -> None:
+    """#113's provenance guard must still be what a fabricating run is reported
+    for. A run that invented a source AND wrote a 500-character headline is a
+    run that invented a source; reporting it as wordy would be a real
+    regression dressed up as a length check."""
+    from marketing.pipeline import UncitedSourceError
+
+    runaway = "x" * (COPY_LENGTH_BUDGET["headline"] * COPY_LENGTH_CEILING_MULTIPLE + 1)
+
+    with pytest.raises(UncitedSourceError):
+        extract_copy(
+            _copy_call(headline=runaway, sources=[{"url": "https://invented.example", "note": ""}]),
+            channel_plan_channels={"organic_search": "organic"},
+            allowed_source_urls=["https://example.com/thread"],
+        )

--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -386,4 +386,64 @@ describe('CopyArtefact', () => {
     expect(screen.getByText('Get your team live in under a day.')).toBeInTheDocument()
     expect(screen.getByText('Book a demo')).toBeInTheDocument()
   })
+
+  /** #128: the copy pipeline records a length overage rather than rejecting
+   * the run, on the argument that a wordy-but-grounded headline is decidable
+   * by the person at the approval gate and not by a validator. That argument
+   * only holds if the gate actually shows it — these two tests are what stops
+   * the server-side check from being advisory. */
+  it('badges each copy field that came back over its length budget', () => {
+    render(
+      <CopyArtefact
+        body={{
+          channels: [
+            {
+              channel_key: 'linkedin_organic',
+              motion: 'organic',
+              headline: 'Franchise management pricing you can see before you book a demo',
+              body: 'Get your team live in under a day.',
+              cta: 'See our per-location pricing up front — no demo required.',
+              sources: [{ url: 'https://example.com/copy', note: 'Copy grounding' }],
+              over_budget: [
+                { field: 'headline', length: 63, budget: 60 },
+                { field: 'cta', length: 57, budget: 40 },
+              ],
+            },
+          ],
+        }}
+        channelLookup={makeLookup([LINKEDIN, GOOGLE])}
+      />,
+    )
+    // The numbers come off the datum, not from constants duplicated here —
+    // `COPY_LENGTH_BUDGET` lives in definitions.py and must stay there.
+    expect(screen.getByText('63 chars · budget 60')).toBeInTheDocument()
+    expect(screen.getByText('57 chars · budget 40')).toBeInTheDocument()
+    // The body was inside its budget, so it carries no badge at all.
+    expect(screen.queryByText(/budget 200/)).not.toBeInTheDocument()
+  })
+
+  it('renders copy proposed before #128, which carries no over_budget at all', () => {
+    // Every artefact already in the database predates the field. Treating a
+    // missing `over_budget` as anything other than "nothing to say" would
+    // break the review gate for every campaign that already exists.
+    render(
+      <CopyArtefact
+        body={{
+          channels: [
+            {
+              channel_key: 'linkedin_organic',
+              motion: 'organic',
+              headline: 'Faster onboarding, starting today',
+              body: 'Get your team live in under a day.',
+              cta: 'Book a demo',
+              sources: [{ url: 'https://example.com/copy', note: 'Copy grounding' }],
+            },
+          ],
+        }}
+        channelLookup={makeLookup([LINKEDIN, GOOGLE])}
+      />,
+    )
+    expect(screen.getByText('Faster onboarding, starting today')).toBeInTheDocument()
+    expect(screen.queryByText(/budget/)).not.toBeInTheDocument()
+  })
 })

--- a/web-admin/src/components/ArtefactBody.tsx
+++ b/web-admin/src/components/ArtefactBody.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import type {
   ChannelPlanBody as ChannelPlanBodyT,
   CopySetBody,
+  LengthOverage,
   PositioningBody as PositioningBodyT,
   ResearchSynthesisBody,
   Source,
@@ -283,6 +284,31 @@ export function ChannelPlanArtefact({
   )
 }
 
+/** The length budget a copy field blew, rendered beside the line that blew it
+ * (#128).
+ *
+ * This badge is the whole reason the server-side check can afford NOT to be
+ * fatal. `pipeline.measure_copy_length` records the overage instead of
+ * rejecting the run, on the argument that a length problem is decidable by the
+ * person at the approval gate and not by a validator — which is only true if
+ * that person is actually shown it. Rendering it in a summary elsewhere, or
+ * only as a count, would make the check advisory in the way #128 complains
+ * about; attached to the offending line, the operator cannot approve the copy
+ * without it being on screen next to the text it is about.
+ *
+ * Reads `budget` off the datum rather than knowing any numbers itself, so
+ * changing `COPY_LENGTH_BUDGET` in `definitions.py` never needs a matching
+ * edit here. */
+function OverBudget({ overages, field }: { overages: LengthOverage[] | undefined; field: LengthOverage['field'] }) {
+  const overage = overages?.find((o) => o.field === field)
+  if (overage === undefined) return null
+  return (
+    <span className="over-budget" title={`This ${field} is longer than the campaign studio's length budget.`}>
+      {overage.length} chars · budget {overage.budget}
+    </span>
+  )
+}
+
 export function CopyArtefact({ body, channelLookup }: { body: CopySetBody; channelLookup: ChannelLookup }) {
   return (
     <div className="artefact-body">
@@ -297,9 +323,15 @@ export function CopyArtefact({ body, channelLookup }: { body: CopySetBody; chann
           ),
           body: (
             <>
-              <p className="headline">{c.headline}</p>
-              <p>{c.body}</p>
-              <p className="cta">{c.cta}</p>
+              <p className="headline">
+                {c.headline} <OverBudget overages={c.over_budget} field="headline" />
+              </p>
+              <p>
+                {c.body} <OverBudget overages={c.over_budget} field="body" />
+              </p>
+              <p className="cta">
+                {c.cta} <OverBudget overages={c.over_budget} field="cta" />
+              </p>
             </>
           ),
           sources: c.sources,

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -721,6 +721,24 @@ details.mint-toggle[open] > .mint {
   color: var(--text-secondary);
 }
 
+/* A copy field over its length budget (#128), badged next to the line itself.
+   Deliberately quiet rather than alarming: this is a note that the copy is
+   wordier than the brief allows, sitting at an approval gate whose other
+   signals (an uncited source, an unknown channel) are hard failures that never
+   reach the screen at all. Loud styling here would compete with the copy it is
+   annotating, which is the thing the operator is actually there to read. */
+.artefact-body .over-budget {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+  vertical-align: middle;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--warning-bg);
+  color: var(--warning-text);
+}
+
 .motion {
   font-size: 0.7rem;
   font-weight: 700;

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -383,6 +383,16 @@ export interface ChannelPlanBody {
 /** #76 increment 2: `channel` → `channel_key`, always a real taxonomy key —
  * a proposal is never promoted into copy without operator acceptance, so
  * `ChannelCopy` (unlike `ChannelRecommendation`) has no `suggested_label`. */
+/** One copy field that came back longer than its length budget (#128).
+ * Derived server-side in `pipeline.measure_copy_length`, never written by the
+ * agent — and it carries its own `budget`, so this UI renders the finding
+ * without a second copy of numbers that live in `definitions.py`. */
+export interface LengthOverage {
+  field: 'headline' | 'body' | 'cta'
+  length: number
+  budget: number
+}
+
 export interface ChannelCopy {
   channel_key: string
   motion: 'organic' | 'paid'
@@ -390,6 +400,9 @@ export interface ChannelCopy {
   body: string
   cta: string
   sources: Source[]
+  /** Absent on any copy artefact proposed before #128 landed — every reader
+   * must treat it as optional rather than assume the server filled it. */
+  over_budget?: LengthOverage[]
 }
 
 export interface CopySetBody {


### PR DESCRIPTION
## The problem

Generated copy was accurate, well-grounded, on-message — and three sentences where one would land harder, closing with a CTA that restated the headline instead of asking for anything (#128, campaign `fa6590f1`).

Nothing in the codebase disagreed with it. `COPY_INSTRUCTIONS` carried no brevity constraint at all, `ChannelCopy.headline/body/cta` had no size, and the only character limits anywhere lived on the **paid** path (`paid_pack_routes._PLATFORM_LIMITS`, `_fit_to_limit`). Those answer a different question — *does this fit an Ads Manager form* — and they answer it by truncating.

## Where the constraint went, and why

**One number, three readers.** `COPY_LENGTH_BUDGET` (headline 60 / body 200 / CTA 40) is quoted into `COPY_INSTRUCTIONS`, into the JSON-schema field descriptions the model reads *while filling that specific field*, and into `pipeline.measure_copy_length` which measures the result. A prompt that asks for brevity and a checker that decides what brevity means are two places for one rule to drift; there is one place here, and a test that fails if the prompt or the schema stops quoting it.

**The numbers are derived, not borrowed.** Not `_PLATFORM_LIMITS` — those are ad-form sizes. These come from reading behaviour: 60 is where a lead line stops being taken in as one unit (and where a SERP title and an email subject get clipped, for the same reason); 200 is #128's own rule — *earn the second sentence or do not get one* — expressed as two sentences of plain English; 40 is an imperative verb phrase and its object, past which a CTA stops instructing. The derivation is a comment sitting directly above the constant.

**One budget per field, not per channel** — a structural constraint, not a stylistic one. At `extract_copy` the only channel fact available is `{channel_key: motion}`; deriving a channel's *shape* from its key means matching substrings against it, which is exactly what `_platform_for_channel` deleted in #76 increment 2 ("the keyword table itself is deleted, not kept as an unreachable fallback"). Re-introducing that one module over would be a worse version of the thing that was removed. Per-channel ceilings need the taxonomy to carry a shape.

## Fatal, advisory, and the line between

Deliberately **not** `max_length` on the fields. Two reasons, both about behaviour rather than tidiness:

1. **Truncating a wordy headline gives you a wordy headline with the end cut off.** The cheapest way for a model to satisfy a hard `max_length` is to write the long sentence and stop typing. That is fitting, not writing — and #128 is a request for a different sentence.
2. **One long field would discard every other channel's copy.** `max_length` fails inside `_extract_cited_artefact`'s `model_validate`, surfacing as a `MalformedOutputError` carrying a raw pydantic traceback, throwing away a whole run to fix something an operator judges in seconds.

So the budget is enforced **where a length problem is actually decidable — the approval gate this artefact already has to pass.** `measure_copy_length` records each overage on the `ChannelCopy` (`over_budget`, hidden from the tool schema via `SkipJsonSchema` so the agent is neither shown it nor able to assert compliance in it), it rides into `marketing_artefact.body`, and `ArtefactBody.tsx` badges it *beside the offending line*: "63 chars · budget 60" next to the headline itself.

That is the answer to "what stops it being ignored": not that the model was asked nicely, but that its drift is measured, attributed per field, and on screen at the moment a human decides whether to ship it. Rendering it as a summary elsewhere, or only as a count, would make it advisory in the way #128 complains about — so the badge has its own test.

**Grossly over is still fatal.** Past `COPY_LENGTH_CEILING_MULTIPLE` (3x) the constraint was not applied at all — a 180-character headline is not a headline, whatever the channel — so there is nothing for an operator to weigh up and handing it over wastes their time. `CopyTooLongError`, a `PipelineError`, so `admin_app._pipeline_error_to_http` maps it to a **502 whose detail names the channel, the field, its length, its budget, and says to run copy generation again**. There is a test asserting that mapping, because that function maps the base class specifically "so a new pipeline error type cannot silently fall through as a 500" — and this is a new pipeline error type.

**The calibration, checked against the real report:** #128's own example measures 63 / 254 / 57. Over budget on all three fields, nowhere near the ceiling on any of them. It gets flagged for the operator and the run survives — which is right, because an operator called that copy "accurate, well-grounded and on-message".

## The two things I was told not to break

1. **#113's citation provenance guard.** Untouched. `measure_copy_length` runs *after* the citation guards and after the `channel_key`/`motion` join, on purpose: a run that fabricated a source must be reported as having fabricated a source, not as having written a long headline. `test_length_is_checked_after_the_citation_guards` pins that ordering with a run that does both at once.

2. **#131's 240s timeout, with no headroom left.** **This change does not make the copy agent do materially more work, and should reduce it.** The prompt grows by ~40 lines of instructions (one-off input tokens, no extra retrieval, no extra turns — `COPY_MAX_TURNS` and `timeout_seconds` are unchanged), and the whole point of the change is *shorter output*, which is where the generation time actually goes. The one thing that would have added agent-visible weight — the `over_budget` field — is `SkipJsonSchema`'d out of the tool schema for exactly that reason.

## Fail-first evidence

Tests written first. With the implementation stashed, the new suite fails on the absence of the constant itself:

```
ImportError: cannot import name 'COPY_LENGTH_BUDGET' from 'marketing.definitions'
```

That is a weak failure, so here is the sharper one — implementation restored, with **only** the `measure_copy_length(result.channels)` call in `extract_copy` commented out:

```
FAILED tests/test_marketing_copy_brevity.py::test_the_reported_copy_is_flagged_on_every_field_and_still_returned
FAILED tests/test_marketing_copy_brevity.py::test_copy_far_past_the_ceiling_is_rejected
FAILED tests/test_marketing_copy_brevity.py::test_copy_exactly_at_the_ceiling_is_flagged_rather_than_rejected
3 failed, 7 passed in 0.15s

E       Failed: DID NOT RAISE CopyTooLongError
E       AssertionError: assert [] == ['headline']
```

And the UI badge, before `ArtefactBody.tsx` changed:

```
 ❯ src/components/ArtefactBody.test.tsx:419:19
     expect(screen.getByText('63 chars · budget 60')).toBeInTheDocument()
 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

With the call restored:

```
587 passed, 4 warnings in 5.51s          # python, was 586
Test Files  20 passed (20)
     Tests  146 passed (146)             # web-admin, +2 new
```

`ruff check` / `ruff format --check` / `pyright` (0 errors) / `pnpm lint` / `pnpm typecheck` / `pnpm build` all clean; the pre-push `verify` gate passed every applicable check.

## What only a live run can judge

Whether the copy is **actually better**. Everything above proves the constraint exists, is measured, is disclosed and cannot silently drift from what the model was told — none of it proves the model writes a sharper headline when asked this way. #128 says as much itself ("worth generating one campaign before and after and comparing rather than assuming the prompt landed"), and that is why this says `Refs #128` and not a closing keyword: the observable that opened the issue is a paragraph of prose from a live agent run, and nothing in a green suite is evidence about it. Generate a campaign, compare against `fa6590f1`, then close by hand with what you saw.

Two specific things to watch on that run, both of which would show up as data rather than opinion:

- **The `over_budget` badges.** If copy still comes back flagged on every field, the prompt did not land and the number is doing the work alone.
- **Fewer `*_truncated` flags on the paid pack.** Paid channels are measured too, so paid copy should arrive with less for `_fit_to_limit` to trim. That is a side effect, not the goal, but it is a free signal.

Refs #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
