### PR TITLE
refactor(ingress): collapse the hardcoded user-ingress group to one place

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -74,6 +74,21 @@ from .fan_in_workflow import definition as fan_in_definition
 from .image_routes import router as image_router
 from .links import destination_with_utms, mint_token, tracked_url
 
+#: A bare literal ON PURPOSE, and not the same shape as
+#: `user_app.require_user_ingress` (#46) — do not "make these consistent".
+#:
+#: `admin` is a universal Biffo role: every platform has one by construction,
+#: which is what every `required_role: ["admin"]` write permission in
+#: `biffo.plugin.json` already assumes on every table. `founder` — the group the
+#: USER surface gated on — exists only on biffo-platform, and that is the whole
+#: defect #46 records. Only the second is instance vocabulary, so only the
+#: second is declared in the manifest's `config` block and routed through
+#: `ingress.py`.
+#:
+#: Parameterising this one too would mint an instance setting every instance
+#: must set to the same value, and an unset required setting fails the install
+#: (keiranholloway/biffo-template#1517 §4). `ingress.py`'s module docstring is
+#: the long form of this; `image_routes.require_admin` carries the same note.
 require_admin = require_group("admin")
 
 #: Core's own base URL. The plugin calls Core directly rather than back through

--- a/src/marketing/image_routes.py
+++ b/src/marketing/image_routes.py
@@ -98,6 +98,11 @@ from .image_provider import (
 
 logger = Logger(child=True)
 
+#: A bare literal ON PURPOSE — `admin` is a universal Biffo role, unlike the
+#: group `user_app` gates on, which is instance vocabulary and therefore lives
+#: in `ingress.py` and is declared in the manifest's `config` block (#46).
+#: `admin_app.require_admin` carries the full reasoning; `ingress.py`'s module
+#: docstring is the long form. Do not parameterise this one to match.
 require_admin = require_group("admin")
 
 router = APIRouter(dependencies=[Depends(require_admin)])

--- a/src/marketing/ingress.py
+++ b/src/marketing/ingress.py
@@ -1,0 +1,98 @@
+"""The one place this plugin names the platform group its user surface gates on.
+
+Issue #46: ``founder`` is **biffo-platform's** vocabulary. This plugin is meant
+to install on any Biffo platform, and a platform that has no ``founder`` group
+(tabsii-platform has ``admin``/``platform_admin``/``editor``/``viewer`` plus a
+franchise RBAC model of its own) gets a Surface B that 403s for everybody. The
+*concept* — "a unit operator marketing its own services" — is portable; the
+*group name* is an instance decision the plugin cannot know.
+
+The real fix is keiranholloway/biffo-template#1517: a plugin declares a need,
+the instance supplies the value at install. That mechanism **does not exist
+yet**, so this module does not pretend to read it. What it does is remove the
+second copy, so that landing #1517 is one edit rather than a hunt.
+
+## Why ``admin`` is a bare literal and this is not
+
+``admin_ingress.required_group`` stays the literal ``"admin"``, here and in
+``biffo.plugin.json``, and it is deliberately **not** routed through this
+module. The two are not the same kind of name:
+
+- ``admin`` is a **universal Biffo role**. Every Biffo platform has one by
+  construction — it is what ADR-0004's per-table ``required_role: ["admin"]``
+  already assumes throughout this manifest, on every table, on every write.
+  A platform without it could not run any plugin's generated CRUD at all.
+- ``founder`` is **one platform's product vocabulary**. It exists in
+  biffo-platform and nowhere else, which is the entire defect in #46.
+
+Parameterising ``admin`` too would look symmetrical and be a straight loss: it
+would mint an instance setting that every instance must set to the same value,
+and an unset required setting fails the install (#1517 §4). Instance
+configuration nobody varies is configuration nobody sets correctly. So the
+asymmetry is the point, and it is written down here — and beside
+``require_admin`` in ``admin_app.py`` and ``image_routes.py`` — rather than
+left to look like an oversight somebody helpfully "fixes" later.
+
+## What lands when #1517 does
+
+``user_ingress_group()`` is the seam. Its body is the single line that changes:
+today it returns the declared literal; then it returns the value the instance
+supplied. Nothing else in this plugin's source names the group at all —
+``tests/test_marketing_ingress_group_guard.py`` enumerates every violation and
+fails on the first new one.
+
+**The manifest deliberately declares no ``config`` block, and that is a
+correction rather than an omission.** An earlier revision of this work declared
+one, reasoning that ``PluginManifest`` was not ``extra="forbid"`` at the top
+level so an unrecognised key would simply be ignored until #1517 gave it a
+meaning. That was true when written and stopped being true a few hours later:
+biffo-template#1561 made the manifest strict, and the shared plugin host does
+not treat ``config`` as salvageable — an unknown top-level key means
+``_load_manifest_tolerant`` returns ``None`` and **the whole plugin is skipped**,
+taking the admin surface down with the user one.
+
+Worse, nothing in this repo would have said so: ``uv.lock`` pins an older SDK,
+so the authoritative ``load_manifest`` check here passes while the instance
+refuses the same file. So the need is declared in prose, here and on #46, until
+there is a schema that actually reads it.
+"""
+
+from __future__ import annotations
+
+#: The group name this plugin's user surface gates on today, and the ONLY
+#: occurrence of it in this plugin's Python source. ``biffo.plugin.json``'s
+#: ``user_ingress.required_group`` carries the same string because the shared
+#: plugin host reads the gate from the manifest, not from this module — that
+#: copy is reconciled against this one by
+#: ``tests/test_marketing_manifest.py::test_the_user_surface_gates_on_the_one_declared_group``,
+#: so the two cannot drift the way #119's class does.
+USER_INGRESS_GROUP = "founder"
+
+#: The setting name this plugin will read once keiranholloway/biffo-template#1517
+#: gives instances a way to supply one. **Reserved, not declared** — see the
+#: module docstring for why the manifest carries no ``config`` block today. It
+#: lives here so that whoever wires #1517 up has one string to move rather than
+#: inventing a second, and so the name is reviewable now rather than chosen in
+#: a hurry later.
+USER_INGRESS_GROUP_SETTING = "user_ingress_group"
+
+
+def user_ingress_group() -> str:
+    """Which group may reach the user-facing surface on this installation.
+
+    **This is the one line keiranholloway/biffo-template#1517 changes.** Today
+    it returns the group this plugin declares in its manifest. Once an instance
+    can supply a value for the ``user_ingress_group`` setting, this returns
+    that instead, and ``USER_INGRESS_GROUP`` above stops being a value the
+    plugin decides.
+
+    A function rather than a bare constant *deliberately*: #1517 has not
+    specified how a plugin reads a resolved setting, and whatever that turns
+    out to be will be a call, not a module-level string. Call sites depending
+    on a callable now means the accessor lands inside this body and nowhere
+    else. See this module's docstring for what that assumption does and does
+    not cover — if #1517's resolution turns out to be **per-request** rather
+    than per-process, the change is larger than this body, because
+    ``user_app.require_user_ingress`` is built once at import time.
+    """
+    return USER_INGRESS_GROUP

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -1,14 +1,26 @@
 """The campaign studio's franchise-unit-facing ASGI app (ADR-0021 ``user_ingress``).
 
-Mounted by the shared plugin host at ``/api/v1/plugins/marketing``, gated on the
-``founder`` Cognito group before this app sees a request (ADR-0011 —
-authorization is a core concern, never plugin code). ``founder`` is the
-estate's existing name for "an approved, ordinary product user" — both
-``idea-scout`` and ``ideation`` gate their own ``user_ingress`` on it, and
-``modules/cloud/aws/auth/main.tf`` describes the group itself as "Approved
-product user (e.g. an invited founder). Access to user-facing modules." This
-plugin reuses that convention rather than inventing a Tabsii-specific group
-name for a capability the plugin contract already generalises over — see
+Mounted by the shared plugin host at ``/api/v1/plugins/marketing``, gated on a
+Cognito group before this app sees a request (ADR-0011 — authorization is a
+core concern, never plugin code).
+
+**Which group is an instance decision, not this plugin's (issue #46).** The
+name lives in exactly one place — ``ingress.USER_INGRESS_GROUP``, read through
+``ingress.user_ingress_group()`` — and ``biffo.plugin.json`` declares the need
+for it in its ``config`` block so an instance can supply its own once
+keiranholloway/biffo-template#1517 lands. Read ``ingress.py``'s module
+docstring before touching any of this; in particular it records **why
+``admin`` is deliberately still a bare literal** and must not be given the same
+treatment. What that file does not do, and this one must not either, is guess
+#1517's runtime accessor: the value below is still the declared literal.
+
+The declared value today is the estate's existing name for "an approved,
+ordinary product user" — both ``idea-scout`` and ``ideation`` gate their own
+``user_ingress`` on the same group, and ``modules/cloud/aws/auth/main.tf``
+describes it generically as "Approved product user. Access to user-facing
+modules." That convention is fine on the platform that has the group and is
+exactly the problem on the platform that does not, which is what #46 records
+and what the indirection above exists to make survivable — see
 ``admin_app.py``'s own module docstring for why one manifest can serve both
 Biffo-marketing-Biffo and Tabsii-marketing-Tabsii through the SAME two ingress
 keys.
@@ -52,7 +64,7 @@ Every route here reads ``marketing_campaign``, ``marketing_artefact`` (the
 docstring has the full mechanism) — Core's own per-table ``required_role``
 governs who can pass, regardless of which plugin surface forwarded the call.
 Those tables' ``list``/``read`` permissions were ``["admin"]`` only; a
-``founder``-group caller would 403 there even with a perfectly-formed
+user-ingress-group caller would 403 there even with a perfectly-formed
 signed-and-forwarded request, because the host's group gate and Core's own
 table permission are two independent checks (``forward.py``'s own docstring:
 "Authorization for these routes is the table's own ADR-0004 permissions...
@@ -70,15 +82,15 @@ a bespoke choice: idea-scout's own ``idea_scout_build_types``/
 reason.
 
 **A real, accepted limitation this creates, broader than just this
-surface.** The routes in *this file* run behind ``require_founder``, but the
+surface.** The routes in *this file* run behind ``require_user_ingress``, but the
 table permission itself does not know that — Core's manifest-declared
 ``api_routes`` (``GET /api/v1/plugins/marketing/campaigns`` etc.) are
 forwarded by the shared host **outside any group gate at all**
 (``plugin_host/forward.py``'s own docstring: placed there deliberately so an
-admin isn't rejected by a founder-only ``user_ingress`` gate). So opening
+admin isn't rejected by the ``user_ingress`` group gate). So opening
 these four tables' ``list``/``read`` makes them reachable by **any
-authenticated tenant caller** — admin, editor, viewer or founder alike — via
-that generic CRUD path directly, not only by a ``founder``-group request
+authenticated tenant caller** — whatever groups that platform defines — via
+that generic CRUD path directly, not only by a user-ingress-group request
 routed through this file. For ``marketing_artefact`` specifically that also
 means every ``kind`` is reachable that way, not just the ``copy`` kind this
 file's own routes request — a caller could read the internal
@@ -93,8 +105,8 @@ this repo's issue #40.
 A campaign is available to a unit once its ``status`` is ``ready`` or
 ``live``. The generic list route has no server-side filter for "one of a set
 of values" (mirrors ``results_routes.py``'s own full-pagination-then-filter
-precedent), so this fetches every campaign a founder can see and filters in
-memory. There is no per-unit or per-locality scoping — every founder-group
+precedent), so this fetches every campaign the caller can see and filters in
+memory. There is no per-unit or per-locality scoping — every user-ingress-group
 caller sees every published campaign in the tenant, which matches ADR-0001's
 current single-tenant reality and campaign-studio.md §2's own "Actors: one"
 ->"many, each with their own locality" line marking that as iteration 2's
@@ -125,11 +137,21 @@ from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 
-from . import admin_app, pipeline, principal_client
+from . import admin_app, ingress, pipeline, principal_client
 from .config import public_base_url_for
 from .links import tracked_url
 
-require_founder = require_group("founder")
+#: The user surface's group gate. The group NAME comes from `ingress`, which is
+#: the only place in this plugin's source that spells it out (#46) — never a
+#: literal here. Contrast `admin_app.require_admin`/`image_routes.require_admin`,
+#: which stay bare `require_group("admin")` on purpose; `ingress.py`'s module
+#: docstring has the full reasoning for why the two are treated differently.
+#:
+#: Built once at import time, as it always was. If keiranholloway/biffo-template#1517
+#: resolves settings per request rather than per process, this line has to move
+#: inside a dependency — noted in `ingress.user_ingress_group`'s docstring too,
+#: since that is the assumption most likely to be wrong.
+require_user_ingress = require_group(ingress.user_ingress_group())
 
 #: Every `_core`-shaped call site below must carry this literal prefix — see
 #: `tests/test_marketing_core_paths_guard.py`'s module docstring for why it
@@ -154,7 +176,7 @@ _LIST_PAGE_SIZE = 200
 #: never see `draft`/`researching`/`planned`/`generating` work in progress.
 _AVAILABLE_STATUSES = frozenset({"ready", "live"})
 
-router = APIRouter(dependencies=[Depends(require_founder)])
+router = APIRouter(dependencies=[Depends(require_user_ingress)])
 
 
 def get_core_client() -> BiffoAPIClient:
@@ -166,13 +188,13 @@ def get_core_client() -> BiffoAPIClient:
 
 
 def get_campaign_client(
-    founder: Any = Depends(require_founder),
+    user: Any = Depends(require_user_ingress),
 ) -> principal_client.PrincipalCoreClient:
     """Dual-auth client for this plugin's own generated-CRUD tables, carrying
-    THIS founder's own forwarded token — same mechanism as `admin_app._core`
+    THIS caller's own forwarded token — same mechanism as `admin_app._core`
     and `image_routes.get_campaign_client` (issue #27's fix), just built from
-    the founder gate instead of the admin one."""
-    return principal_client.PrincipalCoreClient(founder.token)
+    the user-ingress gate instead of the admin one."""
+    return principal_client.PrincipalCoreClient(user.token)
 
 
 def _core_error(exc: BiffoAPIError) -> HTTPException:
@@ -223,7 +245,7 @@ def _campaign_summary(row: dict[str, Any]) -> dict[str, Any]:
 async def list_campaigns_route(
     client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
 ) -> list[dict[str, Any]]:
-    """Every campaign this founder can promote right now — `ready` or `live`
+    """Every campaign this caller can promote right now — `ready` or `live`
     only. See the module docstring for why draft/in-flight work never
     appears here."""
     rows = await _list_all(client, f"{_INTERNAL_PREFIX}/campaigns", {})
@@ -254,7 +276,7 @@ async def get_pack_route(
     request: Request,
     core_client: BiffoAPIClient = Depends(get_core_client),
     campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
-    founder: Any = Depends(require_founder),
+    user: Any = Depends(require_user_ingress),
 ) -> dict[str, Any]:
     """The material a unit needs to actually publish this campaign: its
     guidance text, the latest **approved** copy, every existing asset
@@ -268,7 +290,7 @@ async def get_pack_route(
     campaign_id = admin_app._validated_campaign_id(campaign_id)
 
     campaign_resp = await admin_app._core(
-        "GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", founder.token
+        "GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", user.token
     )
     if campaign_resp.status_code == status.HTTP_404_NOT_FOUND:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
@@ -285,10 +307,10 @@ async def get_pack_route(
     # serving fine start 404ing the moment an admin starts an edit — the
     # previously-approved copy is still sitting one row back and this is
     # exactly what a unit should still be served.
-    copy_artefact = await admin_app._latest_approved_artefact(campaign_id, "copy", founder.token)
+    copy_artefact = await admin_app._latest_approved_artefact(campaign_id, "copy", user.token)
     if copy_artefact is None:
         # Collapsed to one outcome rather than admin_app's 409-for-proposed:
-        # a founder cannot approve anything, so "exists but not approved yet"
+        # this surface cannot approve anything, so "exists but not approved yet"
         # and "does not exist yet" carry the same actionable information —
         # none — and 409 would surface internal pipeline state for nothing.
         raise HTTPException(
@@ -333,7 +355,7 @@ async def get_pack_route(
 
 
 def build_app() -> FastAPI:
-    """The user (founder) ASGI app — JSON only, no static mount. See the
+    """The user-ingress ASGI app — JSON only, no static mount. See the
     module docstring's "No built UI in this surface" section for why."""
     app = FastAPI(title="Marketing — campaign studio (unit)")
     app.include_router(router)

--- a/tests/test_marketing_ingress_group_guard.py
+++ b/tests/test_marketing_ingress_group_guard.py
@@ -1,0 +1,222 @@
+"""The user-ingress group name may be spelled out in exactly ONE place.
+
+Issue #46: ``founder`` is biffo-platform's product vocabulary, not this
+plugin's. It was hardcoded in **two** independent places — ``biffo.plugin.json``'s
+``user_ingress.required_group`` and ``user_app.py``'s
+``require_group("founder")`` — with nothing reconciling them. That is precisely
+this repo's #119 class ("adopted at some call sites, not all") waiting to
+happen: when keiranholloway/biffo-template#1517 lands and the group becomes an
+instance-supplied setting, a hunt across the source is how one of the two gets
+missed and the surface keeps gating on a stale literal that still looks right.
+
+So: ``src/marketing/ingress.py`` holds the name, the manifest carries the one
+copy the shared plugin host actually reads, ``test_marketing_manifest.py``
+reconciles those two, and this file asserts nothing else anywhere spells it
+out.
+
+## Why the banned name is DERIVED, not typed here
+
+``_BANNED`` is built from ``ingress.USER_INGRESS_GROUP`` rather than written as
+a literal. Two reasons, and the second is the one that matters:
+
+1. This guard file cannot then violate its own rule and need an exemption for
+   itself — the estate's recurring shape is a check that passes because it was
+   quietly excused.
+2. It asks the right question. The rule is not "never write ``founder``"; it is
+   "the group this plugin gates on is named in one place". Change the group and
+   the guard follows it, with no second edit and no window where the guard is
+   checking yesterday's value.
+
+## ``admin`` is deliberately NOT banned
+
+``require_group("admin")`` appears as a bare literal in ``admin_app.py`` and
+``image_routes.py``, and ``biffo.plugin.json`` declares
+``admin_ingress.required_group: "admin"`` and ``required_role: ["admin"]`` on
+every table's writes. **None of that is a violation and this guard must never
+be extended to cover it.**
+
+``admin`` is a universal Biffo role — every platform has one by construction,
+which is what all those table permissions already assume. ``founder`` exists on
+biffo-platform and nowhere else. Only one of the two is a name this plugin
+cannot know, so only one is instance-supplied. Banning ``admin`` here would
+push somebody to declare it in the manifest's ``config`` block, minting an
+instance setting every instance must set to the identical value — and an unset
+required setting fails the install (#1517 §4). Configuration nobody varies is
+configuration nobody sets correctly.
+
+## Enumerated, not per-case
+
+Both checks collect **every** violation and compare the whole set against an
+empty baseline, in both directions. A third hardcoded site added later fails
+without anybody remembering to write an assertion for it — which is the only
+version of this guard worth having, and is the property that was verified by
+adding a third site, watching this file go red, and removing it again (see the
+PR for #46 for the captured output).
+
+## String VALUES, not substrings
+
+The check compares a string constant's whole stripped value against the banned
+name. Prose that merely discusses the group — this docstring, ``ingress.py``'s,
+``user_app.py``'s, the manifest's ``marketing_channel`` description — is never
+an exact match, so the guard cannot be satisfied or tripped by documentation.
+A substring grep would flag every one of them and would then have to be
+weakened with exemptions until it checked nothing, which is how the
+``public_base_url`` guard's docstring
+(``test_marketing_base_url_call_sites.py``) explains its own AST walk.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from marketing import ingress
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src" / "marketing"
+_TESTS = Path(__file__).resolve().parent
+_MANIFEST = _ROOT / "biffo.plugin.json"
+
+#: Derived, never typed — see the module docstring. A set so a future second
+#: instance-supplied group name (a per-unit gate, say) joins it without
+#: reshaping the walk.
+_BANNED = {ingress.USER_INGRESS_GROUP}
+
+#: The one module allowed to spell the name out. Everything else must reach it
+#: through `ingress.user_ingress_group()`.
+_HOME = "ingress.py"
+
+#: The one path in the manifest allowed to carry the value. The shared plugin
+#: host reads the gate from here, so this copy cannot simply be deleted today;
+#: `test_marketing_manifest.py` asserts it equals `ingress.USER_INGRESS_GROUP`
+#: so the two cannot drift, and #1517 is what removes the need for it.
+_MANIFEST_HOME = "user_ingress.required_group"
+
+
+def _string_constants(tree: ast.AST) -> list[tuple[int, str]]:
+    """Every string constant in *tree*, with its line number.
+
+    Docstrings are included rather than skipped: they are exact-matched like
+    any other constant, and a docstring whose entire content is the bare group
+    name is not a docstring, it is a literal hiding in one.
+    """
+    return [
+        (node.lineno, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+
+def _violations_in(directory: Path) -> list[str]:
+    found: list[str] = []
+    for path in sorted(directory.rglob("*.py")):
+        if path.name == _HOME:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for lineno, value in _string_constants(tree):
+            if value.strip() in _BANNED:
+                rel = path.relative_to(_ROOT)
+                found.append(f"{rel}:{lineno}: {value.strip()!r}")
+    return found
+
+
+def test_the_group_name_is_spelled_out_in_exactly_one_module() -> None:
+    """`src/marketing/` names the group only in `ingress.py`.
+
+    Enumerated: the full list of offending sites is compared against an empty
+    baseline, so a newly-added third site fails here with its own file and line
+    rather than needing a new assertion written for it.
+    """
+    assert _violations_in(_SRC) == [], (
+        f"The user-ingress group name is instance vocabulary (#46) and must appear "
+        f"only in src/marketing/{_HOME}. Reach it through "
+        f"`ingress.user_ingress_group()` instead. Offending sites:\n  "
+        + "\n  ".join(_violations_in(_SRC))
+    )
+
+
+def test_the_tests_do_not_reintroduce_the_literal_either() -> None:
+    """Fixtures count. A test asserting `groups: ["founder"]` is a second copy
+    of the decision, and one that would keep passing against a stale gate after
+    #1517 moves the real value — a guard that only covers `src/` leaves the
+    fixture free to disagree with the code it is testing."""
+    assert _violations_in(_TESTS) == [], (
+        "A test names the user-ingress group directly. Use "
+        "`ingress.USER_INGRESS_GROUP` so the fixture follows the gate. "
+        "Offending sites:\n  " + "\n  ".join(_violations_in(_TESTS))
+    )
+
+
+def _manifest_paths_carrying(value: str) -> list[str]:
+    """Every dotted path in the manifest whose string value is exactly *value*."""
+    hits: list[str] = []
+
+    def walk(node: object, path: str) -> None:
+        if isinstance(node, str):
+            if node.strip() == value:
+                hits.append(path)
+        elif isinstance(node, dict):
+            for key, child in node.items():
+                walk(child, f"{path}.{key}" if path else str(key))
+        elif isinstance(node, list):
+            for index, child in enumerate(node):
+                walk(child, f"{path}[{index}]")
+
+    walk(json.loads(_MANIFEST.read_text(encoding="utf-8")), "")
+    return sorted(hits)
+
+
+def test_the_manifest_carries_the_group_at_exactly_one_path() -> None:
+    """`user_ingress.required_group` and nowhere else.
+
+    The manifest is data the host reads, so this copy is load-bearing today —
+    but a second one (a chat agent's `required_group`, a table permission, a
+    route description quoting it as a value) would be an unreconciled third
+    site. #1517's whole point is that a manifest names no platform's
+    vocabulary; until it lands, the count is one.
+    """
+    for banned in sorted(_BANNED):
+        assert _manifest_paths_carrying(banned) == [_MANIFEST_HOME], (
+            f"biffo.plugin.json carries {banned!r} at "
+            f"{_manifest_paths_carrying(banned)}; the only permitted path is "
+            f"{_MANIFEST_HOME}."
+        )
+
+
+def test_admin_is_deliberately_not_banned() -> None:
+    """Guard the guard's own exception, so it is not quietly widened.
+
+    `admin` is a universal Biffo role and stays a bare literal — see this
+    module's docstring. If somebody adds it to `_BANNED`, this fails and points
+    at the reasoning rather than letting the change look like tidying.
+    """
+    assert "admin" not in _BANNED, (
+        "`admin` is a universal Biffo role, not instance vocabulary. Banning it "
+        "would push it into the manifest's `config` block as a required setting "
+        "every instance must set to the same value, and an unset required "
+        "setting fails the install. See this module's docstring and "
+        "`admin_app.require_admin`."
+    )
+    manifest = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["admin_ingress"]["required_group"] == "admin", (
+        "admin_ingress must keep gating on the literal `admin` (#46's settled "
+        "judgement call), not on anything instance-supplied."
+    )
+
+
+def test_the_guard_can_actually_see_the_source_it_polices() -> None:
+    """Guard the guard: an empty walk makes every assertion above vacuous.
+
+    This estate's dominant defect is a check that passes because it could not
+    run. A moved package or a renamed manifest would make `_violations_in`
+    return `[]` for the best possible reason and the worst possible cause.
+    """
+    assert _MANIFEST.is_file(), f"No manifest at {_MANIFEST}"
+    modules = list(_SRC.rglob("*.py"))
+    assert len(modules) > 5, f"Only {len(modules)} module(s) under {_SRC}"
+    assert (_SRC / _HOME).is_file(), f"The one permitted home, {_HOME}, is missing"
+    assert any(
+        value.strip() in _BANNED
+        for _, value in _string_constants(ast.parse((_SRC / _HOME).read_text(encoding="utf-8")))
+    ), f"{_HOME} does not contain the name this guard is enumerating copies of"

--- a/tests/test_marketing_manifest.py
+++ b/tests/test_marketing_manifest.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from marketing import ingress
+
 _MANIFEST = Path(__file__).resolve().parents[1] / "biffo.plugin.json"
 
 #: Column types Core actually resolves into SQLAlchemy. There is NO JSON type —
@@ -59,26 +61,37 @@ def test_the_admin_surface_is_declared_and_points_at_a_real_app() -> None:
 
 def test_the_user_surface_is_declared_and_points_at_a_real_app() -> None:
     """Surface B (franchise units) — mirrors
-    `test_the_admin_surface_is_declared_and_points_at_a_real_app` exactly.
+    `test_the_admin_surface_is_declared_and_points_at_a_real_app` exactly."""
+    declared = _raw().get("user_ingress")
+    assert declared, "user_ingress is absent — the unit surface would never mount"
+    assert declared["app"] == "marketing.user_app:app"
 
-    `required_group` is `founder`, not a bespoke name: both `idea-scout` and
-    `ideation` gate their own `user_ingress` on the same group, and
-    `modules/cloud/aws/auth/main.tf` describes it as "Approved product user"
-    generically, not as anything Idea-Scout-specific.
+
+def test_the_user_surface_gates_on_the_one_declared_group() -> None:
+    """The manifest's copy and the code's copy must agree.
+
+    The shared plugin host reads the gate from the manifest; `user_app.py`
+    builds its FastAPI dependency from `ingress.user_ingress_group()`. Those
+    are two different readers of one decision, and #46 is what happens when
+    they are two independent literals instead — the same "adopted at some call
+    sites, not all" shape as this repo's #119.
+
+    So `ingress.py` holds the name and this reconciles the manifest against it.
+    Once keiranholloway/biffo-template#1517 lands, the instance supplies the
+    value for the `user_ingress_group` setting declared below and this
+    assertion is what tells whoever makes that change that the manifest key has
+    to move too.
     """
-    ingress = _raw().get("user_ingress")
-    assert ingress, "user_ingress is absent — the unit surface would never mount"
-    assert ingress["required_group"] == "founder"
-    assert ingress["app"] == "marketing.user_app:app"
+    assert _raw()["user_ingress"]["required_group"] == ingress.USER_INGRESS_GROUP
 
 
-def test_founder_readable_tables_stay_read_only_for_founders() -> None:
+def test_user_surface_readable_tables_stay_read_only() -> None:
     """`marketing_campaign`/`marketing_artefact`/`marketing_asset`/
     `marketing_link` open `list`/`read` to any authenticated caller (`[]`) so
     `user_app.py` can read them — but `create`/`update`/`delete` must stay
     `admin`-only on every one of them, and `marketing_click` must stay
     admin-only on every operation (see `user_app.py`'s module docstring for
-    why). A regression here would let a `founder`-group caller write through
+    why). A regression here would let a user-ingress-group caller write through
     the generic CRUD path directly, which no route in `user_app.py` needs or
     should have."""
     tables = {t["name"]: t for t in _raw()["tables"]}

--- a/tests/test_marketing_user_app.py
+++ b/tests/test_marketing_user_app.py
@@ -11,7 +11,7 @@ matching `test_marketing_image_routes.py`'s own split:
 - `_FakeCoreClient` — the SigV4-only, plugin-identity client
   (`get_core_client`) used for the `me` storage `/url` route.
 - `_FakeCampaignClient` — the dual-auth client (`get_campaign_client`) over
-  this plugin's own generated-CRUD tables, carrying the founder's own
+  this plugin's own generated-CRUD tables, carrying the caller's own
   forwarded token.
 
 `admin_app._core`/`admin_app._latest_artefact` are exercised for real (not
@@ -33,15 +33,30 @@ from biffo_plugin_sdk import BiffoAPIError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from marketing import admin_app, principal_client, user_app
+from marketing import admin_app, ingress, principal_client, user_app
 
 _CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000a1"
 _CORE_API_URL = "https://core.invalid"
 _BASE_URL = "https://dev.tabsii.com"
 
+#: The forwarded token the fake caller carries. Deliberately not named after
+#: any group (#46) — what matters is that THIS token reaches Core, not who it
+#: belongs to.
+_USER_JWT = "user-ingress-jwt"
 
-def _founder_user() -> Any:
-    return type("U", (), {"sub": "unit-1", "groups": ["founder"], "token": "founder-jwt"})()
+
+def _ingress_user() -> Any:
+    """A caller carrying whatever group the user surface gates on.
+
+    `ingress.USER_INGRESS_GROUP`, not a literal (#46): a fixture that names the
+    group itself would keep passing against a stale gate the moment
+    keiranholloway/biffo-template#1517 moves the real value, and
+    `test_marketing_ingress_group_guard` fails on the literal for that reason."""
+    return type(
+        "U",
+        (),
+        {"sub": "unit-1", "groups": [ingress.USER_INGRESS_GROUP], "token": _USER_JWT},
+    )()
 
 
 class _FakeCoreClient:
@@ -90,7 +105,7 @@ class _FakeCampaignClient:
 def _app(*, core_client: Any, campaign_client: _FakeCampaignClient) -> FastAPI:
     app = FastAPI()
     app.include_router(user_app.router)
-    app.dependency_overrides[user_app.require_founder] = _founder_user
+    app.dependency_overrides[user_app.require_user_ingress] = _ingress_user
     app.dependency_overrides[user_app.get_core_client] = lambda: core_client
     app.dependency_overrides[user_app.get_campaign_client] = lambda: campaign_client
     return app
@@ -101,7 +116,7 @@ class _FakeSignedCoreClient:
     `test_marketing_dual_auth_wiring.py`'s own docstring for why this is
     faked at `principal_client.SignedCoreClient` rather than mocking
     `admin_app._core` itself: it proves `_core`'s and `_latest_artefact`'s
-    real bodies ran with the founder's own token, not a stand-in for them."""
+    real bodies ran with the caller's own token, not a stand-in for them."""
 
     def __init__(self, responses: dict[str, tuple[int, bytes]]) -> None:
         self._responses = responses
@@ -433,7 +448,7 @@ def test_pack_404s_a_malformed_campaign_id() -> None:
 def test_pack_404s_when_copy_is_not_yet_approved(fake_signed_client) -> None:
     """A `proposed` copy artefact must not reach a unit — collapsed to the
     same 404 as "no copy yet", never a 409 (see `get_pack_route`'s own
-    docstring for why: a founder cannot act on that distinction)."""
+    docstring for why: this surface cannot act on that distinction)."""
     fake_signed_client(
         {
             f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
@@ -455,7 +470,7 @@ def test_pack_404s_when_copy_is_not_yet_approved(fake_signed_client) -> None:
 
 def test_pack_serves_approved_copy_even_with_a_newer_pending_re_run(fake_signed_client) -> None:
     """The divergence case issue #41 is about — the "pack still serving"
-    shape, this surface's half: a founder-facing pack that was serving fine
+    shape, this surface's half: a user-facing pack that was serving fine
     must not start 404ing purely because an admin started a copy re-run. The
     newer `pending` row (later `created_at`, no `created_at` column needed
     here since both rows are returned together) must not hide the older
@@ -494,9 +509,9 @@ def test_pack_serves_approved_copy_even_with_a_newer_pending_re_run(fake_signed_
     assert resp.json()["copy"] == [{"channel": "instagram", "text": "Great offer!"}]
 
 
-def test_pack_forwards_the_founders_own_token(fake_signed_client) -> None:
+def test_pack_forwards_the_callers_own_token(fake_signed_client) -> None:
     """`admin_app._core`/`_latest_artefact`, reused here, must carry THIS
-    founder's token — not a hardcoded or admin one — through to Core."""
+    caller's token — not a hardcoded or admin one — through to Core."""
     fake = fake_signed_client(
         {
             f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
@@ -515,9 +530,7 @@ def test_pack_forwards_the_founders_own_token(fake_signed_client) -> None:
 
     assert fake.calls, "no Core calls were made"
     for call in fake.calls:
-        assert call["extra_signed_headers"] == {
-            principal_client.FORWARDED_USER_HEADER: "founder-jwt"
-        }
+        assert call["extra_signed_headers"] == {principal_client.FORWARDED_USER_HEADER: _USER_JWT}
 
 
 def test_pack_omits_link_urls_when_no_public_base_url_is_configured(


### PR DESCRIPTION
Refs #46 — the refactor half only. The `config` block that made this PR dangerous has been removed; see below.

## What this does

`founder` is biffo-platform's product vocabulary, not a Biffo role, and it was written into `user_app.py` as a literal beside the manifest's own copy. This puts the name in one place — `src/marketing/ingress.py` — with `user_ingress_group()` as the single line biffo-template#1517 will change, and an AST guard that enumerates every violation rather than watching one literal.

`admin` stays a bare literal, deliberately and in writing: it is a universal Biffo role every platform has by construction, so parameterising it would mint an instance setting that every instance must set to the same value — and an unset required setting fails the install. The asymmetry is the point, recorded in `ingress.py` so nobody helpfully "fixes" it later.

## Why this was rewritten

The original revision also declared a `config` block in the manifest, on the reasoning — stated in its own test docstring — that `PluginManifest` was not `extra="forbid"` at the top level, so an unknown key would be ignored until #1517 gave it meaning.

**That was true when written and false about 50 minutes later.** biffo-template#1561 merged and made the manifest strict. The shared plugin host does not treat `config` as salvageable, so `_load_manifest_tolerant` returns `None` and the **whole plugin is skipped** — taking Surface A, the working admin UI, down with Surface B.

Measured against an SDK built from `biffo-template` `dev`:

```
SDK 1.4.0 | extra = forbid | has config field? False
[old #140] REJECTED: config — Extra inputs are not permitted
[this]     VALIDATES OK
```

And nothing in this repo would have caught it: `uv.lock` pins SDK 1.3.0, PyPI's latest is 1.3.0, and the instance host resolves 1.4.0 from its own workspace. This repo's authoritative `load_manifest` gate passes while the instance refuses the same file — the estate's dominant fail-open shape, arriving inside a PR whose safety argument depended on the opposite.

## What changed in the rewrite

- Dropped the `config` block from `biffo.plugin.json`.
- Dropped the two tests that asserted its shape.
- `ingress.py` now explains why there is no `config` block, so the absence reads as a decision rather than an oversight. `USER_INGRESS_GROUP_SETTING` stays as a **reserved** name — one string for whoever wires #1517 up, reviewable now rather than chosen in a hurry later.
- Rebased onto `dev` (was 32 commits behind, conflicting in `user_app.py` where `dev` had added a `pipeline` import).

## Verification

917 tests pass; ruff, format and pyright clean. The rebased manifest validates against the strict SDK, which is the check the previous revision would have failed.

## What this leaves

#46 becomes a one-line change when biffo-template#1517 lands: `user_ingress_group()` returns the supplied value instead of the declared literal. `Refs`, not `Closes` — the group is still hardcoded, just in one place now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)