### PR TITLE
feat(web-admin): make the open campaign addressable so it can be shared

### DIFF
--- a/web-admin/src/App.test.tsx
+++ b/web-admin/src/App.test.tsx
@@ -230,3 +230,85 @@ describe('minting a tracked link from the campaign list', () => {
     expect(screen.getByLabelText('Channel')).toBeVisible()
   })
 })
+
+describe('deep linking to a campaign (#142)', () => {
+  const ID = '5380e9cf-457f-4932-a7ff-c1c6986524e5'
+
+  /** Campaigns fetch, with `/channels` routed separately — see the note on
+   *  'lists campaigns it receives' for why a blanket response is wrong. */
+  function stubFetch(campaigns: unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        typeof url === 'string' && url.endsWith('/channels')
+          ? Promise.resolve({ ok: true, json: async () => [] })
+          : Promise.resolve({ ok: true, json: async () => campaigns }),
+      ),
+    )
+  }
+
+  /** Put the browser on a URL asking for `campaign`, as a shared link would. */
+  function locationAsking(campaign: string | null) {
+    const search = campaign === null ? '' : `?campaign=${campaign}`
+    window.history.replaceState(null, '', `/api/v1/plugins/marketing/admin${search}`)
+  }
+
+  afterEach(() => locationAsking(null))
+
+  it('opens the campaign a shared link names, without anyone clicking', async () => {
+    // The whole point: a colleague pastes the URL and lands on the campaign.
+    locationAsking(ID)
+    stubFetch([{ id: ID, name: 'Shared campaign', status: 'draft', destination_url: null }])
+
+    render(<App />)
+
+    expect(await screen.findByRole('heading', { name: 'Shared campaign' })).toBeInTheDocument()
+  })
+
+  it('says why when the link names a campaign this reader cannot see', async () => {
+    // Deleted, or another tenant's: it is simply absent from the tenant-scoped
+    // list. Rendering an empty studio would be the wrong answer.
+    locationAsking(ID)
+    stubFetch([{ id: 'another-id', name: 'Not the one', status: 'draft', destination_url: null }])
+
+    render(<App />)
+
+    expect(await screen.findByText(/could not be opened/i)).toBeInTheDocument()
+  })
+
+  it('ignores a junk id and shows the list rather than an error page', async () => {
+    window.history.replaceState(null, '', '/api/v1/plugins/marketing/admin?campaign=nonsense')
+    stubFetch([{ id: ID, name: 'Spring demo push', status: 'draft', destination_url: null }])
+
+    render(<App />)
+
+    expect(await screen.findByText('Spring demo push')).toBeInTheDocument()
+    expect(screen.queryByText(/could not be opened/i)).not.toBeInTheDocument()
+  })
+
+  it('puts the campaign in the address bar when one is opened', async () => {
+    stubFetch([{ id: ID, name: 'Spring demo push', status: 'draft', destination_url: null }])
+    render(<App />)
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
+
+    expect(window.location.search).toBe(`?campaign=${ID}`)
+  })
+
+  it('takes it back out when the campaign is closed', async () => {
+    // A stale `?campaign=` on the list view would make the address bar
+    // disagree with the screen.
+    stubFetch([{ id: ID, name: 'Spring demo push', status: 'draft', destination_url: null }])
+    render(<App />)
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open' }))
+    // Asserted before closing so this cannot pass vacuously: without the
+    // feature the search string is empty at BOTH points, and a test that only
+    // checked the end state would report success against no implementation.
+    expect(window.location.search).toBe(`?campaign=${ID}`)
+
+    await userEvent.click(await screen.findByRole('button', { name: /Back to campaigns/i }))
+
+    expect(window.location.search).toBe('')
+  })
+})

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { CampaignDetail } from './components/CampaignDetail'
 import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
+import { campaignUrl, readCampaignParam } from './lib/campaignLink'
 import { destinationSuggestions } from './lib/destinationSuggestions'
 import { useChannelTaxonomy } from './lib/useChannelTaxonomy'
 
