### PR TITLE
feat(web-admin): auto-update a pending pipeline stage instead of only on click

### DIFF
--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { act, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,6 +9,10 @@ import { Pipeline } from './Pipeline'
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  // A no-op when real timers are already active — belt-and-braces so a
+  // test that enables fake timers (the polling tests below) can never leak
+  // them into a later test if it fails before its own cleanup runs.
+  vi.useRealTimers()
 })
 
 function stubSession(jwt = 'test-jwt') {
@@ -177,5 +181,108 @@ describe('Pipeline', () => {
     const copy = await screen.findByTestId('stage-copy')
     expect(await within(copy).findByText(/approve the channel plan stage first/i)).toBeInTheDocument()
     expect(within(copy).queryByText(/positioning/i)).not.toBeInTheDocument()
+  })
+
+  // #144: a pending stage now updates itself instead of only responding to
+  // "Check for result" — these two exercise the real wiring in `Pipeline`
+  // (`usePendingPolling` itself is unit-tested in `usePendingPolling.test.ts`
+  // for the timing, backoff, unmount-cleanup and ceiling behaviour these two
+  // build on).
+  describe('auto-updating a pending stage', () => {
+    /** Every `/artefacts/research` GET after the first `answersAfterFirst`
+     * poll returns `laterResponse` — models a research run that is still
+     * `pending` on the page's initial load, then resolves (or fails) on a
+     * subsequent poll. */
+    function pollingFetchStub(laterResponse: { ok: true; body: unknown } | { ok: false; status: number; body: unknown }) {
+      let calls = 0
+      return vi.fn((url: string, init?: RequestInit) => {
+        if (url.endsWith('/artefacts/research') && (!init || init.method === undefined)) {
+          calls += 1
+          if (calls === 1) {
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                id: 'a-research',
+                campaign_id: CAMPAIGN,
+                kind: 'research',
+                status: 'pending',
+                body: null,
+                citations: null,
+                causation_id: null,
+                agent_run_id: null,
+              }),
+            })
+          }
+          return Promise.resolve(
+            laterResponse.ok
+              ? { ok: true, json: async () => laterResponse.body }
+              : { ok: false, status: laterResponse.status, json: async () => laterResponse.body },
+          )
+        }
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+      })
+    }
+
+    it('picks up a finished run on its own, with no click on "Check for result"', async () => {
+      stubSession()
+      const fetchMock = pollingFetchStub({
+        ok: true,
+        body: {
+          id: 'a-research',
+          campaign_id: CAMPAIGN,
+          kind: 'research',
+          status: 'proposed',
+          body: JSON.stringify({ summary: 'The market wants faster onboarding.', findings: [] }),
+          citations: null,
+          causation_id: null,
+          agent_run_id: null,
+        },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+
+      const research = await screen.findByTestId('stage-research')
+      expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+
+      vi.useFakeTimers()
+      // The fast-window cadence is 2s — nobody clicked anything.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+
+      // Not `findByText` — that falls back to a real `setTimeout`-driven
+      // `waitFor`, which never wakes once fake timers are active. `act`'s
+      // `await` above already flushed the resolved fetch and its resulting
+      // re-render, so a synchronous query is both correct and sufficient.
+      expect(within(research).getByText('The market wants faster onboarding.')).toBeInTheDocument()
+      expect(within(research).queryByRole('button', { name: /check for result/i })).not.toBeInTheDocument()
+    })
+
+    it('surfaces a failed run\'s own reason instead of returning the stage to startable', async () => {
+      stubSession()
+      const fetchMock = pollingFetchStub({
+        ok: false,
+        status: 502,
+        body: { detail: 'The research-synthesis run did not complete successfully.' },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+
+      const research = await screen.findByTestId('stage-research')
+      expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+
+      vi.useFakeTimers()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+
+      expect(within(research).getByText(/did not complete successfully/i)).toBeInTheDocument()
+      // Still pending, not silently reset to a startable stage — the manual
+      // escape hatch is exactly what is still offered.
+      expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+      expect(within(research).queryByRole('button', { name: /^start research/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -17,6 +17,7 @@ import {
   type ResearchSynthesisBody,
 } from '../lib/api'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+import { POLL_CEILING_MS, usePendingPolling } from '../lib/usePendingPolling'
 import { ChannelPlanArtefact, CopyArtefact, PositioningArtefact, ResearchArtefact } from './ArtefactBody'
 import { PipelineStage } from './PipelineStage'
 
@@ -190,6 +191,35 @@ export function Pipeline({
     positioning: state.positioning.artefact?.status === 'approved',
     channel_plan: state.channel_plan.artefact?.status === 'approved',
   }
+
+  // #144: a `pending` stage otherwise only ever updates when someone presses
+  // "Check for result" — a research/synthesis run is measured at 2-4 minutes
+  // and everything after at 30-90s, so that is minutes of clicking a button.
+  // `load(kind)` (not `runMutation`) is deliberate: it is the same read this
+  // component already does on mount and via the manual button, so a poll
+  // that lands on a real failure (`getArtefact` throwing on a non-404,
+  // non-ok response — `/artefacts/{kind}`'s 502 with a real sentence, per
+  // #144) surfaces through the exact `error` plumbing the button already
+  // has, without a second failure path to keep in step with it. Excluding a
+  // stage whose manual refresh is already in flight (`s.busy`) avoids two
+  // requests racing for the same stage.
+  usePendingPolling(
+    STAGES.map((stage) => {
+      const s = state[stage.kind]
+      return { kind: stage.kind, pending: s.artefact?.status === 'pending' && !s.busy }
+    }),
+    (kind) => {
+      load(kind)
+    },
+    (kind) => {
+      patch(kind, {
+        error:
+          `Still pending after ${Math.round(POLL_CEILING_MS / 60_000)} minutes — longer than the ` +
+          "agent's own timeout, so this run will not complete on its own. Press \"Check for result\" " +
+          'to confirm, or check CloudWatch for what happened.',
+      })
+    },
+  )
 
   return (
     <div className="pipeline">

--- a/web-admin/src/lib/usePendingPolling.test.ts
+++ b/web-admin/src/lib/usePendingPolling.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { POLL_CEILING_MS, usePendingPolling, type PendingPollStage } from './usePendingPolling'
+
+/** Stubs `document.hidden` (jsdom's own default is always `false`, and it has
+ * no setter) and fires the real event the hook listens for. */
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  setHidden(false)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+})
+
+describe('usePendingPolling', () => {
+  it('polls a pending stage and leaves a non-pending one alone', () => {
+    const onPoll = vi.fn()
+    const stages: PendingPollStage<'research' | 'positioning'>[] = [
+      { kind: 'research', pending: true },
+      { kind: 'positioning', pending: false },
+    ]
+    renderHook(() => usePendingPolling(stages, onPoll, vi.fn()))
+
+    vi.advanceTimersByTime(2_000)
+    expect(onPoll).toHaveBeenCalledOnce()
+    expect(onPoll).toHaveBeenCalledWith('research')
+  })
+
+  it('does not poll at all while nothing is pending', () => {
+    const onPoll = vi.fn()
+    renderHook(() => usePendingPolling([{ kind: 'research', pending: false }], onPoll, vi.fn()))
+
+    vi.advanceTimersByTime(60_000)
+    expect(onPoll).not.toHaveBeenCalled()
+  })
+
+  it('stops polling once the stage leaves pending (a terminal state)', () => {
+    const onPoll = vi.fn()
+    const { rerender } = renderHook(({ pending }) => usePendingPolling([{ kind: 'research', pending }], onPoll, vi.fn()), {
+      initialProps: { pending: true },
+    })
+
+    vi.advanceTimersByTime(2_000)
+    expect(onPoll).toHaveBeenCalledTimes(1)
+
+    rerender({ pending: false })
+    onPoll.mockClear()
+
+    vi.advanceTimersByTime(60_000)
+    expect(onPoll).not.toHaveBeenCalled()
+  })
+
+  it('clears its timer on unmount — no poll fires afterwards', () => {
+    const onPoll = vi.fn()
+    const { unmount } = renderHook(() => usePendingPolling([{ kind: 'research', pending: true }], onPoll, vi.fn()))
+
+    vi.advanceTimersByTime(2_000)
+    expect(onPoll).toHaveBeenCalledTimes(1)
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    unmount()
+    // The classic leak this hook exists to avoid: an interval that keeps
+    // firing after the component using it is gone. If cleanup missed it,
+    // this assertion — not just the call count below — is what would catch
+    // it, because a leaked interval still shows up in the timer count even
+    // if its callback happens to be a no-op afterwards.
+    expect(vi.getTimerCount()).toBe(0)
+
+    onPoll.mockClear()
+    vi.advanceTimersByTime(60_000)
+    expect(onPoll).not.toHaveBeenCalled()
+  })
+
+  it('backs off from a 2s cadence to an 8s cadence after the first 30s', () => {
+    const onPoll = vi.fn()
+    renderHook(() => usePendingPolling([{ kind: 'research', pending: true }], onPoll, vi.fn()))
+
+    // Fast window: 30s / 2s = 15 polls.
+    vi.advanceTimersByTime(30_000)
+    expect(onPoll).toHaveBeenCalledTimes(15)
+
+    onPoll.mockClear()
+    // Slow window: the next 16s at an 8s cadence is 2 more polls, not 8.
+    vi.advanceTimersByTime(16_000)
+    expect(onPoll).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops polling and reports the ceiling once a stage has been pending too long', () => {
+    const onPoll = vi.fn()
+    const onCeiling = vi.fn()
+    renderHook(() => usePendingPolling([{ kind: 'research', pending: true }], onPoll, onCeiling))
+
+    vi.advanceTimersByTime(POLL_CEILING_MS)
+    expect(onCeiling).toHaveBeenCalledOnce()
+    expect(onCeiling).toHaveBeenCalledWith('research')
+
+    onPoll.mockClear()
+    onCeiling.mockClear()
+    // Past the ceiling, neither callback should fire again for the same
+    // stage — it already said its piece once, not every subsequent tick.
+    vi.advanceTimersByTime(60_000)
+    expect(onPoll).not.toHaveBeenCalled()
+    expect(onCeiling).not.toHaveBeenCalled()
+  })
+
+  it('stops polling while the tab is hidden and resumes immediately when it becomes visible', () => {
+    const onPoll = vi.fn()
+    renderHook(() => usePendingPolling([{ kind: 'research', pending: true }], onPoll, vi.fn()))
+
+    setHidden(true)
+    vi.advanceTimersByTime(30_000)
+    expect(onPoll).not.toHaveBeenCalled()
+
+    setHidden(false)
+    // The visibility handler itself polls immediately on resume, ahead of
+    // the next heartbeat tick.
+    expect(onPoll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-admin/src/lib/usePendingPolling.ts
+++ b/web-admin/src/lib/usePendingPolling.ts
@@ -1,0 +1,146 @@
+import { useEffect, useRef } from 'react'
+
+/** How soon after a stage becomes `pending` we poll, and how that eases off.
+ * A flat 1s poll for the full ceiling (below) would be 240 requests per
+ * stage per open tab; even a flat 2s poll would be 120. Two windows keep the
+ * fast cadence only where it earns its keep — the fan-out/synthesis stages
+ * are measured at 2-4 minutes and everything after at 30-90s (issue #144),
+ * so a result in the first 30s is common enough to poll for quickly, and
+ * past that a slower cadence is the higher-odds bet. At 2s for 30s then
+ * 8s beyond it: ~15 polls in the fast window, then up to ~26 more before the
+ * ceiling below is hit — about 41 requests worst case, versus 240 for a flat
+ * 1s poll. */
+const FAST_INTERVAL_MS = 2_000
+const FAST_WINDOW_MS = 30_000
+const SLOW_INTERVAL_MS = 8_000
+
+/** Mirrors `AGENT_TIMEOUT_SECONDS` in `src/marketing/definitions.py` — the
+ * agent's own wall-clock budget. A stage still `pending` this long after we
+ * started watching it cannot be an in-flight run that is merely slow; it is
+ * one that will never report back (a wall-clock kill, a crash CloudWatch has
+ * but the API never got told about). Polling past this point only spends
+ * requests on a question the agent has already stopped being able to
+ * answer, so we stop and say so instead. */
+export const POLL_CEILING_MS = 240_000
+
+/** The heartbeat's own granularity — small enough that the schedule above
+ * lands within a second of its target, and cheap because a tick that finds
+ * nothing due does no network work at all. */
+const TICK_MS = 1_000
+
+function nextDelayMs(elapsedMs: number): number {
+  return elapsedMs < FAST_WINDOW_MS ? FAST_INTERVAL_MS : SLOW_INTERVAL_MS
+}
+
+export interface PendingPollStage<K extends string> {
+  kind: K
+  pending: boolean
+}
+
+/** Polls every currently-`pending` stage in `stages` on ONE shared heartbeat,
+ * not one `setInterval`/`visibilitychange` pair per stage.
+ *
+ * `Pipeline` renders four stages at once, and this pipeline's own gating
+ * means at most one of them is ever `pending` simultaneously in practice —
+ * but nothing here assumes that. A single timer that checks every pending
+ * stage's own due time on each tick behaves identically whether one stage or
+ * four are pending at once, without four independent timers drifting apart,
+ * quadrupling the `visibilitychange` listener count, or leaking N intervals
+ * if cleanup ever missed one.
+ *
+ * Only reacts to *which* stages are pending (`pendingKey`), not to the
+ * `stages` array's identity — the caller's per-render array would otherwise
+ * restart the heartbeat, and its backoff with it, on every unrelated
+ * re-render.
+ */
+export function usePendingPolling<K extends string>(
+  stages: PendingPollStage<K>[],
+  onPoll: (kind: K) => void,
+  onCeiling: (kind: K) => void,
+): void {
+  const onPollRef = useRef(onPoll)
+  const onCeilingRef = useRef(onCeiling)
+  onPollRef.current = onPoll
+  onCeilingRef.current = onCeiling
+
+  // Survive across renders without forcing one: when a stage starts or stops
+  // being pending, we want to remember *when* without re-rendering to record
+  // it.
+  const pendingSince = useRef(new Map<K, number>())
+  const nextDue = useRef(new Map<K, number>())
+  const ceilingHit = useRef(new Set<K>())
+
+  const pendingKinds = stages.filter((s) => s.pending).map((s) => s.kind)
+  const pendingKey = pendingKinds.slice().sort().join(',')
+
+  useEffect(() => {
+    const since = pendingSince.current
+    const due = nextDue.current
+    const hit = ceilingHit.current
+
+    for (const kind of pendingKinds) {
+      if (!since.has(kind)) {
+        since.set(kind, Date.now())
+        due.set(kind, Date.now() + FAST_INTERVAL_MS)
+        hit.delete(kind)
+      }
+    }
+    // A kind that left the pending set (terminal state, or never started)
+    // stops being tracked — this is the "stop on any terminal state" half of
+    // the contract, alongside the `pending: false` filter above.
+    for (const kind of Array.from(since.keys())) {
+      if (!pendingKinds.includes(kind)) {
+        since.delete(kind)
+        due.delete(kind)
+        hit.delete(kind)
+      }
+    }
+
+    if (pendingKinds.length === 0) return
+
+    let hidden = document.hidden
+
+    function tick() {
+      const now = Date.now()
+      for (const kind of pendingKinds) {
+        const startedAt = since.get(kind)
+        if (startedAt === undefined || hit.has(kind)) continue
+        const elapsed = now - startedAt
+        if (elapsed >= POLL_CEILING_MS) {
+          hit.add(kind)
+          onCeilingRef.current(kind)
+          continue
+        }
+        // Stop when the tab is hidden — checked after the ceiling, not
+        // before, so a background tab still gets told once it crosses the
+        // ceiling rather than polling forever silently.
+        if (hidden) continue
+        const dueAt = due.get(kind) ?? 0
+        if (now >= dueAt) {
+          onPollRef.current(kind)
+          due.set(kind, now + nextDelayMs(elapsed))
+        }
+      }
+    }
+
+    const interval = setInterval(tick, TICK_MS)
+
+    function handleVisibilityChange() {
+      hidden = document.hidden
+      // Resume immediately rather than waiting up to one more tick — a
+      // result that finished while the tab was hidden should appear the
+      // moment the operator looks back, not up to a second later.
+      if (!hidden) tick()
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+    // pendingKey is the only thing this effect should re-run on — see the
+    // doc comment above for why `stages` itself is deliberately not here. No
+    // react-hooks lint plugin is installed in this package (see `Pipeline.tsx`),
+    // so there is no exhaustive-deps rule to satisfy or suppress.
+  }, [pendingKey])
+}


### PR DESCRIPTION
Closes #144

## What changed

A `pending` pipeline stage now updates itself instead of relying entirely on the operator pressing "Check for result". Adds `usePendingPolling` (`web-admin/src/lib/usePendingPolling.ts`) and wires it into `Pipeline.tsx`. `PipelineStage.tsx` is untouched — #145 (per-element approval) is concurrently working that file, so all new logic lives in the hook and in `Pipeline`, which already owns `load`/`patch`/the fetch plumbing.

## Interval and backoff (the arithmetic)

2s for the first 30s, then 8s after that:

- Fast window: 30s / 2s = 15 requests.
- Slow window: up to (240s ceiling − 30s) / 8s ≈ 26 more requests.
- ~41 requests worst case per stage per viewer, versus 240 for a flat 1s poll (~83% fewer).

The split matches the issue's measured durations: research/synthesis at 2-4 minutes (so a result often lands inside the fast window), later stages at 30-90s (mostly caught by the fast window too, with the slow cadence covering the long tail).

## Stop conditions

- Polls only while a stage's `status === 'pending'`, and only when its manual refresh isn't already in flight (`!busy`) — otherwise a click on "Check for result" and an in-flight poll could race the same request.
- Stops immediately on any terminal state (`proposed`/`approved`/`rejected`) — the hook clears its own bookkeeping for a kind the moment it leaves the pending set.
- Stops while the tab is hidden (`visibilitychange`) and polls again immediately on resume, rather than waiting up to one more heartbeat tick.
- Gives up after 240s (mirrors `AGENT_TIMEOUT_SECONDS` in `src/marketing/definitions.py` — the agent's own wall-clock budget) and shows a message instead of polling forever: a stage still `pending` that long after this tab started watching it cannot be a slow in-flight run, only one that will never report back.

## Where the polling lives, and why

In `Pipeline.tsx`, not `PipelineStage.tsx`. `Pipeline` renders four stages at once, but this pipeline's own gating (each stage requires the previous one `approved`) means at most one stage can ever be `pending` at the same time — so putting a `setInterval` inside `PipelineStage` would, in practice, still only ever run one at a time, but it would do so per-mounted-component with no shared bookkeeping, and would multiply needlessly if that invariant ever changes. Instead `usePendingPolling` takes the whole stage list and drives ONE `setInterval`/`visibilitychange` pair for however many are pending, checking each pending stage's own due time on every tick. One timer regardless of stage count, one listener, and it happens to keep every line of this change out of the file #145 owns.

Polling calls the exact same `getArtefact` read (`load(kind)`, not a new fetch path) that the initial mount and the manual button already use — so a poll landing on a real failure (the 502 `/artefacts/{kind}` already returns, with a real sentence like `"The research-synthesis run did not complete successfully."`) surfaces through the `error` state `PipelineStage` already renders, with no new failure path to keep in step. The artefact itself is left unmodified on failure, so the stage stays visibly `pending` rather than being silently reset to a startable state.

The API call shape and the pipeline's own semantics are unchanged — this is a UI liveness change only.

## Tests

`web-admin/src/lib/usePendingPolling.test.ts` (7 tests, fake timers): starts polling while pending, leaves a non-pending stage alone, stops on a terminal-state transition, clears its interval on unmount (asserts `vi.getTimerCount() === 0` afterwards, not just that the callback stops firing), backs off from 2s to 8s cadence, stops and reports once at the 240s ceiling, and pauses/resumes on `visibilitychange`.

`web-admin/src/components/Pipeline.test.tsx` adds two integration tests proving the real wiring: a pending research stage picks up a finished run with no click, and a failed run's own message appears while the manual button stays available (proven fail-first — both were run against the wiring with polling forced off and failed correctly, confirming they exercise the real path rather than passing vacuously).

Full suite: `pnpm run lint`, `pnpm run typecheck`, `pnpm vitest run` all pass locally (170/170 tests), and the repo's pre-push gate re-ran the same three plus the Python suite before this push succeeded.
