### PR TITLE
fix(research): move research back to a model whose :online grounding works

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -953,10 +953,43 @@ def research_search_query(*, agent_name: str, brief: Mapping[str, Any] | None) -
 #: Research also requires OpenRouter's ``:online`` suffix (live web results
 #: attached to the turn) for the same reason idea-scout's does — the search
 #: capability travels with the model id, so it cannot be silently
-#: half-configured by a missing Brave key. Sonnet 5 keeps `:online`; the suffix
-#: is a routing directive OpenRouter applies to any supported chat model, not a
-#: per-model capability that a tier change can drop.
-DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-5:online"
+#: half-configured by a missing Brave key.
+#:
+#: **Research stays on Sonnet 4 while the rest of the pipeline is Claude 5, and
+#: that is deliberate (issue #136).** The paragraph that used to sit here said
+#: "Sonnet 5 keeps ``:online``; the suffix is a routing directive OpenRouter
+#: applies to any supported chat model, not a per-model capability that a tier
+#: change can drop." That was reasonable and it is false. Measured on tabsii dev:
+#:
+#: =========================  ============  =========================================
+#: ``definition_snapshot``    annotations   findings on a query it cannot know
+#: =========================  ============  =========================================
+#: ``sonnet-4:online``        5             produced
+#: ``sonnet-5:online``        0             ``[]``
+#: =========================  ============  =========================================
+#:
+#: The second column is the run's own record of what retrieval returned. Every
+#: ``sonnet-5:online`` run since #108 reports **zero**, and a deliberate probe —
+#: asking for the current UK Bank Rate and the MPC decision date, which is
+#: trivially searchable and cannot be answered from weights — came back with no
+#: findings at all. Grounding is not happening on that route.
+#:
+#: **Why this was not obvious, and is worth stating.** The same model cheerfully
+#: cited nine deep, real-looking URLs on a *franchise software* brief — a topic
+#: it can answer from training. So the failure presents as good output on
+#: familiar subjects and honest emptiness on unfamiliar ones, which is the most
+#: expensive shape it could have: every count-based citation check passes, the
+#: artefact reads well, and the sources were never retrieved.
+#:
+#: To the model's credit it did **not** fabricate when it had nothing — it
+#: returned ``findings: []`` rather than inventing a Bank Rate. The problem is
+#: provenance, not honesty.
+#:
+#: Revisit when OpenRouter's web plugin demonstrably supports a Claude 5 route.
+#: The test is cheap and stated above: run research on a fact that post-dates
+#: training and read ``annotations``. Do not move this constant on the strength
+#: of a model being newer — that is exactly what #108 did.
+DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-4:online"
 #: Neither synthesis, positioning nor channel planning searches — all three
 #: reason over what they are given — so none of them needs `:online`.
 DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-5"

--- a/tests/test_marketing_stage_models.py
+++ b/tests/test_marketing_stage_models.py
@@ -41,12 +41,42 @@ _STAGE_MODELS = {
 }
 
 
+#: Research is deliberately NOT on Claude 5 — see issue #136 and
+#: `DEFAULT_RESEARCH_MODEL`'s docstring. Named here rather than special-cased
+#: inline so the exception is one reviewable fact, not a condition buried in an
+#: assertion.
+_GROUNDED_STAGE = "research"
+
+
 @pytest.mark.parametrize(("stage", "model"), sorted(_STAGE_MODELS.items()))
 def test_every_stage_runs_on_the_claude_5_family(stage: str, model: str) -> None:
-    """A stage left on an older generation bills and succeeds — assert it."""
+    """A stage left on an older generation bills and succeeds — assert it.
+
+    Research is exempt, and the exemption is the point rather than a
+    concession. #62 moved it to `sonnet-5:online` on the reasoning that
+    `:online` is a routing directive applied to any supported chat model. That
+    is false: measured on tabsii dev, every `sonnet-5:online` run reports
+    **zero** `annotations`, and a probe for a fact that post-dates training
+    (the current UK Bank Rate) returned `findings: []` — while the same model
+    cited nine plausible URLs on a topic it could answer from memory.
+    Grounding, not model recency, is what research is for.
+    """
     base = model.split(":", 1)[0]
 
     assert base.startswith("anthropic/claude-"), f"{stage} is not on an Anthropic slug: {model!r}"
+
+    if stage == _GROUNDED_STAGE:
+        # Asserted positively rather than skipped: research must stay on a
+        # route whose grounding has actually been observed, so silently
+        # drifting it forward again fails here rather than in production.
+        assert model == "anthropic/claude-sonnet-4:online", (
+            "research must stay on a model whose `:online` grounding has been "
+            f"verified live (#136); got {model!r}. If you are moving it, run "
+            "research against a fact that post-dates training and confirm "
+            "`annotations` comes back non-empty first."
+        )
+        return
+
     assert base.endswith("-5"), f"{stage} is not on the Claude 5 family: {model!r}"
 
 


### PR DESCRIPTION
fix(research): move research back to a model whose :online grounding works

Research has not been grounded since #108. Every `sonnet-5:online` run
reports zero `annotations`, so its citations come from the model's
training data rather than from retrieval.

## Evidence, measured on tabsii dev

| `definition_snapshot.model` | annotations | findings on an unknowable query |
| --- | --- | --- |
| `anthropic/claude-sonnet-4:online` | 5 | produced |
| `anthropic/claude-sonnet-5:online` | 0 | `[]` |

Annotations went 5 -> 0 at the deploy carrying #108 and have been 0 on
every run since. #120 shipped in the same deploy and looked like the
cause; it is not.

The decisive probe: a brief asking for the current UK Bank Rate and MPC
decision date — trivially searchable, impossible from weights. Both
research agents returned `findings: []`. If `:online` were grounding,
the provider would have injected results.

Ruled out along the way: the `:online` suffix is intact in both
snapshots, and the bare model id in the run `result` is OpenRouter
normalising its own response — the sonnet-4 run reports a bare id too
while carrying five annotations, so that field proves nothing.

## Why nobody noticed

The same model cited nine deep, real-looking URLs on a franchise-software
brief — a topic it can answer from memory. So the failure looks like good
output on familiar subjects and honest emptiness on unfamiliar ones.
Every count-based citation check passes and the artefact reads well.

To the model's credit it did not fabricate when it had nothing: it
returned an empty findings list rather than inventing a Bank Rate. The
problem is provenance, not honesty.

## The claim this replaces

`DEFAULT_RESEARCH_MODEL`'s docstring asserted "Sonnet 5 keeps `:online`;
the suffix is a routing directive OpenRouter applies to any supported
chat model, not a per-model capability that a tier change can drop."
Reasonable, and false. Corrected in place with the measurement.

`test_every_stage_runs_on_the_claude_5_family` pinned the same belief. It
is REPLACED rather than relaxed: research is asserted positively against
a route whose grounding has been observed, so drifting it forward again
fails here rather than in production. The other four stages still must be
Claude 5 — none of them searches, so the tier move was right for them.

Revisit when OpenRouter's web plugin demonstrably supports a Claude 5
route. The test is cheap and written down: run research on a fact that
post-dates training and read `annotations`.

Refs #136 — deliberately not `Closes`. The issue also asks whether the
breadth instrument itself is sound; this fixes the grounding it was
correctly reporting on, and the instrument should be re-read on a live
run before that half is called settled.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