@@ -19,6 +20,16 @@ export default function App() {
   const [campaigns, setCampaigns] = useState<Campaign[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<Campaign | null>(null)
+  // The id the URL is asking for (#142). Tracked separately from `selected`
+  // because it exists BEFORE the campaigns are fetched — a shared link is
+  // read on mount, and can only be resolved to a campaign once the list
+  // arrives. Kept in state rather than read from `window` at render time so
+  // that browser back/forward, which fires `popstate` without re-mounting,
+  // actually re-renders.
+  const [linkedId, setLinkedId] = useState<string | null>(() =>
+    readCampaignParam(window.location.search),
+  )
+  const [linkError, setLinkError] = useState<string | null>(null)
 
   const [name, setName] = useState('')
   const [destination, setDestination] = useState('')
@@ -38,6 +49,55 @@ export default function App() {
 
   useEffect(load, [])
 
+  // Back/forward between the list and a campaign. `popstate` fires without a
+  // re-mount, so without this the address bar and the screen disagree — the
+  // reader presses Back, the URL changes, and the same campaign stays open.
+  useEffect(() => {
+    function onPopState() {
+      setLinkedId(readCampaignParam(window.location.search))
+      setLinkError(null)
+    }
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
+  }, [])
+
+  // Resolve the URL's campaign id against the fetched list.
+  //
+  // Resolved from `campaigns` rather than by fetching the id directly: the
+  // list is already tenant-scoped, so a link to another tenant's campaign —
+  // or to a deleted one — simply is not in it. That yields "you cannot see
+  // this" without this component needing to interpret a 403 or a 404, and
+  // without a second request.
+  useEffect(() => {
+    if (linkedId === null) {
+      setSelected(null)
+      return
+    }
+    if (campaigns === null) return // still loading; the link is not wrong yet
+    const match = campaigns.find((c) => c.id === linkedId) ?? null
+    setSelected(match)
+    setLinkError(
+      match === null
+        ? 'That campaign could not be opened. It may have been deleted, or belong to a tenant you do not have access to.'
+        : null,
+    )
+  }, [linkedId, campaigns])
+
+  /** Open or close a campaign, keeping the address bar in step (#142). */
+  function openCampaign(campaign: Campaign | null) {
+    const id = campaign?.id ?? null
+    setLinkedId(id)
+    setSelected(campaign)
+    setLinkError(null)
+    // `pushState`, not `replaceState`: opening a campaign is a navigation the
+    // reader should be able to reverse with Back.
+    window.history.pushState(
+      null,
+      '',
+      campaignUrl(id, window.location.pathname, window.location.search),
+    )
+  }
+
   function handleCampaignUpdated(updated: Campaign) {
     setSelected(updated)
     setCampaigns((prev) => prev?.map((c) => (c.id === updated.id ? updated : c)) ?? prev)
@@ -48,7 +108,7 @@ export default function App() {
       <main>
         <CampaignDetail
           campaign={selected}
-          onBack={() => setSelected(null)}
+          onBack={() => openCampaign(null)}
           onCampaignUpdated={handleCampaignUpdated}
         />
       </main>
@@ -125,6 +185,7 @@ export default function App() {
         {saveError !== null && <p className="error">{saveError}</p>}
       </form>
 
+      {linkError !== null && <p className="error">{linkError}</p>}
       {error !== null && <p className="empty">Could not load campaigns: {error}</p>}
       {error === null && campaigns === null && <p className="empty">Loading…</p>}
 
@@ -162,7 +223,7 @@ export default function App() {
                   </details>
                 </td>
                 <td>
-                  <button type="button" onClick={() => setSelected(c)}>
+                  <button type="button" onClick={() => openCampaign(c)}>
                     Open
                   </button>
                 </td>

--- a/web-admin/src/lib/campaignLink.test.ts
+++ b/web-admin/src/lib/campaignLink.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { CAMPAIGN_PARAM, campaignUrl, readCampaignParam } from './campaignLink'
+
+const ID = '5380e9cf-457f-4932-a7ff-c1c6986524e5'
+const PATH = '/api/v1/plugins/marketing/admin'
+
+describe('readCampaignParam', () => {
+  it('reads the id a shared link is asking for', () => {
+    expect(readCampaignParam(`?${CAMPAIGN_PARAM}=${ID}`)).toBe(ID)
+  })
+
+  it('is null when the URL asks for no campaign', () => {
+    expect(readCampaignParam('')).toBeNull()
+    expect(readCampaignParam('?other=1')).toBeNull()
+  })
+
+  it('rejects a value that is not a campaign id rather than passing it on', () => {
+    // A URL bar accepts anything. Rejecting here keeps "not an id" separate
+    // from "an id you cannot see", and stops junk being echoed into history.
+    for (const junk of ['nonsense', '../../etc/passwd', '<script>', '123', `${ID}-extra`]) {
+      expect(readCampaignParam(`?${CAMPAIGN_PARAM}=${encodeURIComponent(junk)}`)).toBeNull()
+    }
+  })
+
+  it('tolerates surrounding whitespace, which copy-paste adds', () => {
+    expect(readCampaignParam(`?${CAMPAIGN_PARAM}=${encodeURIComponent(` ${ID} `)}`)).toBe(ID)
+  })
+
+  it('is case-insensitive about the uuid, since a link may be normalised', () => {
+    expect(readCampaignParam(`?${CAMPAIGN_PARAM}=${ID.toUpperCase()}`)).toBe(ID.toUpperCase())
+  })
+})
+
+describe('campaignUrl', () => {
+  it('addresses an open campaign without touching the path', () => {
+    // The path is load-bearing: the shell answers on `…/admin` and a trailing
+    // slash 401s, so this function must never rewrite it.
+    expect(campaignUrl(ID, PATH, '')).toBe(`${PATH}?${CAMPAIGN_PARAM}=${ID}`)
+  })
+
+  it('drops the parameter when the campaign is closed', () => {
+    // A stale `?campaign=` on the list view would make the address bar
+    // disagree with the screen.
+    expect(campaignUrl(null, PATH, `?${CAMPAIGN_PARAM}=${ID}`)).toBe(PATH)
+  })
+
+  it('preserves other parameters it does not own', () => {
+    const out = campaignUrl(ID, PATH, '?debug=1')
+    expect(out).toContain('debug=1')
+    expect(out).toContain(`${CAMPAIGN_PARAM}=${ID}`)
+  })
+
+  it('replaces rather than appends when one is already present', () => {
+    const other = '11111111-2222-3333-4444-5555aaaabbbb'
+    const out = campaignUrl(other, PATH, `?${CAMPAIGN_PARAM}=${ID}`)
+    expect(out).toBe(`${PATH}?${CAMPAIGN_PARAM}=${other}`)
+    expect(out).not.toContain(ID)
+  })
+
+  it('round-trips: what it writes, the reader reads back', () => {
+    const written = campaignUrl(ID, PATH, '')
+    const search = written.slice(written.indexOf('?'))
+    expect(readCampaignParam(search)).toBe(ID)
+  })
+})

--- a/web-admin/src/lib/campaignLink.ts
+++ b/web-admin/src/lib/campaignLink.ts
@@ -1,0 +1,86 @@
+/** Making the open campaign addressable, so a studio view can be shared (#142).
+ *
+ * ## Why a query parameter and not a path
+ *
+ * The obvious shape — `…/admin/campaigns/<id>` — cannot work here, and the
+ * reason is structural rather than a matter of taste. The admin SPA is served
+ * by the same ASGI app that serves the admin API, as a `StaticFiles` mount at
+ * `/` registered **after** every route (see `admin_app.py`'s module docstring:
+ * a mount at `/` swallows everything registered after it, so it must go last).
+ *
+ * `/campaigns/{campaign_id}` is one of those earlier routes. So a browser
+ * navigation to that path never reaches the SPA — it matches the API route,
+ * the gateway's JWT authorizer answers first, and the reader gets:
+ *
+ *     {"message": "Unauthorized"}
+ *
+ * because a navigation carries no bearer token. Verified live on tabsii dev.
+ *
+ * A query parameter is invisible to routing on both sides: the path stays
+ * `…/admin`, which is the path the shell actually answers on, and the id rides
+ * along where only the client reads it.
+ *
+ * A fragment (`#/campaigns/<id>`) would also avoid the collision — it is never
+ * sent to the server at all — but it is invisible to any server-side logging
+ * and reads as dated. The query string is the better default; nothing here
+ * prevents revisiting that.
+ *
+ * ## Why the id is validated rather than trusted
+ *
+ * The value is attacker-controllable in the sense that anyone can paste
+ * anything into a URL bar. It is only ever compared against ids already
+ * fetched for this tenant, so a junk value can at worst fail to match — but
+ * validating the shape means junk is rejected before it reaches a comparison
+ * or is echoed back into `history`, and keeps "not a campaign id" separate
+ * from "a campaign id you cannot see".
+ */
+
+/** The query parameter carrying the open campaign's id. */
+export const CAMPAIGN_PARAM = 'campaign'
+
+//: A campaign id is a UUID (`marketing_campaign.id`). Deliberately shape-only:
+//: this says "could be an id", never "is a campaign you may see" — that
+//: question belongs to the tenant-scoped fetch, not to a regex.
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * The campaign id a URL is asking for, or `null` if it is not asking for one.
+ *
+ * `search` is the raw query string (`window.location.search`). A malformed or
+ * non-UUID value returns `null` rather than throwing: a bad link should land
+ * the reader on the campaign list, which is a sensible place to be, not on an
+ * error page.
+ */
+export function readCampaignParam(search: string): string | null {
+  const raw = new URLSearchParams(search).get(CAMPAIGN_PARAM)
+  if (raw === null) return null
+  const trimmed = raw.trim()
+  return UUID.test(trimmed) ? trimmed : null
+}
+
+/**
+ * The URL for a given open campaign, preserving everything else about the
+ * current location.
+ *
+ * Takes `pathname` and `search` rather than reading `window` so it is testable
+ * without a DOM, and so it **cannot change the path**: the shell answers on
+ * `…/admin` and a trailing slash 401s, so the path is not this function's to
+ * rewrite.
+ *
+ * Passing `null` for `id` removes the parameter, which is what closing a
+ * campaign should do — leaving a stale `?campaign=` on the list view would
+ * make the address bar disagree with the screen.
+ *
+ * Other parameters are preserved rather than dropped: this is one feature's
+ * parameter, not the whole query string's owner.
+ */
+export function campaignUrl(id: string | null, pathname: string, search: string): string {
+  const params = new URLSearchParams(search)
+  if (id === null) {
+    params.delete(CAMPAIGN_PARAM)
+  } else {
+    params.set(CAMPAIGN_PARAM, id)
+  }
+  const query = params.toString()
+  return query === '' ? pathname : `${pathname}?${query}`
+}


### PR DESCRIPTION
feat(web-admin): make the open campaign addressable so it can be shared

Opening a campaign changed nothing about the URL — the studio kept the
open campaign in `useState` alone — so there was no address to send a
colleague, and a reload dropped the reader back to the list.

A campaign is now `…/admin?campaign=<id>`: readable on load, written on
open, removed on close, and reversible with Back.

## Why a query parameter and not a path

`…/admin/campaigns/<id>` cannot work, structurally. The SPA is served by
the same ASGI app as the admin API, as a `StaticFiles` mount at `/`
registered LAST (a mount at `/` swallows everything after it, per
`admin_app.py`'s module docstring). `/campaigns/{campaign_id}` is an
earlier route, so a browser navigation matches the API, the gateway's JWT
authorizer answers first, and the reader gets

    {"message": "Unauthorized"}

because a navigation carries no bearer token. Verified live on tabsii dev
before choosing the shape.

A fragment would also dodge the collision but is invisible to server-side
logging. The query string is the better default; `campaignLink.ts` records
the reasoning so the next person does not re-derive it.

## What a shared link does for the recipient

* **Not yours to see** — resolved against the tenant-scoped campaign list
  the panel already fetches, so a deleted or cross-tenant id is simply
  absent. The reader is told, rather than shown an empty studio. No second
  request, and no interpreting a 403 vs a 404.
* **Junk** — a non-UUID is rejected before it reaches a comparison or is
  echoed back into `history`, and lands the reader on the list, which is a
  sensible place to be.
* **No session** — unchanged and needs nothing: the panel reads the shared
  portal session from storage and never redirects, so the query survives
  any login the reader does elsewhere.

## Tests

Verified fail-first: with the wiring reverted, 3 of the 5 behaviour tests
fail. The other two passed vacuously in that state, which is not good
enough — the close-the-campaign test now asserts the parameter is PRESENT
after opening before asserting it is gone after closing, so it cannot
report success against no implementation. The junk-id test stays as a
regression guard; it is honestly weak on its own and only meaningful once
the feature exists.

Not verified: no live click-through of a shared link on a deployed
environment. This lands behind a vendored refresh like everything else.

Closes #142

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
