### PR TITLE
feat(marketing): allow partial approval of a proposed artefact

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -125,6 +125,12 @@
           "name": "agent_run_id",
           "type": "String(36)",
           "nullable": true
+        },
+        {
+          "name": "approved_selection",
+          "type": "Text",
+          "nullable": true,
+          "description": "JSON-serialised list of the element `id`s an operator approved out of this artefact's body (issue #145) — e.g. 8 of 9 channel_plan recommendations. NULL means every element was approved: the backwards-compatible reading, and what every artefact approved before this column existed has, since nothing on this deployment has ever written anything else. Kept separate from `body` on purpose — `body` is what was generated, this is what a human chose, and conflating them would make it impossible to see what was discarded."
         }
       ],
       "permissions": {

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -62,7 +62,7 @@ from typing import Any
 import httpx
 from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Request, status
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
@@ -529,6 +529,30 @@ def _parse_artefact_body(raw: Any) -> dict[str, Any]:
     return json.loads(raw) if isinstance(raw, str) else (raw or {})
 
 
+def _artefact_selection(artefact: dict[str, Any]) -> list[str] | None:
+    """The `element_ids` an operator approved this artefact with, or `None`
+    for "everything" (issue #145) — `marketing_artefact.approved_selection`,
+    read tri-shaped exactly like `body`/`citations` (Core's persisted JSON
+    *text*, an already-parsed value, or genuinely absent — see
+    `_parse_artefact_body`'s own docstring for why every artefact-reading
+    route needs the same normalisation).
+
+    `NULL`/unreadable both read as `None` — "everything" — rather than
+    raising or defaulting to "nothing": every artefact approved before this
+    column existed has no selection at all, and must keep behaving exactly as
+    it did before this change, not lose every element the moment it ships.
+    """
+    raw = artefact.get("approved_selection")
+    if isinstance(raw, str):
+        if not raw:
+            return None
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    return raw if isinstance(raw, list) else None
+
+
 def _require_known_kind(kind: str) -> None:
     if kind not in _PIPELINE_ARTEFACT_KINDS:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown artefact kind.")
@@ -639,7 +663,10 @@ async def _advance_artefact(
         token,
         json={
             "status": "proposed",
-            "body": json.dumps(result.model_dump()),
+            # `with_element_ids` (issue #145) — server-assigned ids, stamped
+            # here because this is the one place every artefact kind's real
+            # content is actually persisted (`_advance_artefact`'s docstring).
+            "body": json.dumps(pipeline.with_element_ids(result.model_dump())),
             "citations": json.dumps(pipeline.flatten_citations(result)),
         },
     )
@@ -689,7 +716,7 @@ async def start_research_route(
             # needs them to detect "every research agent failed, so the engine
             # never fired synthesis" (idea-scout's own reasoning for tracking
             # them). Overwritten with the real synthesis output once proposed.
-            "body": json.dumps({"research_run_ids": research_run_ids}),
+            "body": json.dumps(pipeline.with_element_ids({"research_run_ids": research_run_ids})),
         },
     )
     created.raise_for_status()
@@ -723,13 +750,54 @@ async def get_artefact_route(
         raise _pipeline_error_to_http(exc) from exc
 
 
+class ApproveArtefactBody(BaseModel):
+    """The operator's chosen subset of a `proposed` artefact's elements
+    (issue #145).
+
+    `element_ids=None` — the default, and what a request with no body at all
+    parses to — means approve everything, preserving the pre-#145 behaviour
+    exactly: today's UI, and every other existing caller, sends no body and
+    must keep working unchanged.
+    """
+
+    element_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "The element ids to approve out of this artefact's body. Omit entirely to "
+            "approve everything (today's behaviour). An empty list is rejected — see "
+            "approve_artefact_route's docstring — because 'nothing is usable' is what the "
+            "reject route is for, not an empty selection here."
+        ),
+    )
+
+
 @router.post("/campaigns/{campaign_id}/artefacts/{kind}/approve")
 async def approve_artefact_route(
-    campaign_id: str, kind: str, admin: Any = Depends(require_admin)
+    campaign_id: str,
+    kind: str,
+    body: ApproveArtefactBody | None = Body(default=None),
+    admin: Any = Depends(require_admin),
 ) -> dict[str, Any]:
-    """`proposed` -> `approved`. Only a human calls this route — there is no
-    other caller in this plugin — which is the approval gate itself, not
-    ceremony around it."""
+    """`proposed` -> `approved`, optionally narrowed to a subset of the
+    artefact's elements (issue #145). Only a human calls this route — there
+    is no other caller in this plugin — which is the approval gate itself,
+    not ceremony around it.
+
+    **An empty `element_ids` is rejected outright, not treated as "approve
+    nothing".** Every artefact is a list, so an operator who genuinely finds
+    none of it usable has a distinct action already — `reject_artefact_route`
+    — and letting an empty selection through here would make "approve
+    nothing" silently equivalent to "reject", without the operator having
+    chosen reject, and without whatever downstream already read this
+    artefact's status noticing the difference.
+
+    **Unknown ids are rejected too**, against the artefact's OWN persisted
+    element ids (`pipeline.known_element_ids`) — not the ids a stale admin
+    page happened to render. A page that has been open since before a
+    re-run must not be able to silently approve nothing (every requested id
+    unknown) or a different element than the one the operator actually
+    looked at.
+    """
     _require_known_kind(kind)
     campaign_id = _validated_campaign_id(campaign_id)
 
@@ -747,11 +815,35 @@ async def approve_artefact_route(
             ),
         )
 
+    element_ids = body.element_ids if body is not None else None
+    update: dict[str, Any] = {"status": "approved"}
+    if element_ids is not None:
+        if not element_ids:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    "An empty selection is not a valid approval — it is indistinguishable "
+                    "from approving nothing by accident. Use the reject route if none of "
+                    "this artefact is usable."
+                ),
+            )
+        known = pipeline.known_element_ids(_parse_artefact_body(artefact.get("body")))
+        unknown = sorted(set(element_ids) - known)
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    f"Unknown element id(s): {', '.join(unknown)}. This selection may be "
+                    "stale — refresh the artefact and try again."
+                ),
+            )
+        update["approved_selection"] = json.dumps(element_ids)
+
     updated = await _core(
         "PATCH",
         f"{_INTERNAL_PREFIX}/artefacts/{artefact['id']}",
         admin.token,
-        json={"status": "approved"},
+        json=update,
     )
     updated.raise_for_status()
     return updated.json()
@@ -827,15 +919,27 @@ async def start_positioning_route(
             detail="The research artefact must be approved before this can proceed.",
         )
 
-    research_body = _parse_artefact_body(approved_research.get("body"))
+    # Narrowed to the operator's approved subset (issue #145) — `None` means
+    # "everything", the backwards-compatible reading every pre-#145 approved
+    # research artefact gets. This is BOTH what the agent is shown (a dropped
+    # finding must not reach it as input) and what the citation check below is
+    # derived from — the two must agree, or a run could cite something it was
+    # never actually shown.
+    research_body = pipeline.selected_body(
+        _parse_artefact_body(approved_research.get("body")),
+        _artefact_selection(approved_research),
+    )
 
-    # The closed set of URLs this run is actually being shown: the approved
-    # research's own citations (issue #22). Read HERE, at start time, and
-    # stashed below — not re-read when the run completes, since research can
-    # be re-run and re-approved in between, and validating against a set this
-    # run never saw would fail an honest positioning run (and pass a
+    # The closed set of URLs this run is actually being shown (issue #22),
+    # recomputed from the approved SUBSET rather than read off the parent's
+    # unfiltered `citations` column — see `pipeline.source_urls_from_body` for
+    # why a fresh union, not a subtraction, is what makes this narrow
+    # correctly when two findings share a source. Read HERE, at start time,
+    # and stashed below — not re-read when the run completes, since research
+    # can be re-run and re-approved in between, and validating against a set
+    # this run never saw would fail an honest positioning run (and pass a
     # dishonest one).
-    allowed_source_urls = pipeline.citation_source_urls(approved_research.get("citations"))
+    allowed_source_urls = pipeline.source_urls_from_body(research_body)
 
     causation_id, run_id = await pipeline.start_positioning(gateway, research_body=research_body)
 
@@ -853,7 +957,9 @@ async def start_positioning_route(
             # once proposed — the same shape `start_research_route` uses for
             # `research_run_ids` and `start_channel_plan_route` for
             # `channel_taxonomy`.
-            "body": json.dumps({"allowed_source_urls": allowed_source_urls}),
+            "body": json.dumps(
+                pipeline.with_element_ids({"allowed_source_urls": allowed_source_urls})
+            ),
         },
     )
     created.raise_for_status()

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -75,13 +75,24 @@ async def start_channel_plan_route(
             detail="The positioning artefact must be approved before this can proceed.",
         )
 
-    positioning_body = admin_app._parse_artefact_body(approved_positioning.get("body"))
-    # The closed set of URLs this run is being shown (issue #22): exactly the
-    # approved positioning's own citations. Read at start time and stashed on
-    # the pending artefact below for the same reason `taxonomy_motions` is —
-    # it must be what THIS run saw, not what positioning has been re-run to by
+    # Narrowed to the operator's approved subset (issue #145) — `None` means
+    # "everything", the backwards-compatible reading every pre-#145 approved
+    # positioning artefact gets. This is BOTH what the agent is shown (a
+    # dropped segment/pillar/CTA must not reach it as input) and what the
+    # citation check below is derived from.
+    positioning_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_positioning.get("body")),
+        admin_app._artefact_selection(approved_positioning),
+    )
+    # The closed set of URLs this run is being shown (issue #22), recomputed
+    # from the approved SUBSET rather than read off the parent's unfiltered
+    # `citations` column — see `pipeline.source_urls_from_body` for why a
+    # fresh union, not a subtraction, is what makes this narrow correctly when
+    # two elements share a source. Read at start time and stashed on the
+    # pending artefact below for the same reason `taxonomy_motions` is — it
+    # must be what THIS run saw, not what positioning has been re-run to by
     # the time the run completes. See `pipeline.extract_channel_plan`.
-    allowed_source_urls = pipeline.citation_source_urls(approved_positioning.get("citations"))
+    allowed_source_urls = pipeline.source_urls_from_body(positioning_body)
 
     channels_resp = await admin_app._core("GET", f"{_INTERNAL_PREFIX}/channels", admin.token)
     channels_resp.raise_for_status()
@@ -121,10 +132,12 @@ async def start_channel_plan_route(
             # proposed — same shape `start_research_route` already uses for
             # `research_run_ids`.
             "body": json.dumps(
-                {
-                    "channel_taxonomy": taxonomy_motions,
-                    "allowed_source_urls": allowed_source_urls,
-                }
+                pipeline.with_element_ids(
+                    {
+                        "channel_taxonomy": taxonomy_motions,
+                        "allowed_source_urls": allowed_source_urls,
+                    }
+                )
             ),
         },
     )

--- a/src/marketing/copy_routes.py
+++ b/src/marketing/copy_routes.py
@@ -93,12 +93,26 @@ async def start_copy_route(
             detail="The channel-plan artefact must be approved before this can proceed.",
         )
 
-    channel_plan_body = admin_app._parse_artefact_body(approved_channel_plan.get("body"))
-    # `{channel_key: motion}` for the plan's real entries (#76 increment 2) —
-    # excludes any suggested_label-only proposal, since it is not a real
-    # channel yet. Stored on the pending artefact below and re-read at
-    # advance time so `extract_copy` validates against exactly this set,
-    # not whatever the plan has become by the time the run completes.
+    # Narrowed to each parent's own approved subset (issue #145) — `None`
+    # means "everything", the backwards-compatible reading every pre-#145
+    # approved artefact gets. Both are used as agent input below AND as the
+    # basis for the citation check, so a dropped element neither reaches the
+    # model nor stays cite-able.
+    positioning_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_positioning.get("body")),
+        admin_app._artefact_selection(approved_positioning),
+    )
+    channel_plan_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_channel_plan.get("body")),
+        admin_app._artefact_selection(approved_channel_plan),
+    )
+    # `{channel_key: motion}` for the plan's real, APPROVED entries (#76
+    # increment 2, narrowed per #145) — excludes any suggested_label-only
+    # proposal, since it is not a real channel yet, and now also excludes any
+    # channel the operator did not approve. Stored on the pending artefact
+    # below and re-read at advance time so `extract_copy` validates against
+    # exactly this set, not whatever the plan has become by the time the run
+    # completes.
     #
     # Raises 409 when the approved plan predates the taxonomy migration —
     # every entry the old free-text shape, none carrying a channel_key — the
@@ -111,24 +125,28 @@ async def start_copy_route(
     except pipeline.StaleChannelPlanError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
-    # The closed set of URLs this run is being shown (issue #22). Copy is
-    # started against TWO approved artefacts, so its legitimate source set is
-    # the union of both their citations — the plan's are a subset of the
-    # positioning's in practice, but only because this same check holds one
-    # stage up, which is not something this stage should assume. Read at start
-    # time and stashed below for the same reason `channel_plan_channels` is.
+    # The closed set of URLs this run is being shown (issue #22), recomputed
+    # from each approved SUBSET rather than read off either parent's
+    # unfiltered `citations` column — see `pipeline.source_urls_from_body` for
+    # why a fresh union, not a subtraction, is what makes this narrow
+    # correctly when two elements share a source. Copy is started against TWO
+    # approved artefacts, so its legitimate source set is the union of both —
+    # the plan's are a subset of the positioning's in practice, but only
+    # because this same check holds one stage up, which is not something this
+    # stage should assume. Read at start time and stashed below for the same
+    # reason `channel_plan_channels` is.
     allowed_source_urls = list(
         dict.fromkeys(
             [
-                *pipeline.citation_source_urls(approved_positioning.get("citations")),
-                *pipeline.citation_source_urls(approved_channel_plan.get("citations")),
+                *pipeline.source_urls_from_body(positioning_body),
+                *pipeline.source_urls_from_body(channel_plan_body),
             ]
         )
     )
 
     causation_id, run_id = await pipeline.start_copy(
         gateway,
-        positioning_body=admin_app._parse_artefact_body(approved_positioning.get("body")),
+        positioning_body=positioning_body,
         channel_plan_body=channel_plan_body,
     )
 
@@ -145,10 +163,12 @@ async def start_copy_route(
             # Pending-state payload, overwritten with the real result once
             # proposed — same pattern as `channel_plan_routes.py`'s own.
             "body": json.dumps(
-                {
-                    "channel_plan_channels": channel_plan_channels,
-                    "allowed_source_urls": allowed_source_urls,
-                }
+                pipeline.with_element_ids(
+                    {
+                        "channel_plan_channels": channel_plan_channels,
+                        "allowed_source_urls": allowed_source_urls,
+                    }
+                )
             ),
         },
     )

--- a/src/marketing/pack_routes.py
+++ b/src/marketing/pack_routes.py
@@ -566,7 +566,14 @@ async def get_pack_route(
             detail="The copy artefact must be approved before this can proceed.",
         )
 
-    copy_body = admin_app._parse_artefact_body(approved_copy.get("body"))
+    # Narrowed to the operator's approved subset (issue #145) — `None` means
+    # "everything", the backwards-compatible reading every pre-#145 approved
+    # copy artefact gets. A rejected/unselected channel must not appear in an
+    # assembled pack.
+    copy_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_copy.get("body")),
+        admin_app._artefact_selection(approved_copy),
+    )
     channels = copy_body.get("channels") or []
     try:
         pipeline.require_channel_keyed_copy(channels)

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -329,7 +329,12 @@ async def get_paid_pack_route(
             detail="The copy artefact must be approved before this can proceed.",
         )
 
-    copy_body = admin_app._parse_artefact_body(approved_copy.get("body"))
+    # Narrowed to the operator's approved subset (issue #145) — see
+    # `pack_routes.get_pack_route`'s identical comment for the reasoning.
+    copy_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_copy.get("body")),
+        admin_app._artefact_selection(approved_copy),
+    )
     channels = copy_body.get("channels") or []
     try:
         pipeline.require_channel_keyed_copy(channels)
@@ -364,7 +369,12 @@ async def get_paid_pack_route(
             detail="The positioning artefact must be approved before this can proceed.",
         )
 
-    positioning_body = admin_app._parse_artefact_body(approved_positioning.get("body"))
+    # Narrowed to the operator's approved subset (issue #145) — a
+    # dropped/rejected segment must not reach the targeting brief.
+    positioning_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(approved_positioning.get("body")),
+        admin_app._artefact_selection(approved_positioning),
+    )
     raw_segments = positioning_body.get("segments") or []
     if not raw_segments:
         raise HTTPException(

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 from urllib.parse import urlsplit, urlunsplit
@@ -735,6 +735,139 @@ def flatten_citations(
             seen.add(source.url)
             flat.append(source.model_dump())
     return flat
+
+
+# ── Element identity + operator selection (issue #145) ──────────────────────
+#
+# Every artefact body is a LIST of proposed items — research findings,
+# positioning segments/pillars/CTAs, channel recommendations, copy entries —
+# and `approve_artefact_route` used to flip the whole body `proposed ->
+# approved` in one move. An operator who wanted 8 of 9 channels had to accept
+# the ninth or reject the whole run. The functions below are the machinery
+# that makes a PARTIAL approval real: a stable id per element, a way to narrow
+# a body down to an approved subset, and a way to recompute the closed
+# citation set that subset actually supports.
+#
+# **Ids are server-assigned here, at persist time — never model-generated and
+# never positional.** A model asked to invent a stable id will not reliably
+# produce one; a positional id (an index into the list) silently reassigns an
+# operator's earlier choice to whatever content now sits at that index the
+# moment the list is reordered — the exact failure #94 already recorded once
+# for pack link ordering. `with_element_ids` is called on every body this
+# plugin writes (see `admin_app.py`, `channel_plan_routes.py`,
+# `copy_routes.py` — every `"body": json.dumps(...)` site wraps its argument
+# in this, `tests/test_marketing_element_id_call_sites.py` enforces it
+# statically), so a future write site cannot forget to stamp ids just by
+# following the pattern already on screen.
+
+#: The list fields, across every artefact kind, that hold operator-selectable
+#: elements. Field-name based rather than keyed by `kind`, deliberately: a
+#: pending-state placeholder body (`{"channel_taxonomy": ..., ...}`) simply
+#: has none of these keys, so every function below is a no-op on it, and a
+#: stage added later that carries a new list of selectable things needs only
+#: to be named here — not to teach every call site about a new `kind`.
+ELEMENT_LIST_KEYS: tuple[str, ...] = ("findings", "segments", "pillars", "ctas", "channels")
+
+
+def with_element_ids(body: Mapping[str, Any]) -> dict[str, Any]:
+    """`body`, with a server-assigned, stable `id` stamped onto every
+    selectable element it carries (issue #145).
+
+    Idempotent: an element that already carries a truthy `id` keeps it, so
+    calling this twice — or on a body that already went through it — never
+    reassigns anything. Every other key in `body`, and every other key in
+    each element dict, passes through unchanged; this only ever adds `id`.
+    """
+    stamped = dict(body)
+    for key in ELEMENT_LIST_KEYS:
+        items = stamped.get(key)
+        if not isinstance(items, list):
+            continue
+        stamped[key] = [
+            {**item, "id": item.get("id") or uuid.uuid4().hex} if isinstance(item, dict) else item
+            for item in items
+        ]
+    return stamped
+
+
+def known_element_ids(body: Mapping[str, Any]) -> set[str]:
+    """Every element `id` present in `body` — what an approval route's
+    requested `element_ids` is validated against (issue #145), so a stale
+    page selecting a since-regenerated element is rejected rather than
+    silently approving nothing."""
+    ids: set[str] = set()
+    for key in ELEMENT_LIST_KEYS:
+        items = body.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            element_id = item.get("id") if isinstance(item, dict) else None
+            if isinstance(element_id, str) and element_id:
+                ids.add(element_id)
+    return ids
+
+
+def selected_body(body: Mapping[str, Any], element_ids: Collection[str] | None) -> dict[str, Any]:
+    """`body`, narrowed to only the elements named in `element_ids` — the
+    downstream-facing read of an artefact's approval (issue #145).
+
+    `element_ids=None` means "everything was approved"
+    (`marketing_artefact.approved_selection` is `NULL`) — the
+    backwards-compatible reading, and the one every artefact approved before
+    this change has, since nothing on this deployment has ever written
+    anything else. `body` is returned unfiltered in that case: byte-for-byte
+    what every downstream stage already did.
+
+    A non-`None` `element_ids` filters every known list of selectable
+    elements (:data:`ELEMENT_LIST_KEYS`) down to the items whose `id` is in
+    it. An item with no `id` at all — a legacy element, from a body persisted
+    before this change and never re-approved since — cannot have been named
+    in the selection, so it is dropped rather than kept.
+    """
+    if element_ids is None:
+        return dict(body)
+    wanted = set(element_ids)
+    narrowed = dict(body)
+    for key in ELEMENT_LIST_KEYS:
+        items = narrowed.get(key)
+        if not isinstance(items, list):
+            continue
+        narrowed[key] = [
+            item for item in items if isinstance(item, dict) and item.get("id") in wanted
+        ]
+    return narrowed
+
+
+def source_urls_from_body(body: Mapping[str, Any]) -> list[str]:
+    """Every citation URL the elements actually present in `body` carry,
+    first-seen order, deduplicated (issue #145) — the closed source set the
+    NEXT stage down may cite from, recomputed fresh from whatever survived a
+    selection rather than read off the parent's unfiltered `citations`
+    column.
+
+    **This is what makes provenance narrow WITH a selection rather than
+    independently of it.** Called on a body already passed through
+    :func:`selected_body`, a URL that was only ever cited by a dropped
+    element is not in the result — but a URL a *surviving* element also
+    cites still is, because this is a fresh union over what `body` actually
+    contains, never a subtraction of the dropped element's own sources from
+    the parent's full citation set. Subtracting would be wrong the moment two
+    elements cite the same source: dropping one must not revoke a citation a
+    kept element still legitimately relies on.
+    """
+    urls: list[str] = []
+    for key in ELEMENT_LIST_KEYS:
+        items = body.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for source in item.get("sources") or []:
+                url = source.get("url") if isinstance(source, dict) else None
+                if isinstance(url, str) and url and url not in urls:
+                    urls.append(url)
+    return urls
 
 
 # ── The agent-run port ────────────────────────────────────────────────────────

--- a/src/marketing/user_app.py
+++ b/src/marketing/user_app.py
@@ -125,7 +125,7 @@ from biffo_plugin_sdk import BiffoAPIClient, BiffoAPIError, create_core_client
 from biffo_plugin_sdk.user_serving import require_group
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 
-from . import admin_app, principal_client
+from . import admin_app, pipeline, principal_client
 from .config import public_base_url_for
 from .links import tracked_url
 
@@ -295,7 +295,12 @@ async def get_pack_route(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No approved copy for this campaign yet.",
         )
-    copy_body = admin_app._parse_artefact_body(copy_artefact.get("body"))
+    # Narrowed to the operator's approved subset (issue #145) — a founder
+    # must not be shown a channel the operator did not approve.
+    copy_body = pipeline.selected_body(
+        admin_app._parse_artefact_body(copy_artefact.get("body")),
+        admin_app._artefact_selection(copy_artefact),
+    )
     channels = copy_body.get("channels") or []
 
     asset_rows = await _list_all(

--- a/tests/test_marketing_element_id_call_sites.py
+++ b/tests/test_marketing_element_id_call_sites.py
@@ -1,0 +1,124 @@
+"""Every `marketing_artefact.body` write must stamp element ids first (issue
+#145): `json.dumps(<payload>)` under a `"body"` dict key must wrap `<payload>`
+in `pipeline.with_element_ids(...)`.
+
+Only ONE call site (`admin_app._advance_artefact`) actually persists a body
+carrying real elements — every other "body" write is a pending-state
+placeholder (`{"channel_taxonomy": ..., "allowed_source_urls": [...]}`) with
+none of `pipeline.ELEMENT_LIST_KEYS` in it, so wrapping it is a no-op. Every
+site is wrapped anyway, deliberately: `with_element_ids` is a no-op on a body
+that carries no selectable elements, so there is no cost to routing every
+write through it, and doing so is what stops a FOURTH write site — one that
+DOES carry real content, added by someone following the pattern already on
+screen — from forgetting the stamp. This is the same reasoning and the same
+shape as `test_marketing_artefact_body_call_sites.py`'s guard for
+`_parse_artefact_body`, applied to the write side instead of the read side.
+
+**Why this guard rather than a purely functional test.** A functional test
+proves `with_element_ids` itself is correct; nothing about it proves every
+call site that constructs an artefact body actually calls it. Issue #145's
+own brief says as much: "A guard test asserting every persisted element
+carries an id would be worth more than the helper itself." This is that
+guard — an AST walk, not a functional test, because a functional test can
+only exercise the call sites it was told about, and the point of this file is
+to need no such list.
+
+**Why an AST walk rather than a grep.** Same reasoning as
+`test_marketing_core_paths_guard.py`'s module docstring: a textual search for
+`with_element_ids` matches this file's own docstring, the helper's own
+docstring, and every comment naming it. Asking the tree for *a `json.dumps`
+call that is the value of a dict's `"body"` key, whose own argument is a call
+to `with_element_ids`* cannot be fooled by prose.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "marketing"
+
+_HELPER = "with_element_ids"
+
+
+def _is_json_dumps(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "dumps"
+        and (isinstance(func.value, ast.Name) and func.value.id == "json")
+    )
+
+
+def _wraps_with_element_ids(call: ast.Call) -> bool:
+    """True if `call` (a `json.dumps(...)` call) wraps its sole argument in
+    `pipeline.with_element_ids(...)` or a bare `with_element_ids(...)` — the
+    two import shapes actually used across this plugin's modules."""
+    if len(call.args) != 1:
+        return False
+    arg = call.args[0]
+    if not isinstance(arg, ast.Call):
+        return False
+    func = arg.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == _HELPER
+    if isinstance(func, ast.Name):
+        return func.id == _HELPER
+    return False
+
+
+def _body_json_dumps_calls(tree: ast.AST) -> list[ast.Call]:
+    """Every `json.dumps(...)` call that is the value of a `"body"` key in a
+    dict literal, anywhere in the module — regardless of how deeply the dict
+    itself is nested (a `json={...}` kwarg to `_core`, or a nested payload
+    dict built up before being passed in)."""
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=True):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "body"
+                and isinstance(value, ast.Call)
+                and _is_json_dumps(value)
+            ):
+                hits.append(value)
+    return hits
+
+
+def _unwrapped_body_writes(tree: ast.AST) -> list[int]:
+    return sorted(
+        call.lineno for call in _body_json_dumps_calls(tree) if not _wraps_with_element_ids(call)
+    )
+
+
+def test_every_persisted_body_write_stamps_element_ids() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for lineno in _unwrapped_body_writes(tree):
+            offenders.append(f"{path.name}:{lineno}")
+
+    assert not offenders, (
+        "These write marketing_artefact.body without stamping element ids first "
+        "(issue #145) — wrap the json.dumps(...) argument in pipeline.with_element_ids(...): "
+        + ", ".join(offenders)
+    )
+
+
+def test_the_guard_can_actually_fail() -> None:
+    """The guard must detect the thing it claims to detect — an unwrapped
+    `"body": json.dumps(...)` — and must not fire on the wrapped form, on a
+    `json.dumps` under some OTHER key, or on a dict that merely mentions the
+    word `body` as a non-string key."""
+    tree = ast.parse(
+        "a = {'body': json.dumps(payload)}\n"  # offender
+        "b = {'body': json.dumps(pipeline.with_element_ids(payload))}\n"  # wrapped, fine
+        "c = {'body': json.dumps(with_element_ids(payload))}\n"  # bare import, fine
+        "d = {'citations': json.dumps(payload)}\n"  # different key, not this guard's concern
+        "e = {'body': other_call(payload)}\n"  # not json.dumps at all
+    )
+    assert _unwrapped_body_writes(tree) == [1]

--- a/tests/test_marketing_element_ids.py
+++ b/tests/test_marketing_element_ids.py
@@ -1,0 +1,251 @@
+"""Element identity + operator selection (issue #145) — the machinery behind
+partial artefact approval, tested independently of the HTTP layer.
+
+`approve_artefact_route` used to flip an artefact's whole body `proposed ->
+approved` in one move, but every artefact is a LIST — an operator who wanted
+8 of 9 channel recommendations had to accept the ninth or reject the whole
+run. `pipeline.with_element_ids`/`known_element_ids`/`selected_body`/
+`source_urls_from_body` are what make a partial approval real: a stable id
+per element, a way to narrow a body to an approved subset, and a way to
+recompute the closed citation set that subset actually supports. See
+`tests/test_marketing_pipeline_routes.py`'s selection section for the same
+behaviour proven end to end over the HTTP routes.
+"""
+
+from __future__ import annotations
+
+from marketing.pipeline import (
+    ELEMENT_LIST_KEYS,
+    known_element_ids,
+    selected_body,
+    source_urls_from_body,
+    with_element_ids,
+)
+
+
+def _source(url: str) -> dict[str, str]:
+    return {"url": url, "note": "n"}
+
+
+# ── with_element_ids ──────────────────────────────────────────────────────────
+
+
+def test_with_element_ids_stamps_every_known_list() -> None:
+    """One id per element, across every list this plugin's artefact kinds
+    actually use — proven for all five at once rather than one at a time, so
+    a future kind added to `ELEMENT_LIST_KEYS` without a matching branch here
+    is caught the moment this test is extended, not silently skipped."""
+    body = {
+        "summary": "irrelevant to ids",
+        "findings": [{"signal": "s", "sources": [_source("https://a.example")]}],
+        "segments": [{"name": "seg", "sources": [_source("https://b.example")]}],
+        "pillars": [{"pillar": "p", "sources": [_source("https://c.example")]}],
+        "ctas": [{"text": "cta", "sources": [_source("https://d.example")]}],
+        "channels": [{"channel_key": "x", "sources": [_source("https://e.example")]}],
+    }
+
+    stamped = with_element_ids(body)
+
+    for key in ELEMENT_LIST_KEYS:
+        (element,) = stamped[key]
+        assert isinstance(element.get("id"), str) and element["id"], key
+    # Non-element keys pass through untouched.
+    assert stamped["summary"] == "irrelevant to ids"
+
+
+def test_with_element_ids_assigns_distinct_ids() -> None:
+    body = {"channels": [{"channel_key": "a"}, {"channel_key": "b"}, {"channel_key": "c"}]}
+
+    stamped = with_element_ids(body)
+
+    ids = [c["id"] for c in stamped["channels"]]
+    assert len(set(ids)) == 3
+
+
+def test_with_element_ids_is_not_positional() -> None:
+    """The design explicitly settled against a positional id (#94's class):
+    reordering the same elements must not just "happen" to produce the same
+    ids by coincidence of list position — each element's id must travel with
+    its own content, not its index. Proven here by shuffling the list and
+    checking the id for a given `channel_key` is unaffected by where it sits."""
+    original = with_element_ids({"channels": [{"channel_key": "a"}, {"channel_key": "b"}]})
+    by_key = {c["channel_key"]: c["id"] for c in original["channels"]}
+
+    reordered = {"channels": [dict(c) for c in reversed(original["channels"])]}
+    # Re-stamping (idempotency) must not change an id that is already set,
+    # regardless of position in the list.
+    restamped = with_element_ids(reordered)
+
+    for channel in restamped["channels"]:
+        assert channel["id"] == by_key[channel["channel_key"]]
+
+
+def test_with_element_ids_is_idempotent() -> None:
+    once = with_element_ids({"channels": [{"channel_key": "a"}]})
+    twice = with_element_ids(once)
+
+    assert once["channels"][0]["id"] == twice["channels"][0]["id"]
+
+
+def test_with_element_ids_is_a_noop_on_a_pending_placeholder_body() -> None:
+    """Every "body" write in this plugin routes through this helper (issue
+    #145), including the pending-state placeholders
+    (`{"channel_taxonomy": ..., "allowed_source_urls": [...]}`) that carry no
+    selectable elements at all. Must not raise, and must not invent an
+    `ELEMENT_LIST_KEYS` entry that was never there."""
+    placeholder = {"channel_taxonomy": {"x": "organic"}, "allowed_source_urls": ["https://a"]}
+
+    assert with_element_ids(placeholder) == placeholder
+
+
+# ── known_element_ids ──────────────────────────────────────────────────────────
+
+
+def test_known_element_ids_collects_across_every_list() -> None:
+    body = with_element_ids(
+        {
+            "segments": [{"name": "s"}],
+            "pillars": [{"pillar": "p"}],
+            "ctas": [{"text": "c"}],
+        }
+    )
+
+    ids = known_element_ids(body)
+
+    assert ids == {body["segments"][0]["id"], body["pillars"][0]["id"], body["ctas"][0]["id"]}
+
+
+def test_known_element_ids_of_a_body_with_no_ids_is_empty() -> None:
+    """A legacy body — persisted before #145, never re-stamped — has no `id`
+    on anything. `approve_artefact_route`'s unknown-id check must reject
+    every requested element_id against a body like this, not raise."""
+    legacy = {"segments": [{"name": "s", "sources": []}]}
+
+    assert known_element_ids(legacy) == set()
+
+
+# ── selected_body ────────────────────────────────────────────────────────────
+
+
+def test_selected_body_of_none_returns_everything_unfiltered() -> None:
+    """NULL/None selection means "everything" — the backwards-compatible
+    reading every artefact approved before #145 gets (issue #145)."""
+    body = with_element_ids({"channels": [{"channel_key": "a"}, {"channel_key": "b"}]})
+
+    assert selected_body(body, None) == body
+
+
+def test_selected_body_narrows_to_the_requested_ids() -> None:
+    body = with_element_ids(
+        {"channels": [{"channel_key": "a"}, {"channel_key": "b"}, {"channel_key": "c"}]}
+    )
+    keep = body["channels"][0]["id"]
+
+    narrowed = selected_body(body, [keep])
+
+    assert [c["channel_key"] for c in narrowed["channels"]] == ["a"]
+
+
+def test_selected_body_drops_a_legacy_element_with_no_id() -> None:
+    """An element with no `id` cannot have been named in a selection, so it
+    is dropped rather than kept when a non-None selection is applied."""
+    body = {"channels": [{"channel_key": "legacy"}]}  # never stamped
+
+    narrowed = selected_body(body, ["some-id"])
+
+    assert narrowed["channels"] == []
+
+
+def test_selected_body_leaves_non_element_keys_untouched() -> None:
+    body = with_element_ids({"summary": "kept verbatim", "findings": [{"signal": "s"}]})
+
+    narrowed = selected_body(body, [])
+
+    assert narrowed["summary"] == "kept verbatim"
+    assert narrowed["findings"] == []
+
+
+# ── source_urls_from_body ────────────────────────────────────────────────────
+
+
+def test_source_urls_from_body_collects_and_dedupes_in_first_seen_order() -> None:
+    body = {
+        "segments": [
+            {"sources": [_source("https://b.example"), _source("https://a.example")]},
+            {"sources": [_source("https://a.example")]},  # duplicate, dropped
+        ]
+    }
+
+    assert source_urls_from_body(body) == ["https://b.example", "https://a.example"]
+
+
+def test_source_urls_from_body_narrows_when_a_finding_is_dropped() -> None:
+    """The straightforward case: a URL cited only by a dropped element is not
+    in the result once the body has been narrowed."""
+    body = with_element_ids(
+        {
+            "findings": [
+                {"signal": "kept", "sources": [_source("https://kept.example")]},
+                {"signal": "dropped", "sources": [_source("https://dropped.example")]},
+            ]
+        }
+    )
+    keep_id = body["findings"][0]["id"]
+
+    narrowed = selected_body(body, [keep_id])
+
+    assert source_urls_from_body(narrowed) == ["https://kept.example"]
+
+
+def test_source_urls_from_body_keeps_a_url_two_elements_share() -> None:
+    """The subtle case the issue calls out by name: if two elements cite the
+    SAME url and only one of them is dropped, the surviving element's
+    legitimate citation of that url must not be revoked. This is what makes
+    `source_urls_from_body` a fresh union over what survives, never a
+    subtraction of the dropped element's own sources from the parent's full
+    citation set — subtracting would fail this exact case."""
+    body = with_element_ids(
+        {
+            "findings": [
+                {
+                    "signal": "kept",
+                    "sources": [
+                        _source("https://shared.example"),
+                        _source("https://only-kept.example"),
+                    ],
+                },
+                {"signal": "dropped", "sources": [_source("https://shared.example")]},
+            ]
+        }
+    )
+    keep_id = body["findings"][0]["id"]
+
+    narrowed = selected_body(body, [keep_id])
+
+    assert source_urls_from_body(narrowed) == [
+        "https://shared.example",
+        "https://only-kept.example",
+    ]
+
+
+def test_source_urls_from_body_of_a_full_unfiltered_body_matches_the_old_citations_reading() -> (
+    None
+):
+    """NULL selection (`selected_body(body, None)`) must produce the exact
+    same allowed set the pre-#145 code computed from the `citations` column
+    — the equivalence that makes NULL a genuinely backwards-compatible
+    reading, not just an unenforced default."""
+    from marketing.definitions import Positioning
+    from marketing.pipeline import citation_source_urls, flatten_citations
+
+    result = Positioning.model_validate(
+        {
+            "segments": [{"name": "s", "description": "d", "sources": [_source("https://a")]}],
+            "pillars": [],
+            "ctas": [{"text": "c", "rationale": "r", "sources": [_source("https://b")]}],
+        }
+    )
+    body = with_element_ids(result.model_dump())
+    citations = flatten_citations(result)
+
+    assert source_urls_from_body(selected_body(body, None)) == citation_source_urls(citations)

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -897,3 +897,223 @@ def test_copy_artefact_can_be_approved(ctx) -> None:
 
     assert resp.status_code == 200
     assert resp.json()["status"] == "approved"
+
+
+# ── partial approval / selection (issue #145) ─────────────────────────────────
+#
+# `approve_artefact_route` used to flip an artefact's whole body `proposed ->
+# approved` in one move. Every artefact is a LIST, so an operator who wanted 8
+# of 9 channel recommendations had to accept the ninth or reject the whole
+# run. These tests exercise the fix end to end over the HTTP routes; the pure
+# functions it is built from (`with_element_ids`/`selected_body`/
+# `source_urls_from_body`/`known_element_ids`) have their own unit tests in
+# `tests/test_marketing_element_ids.py`.
+
+
+def _synthesis_call_two_findings(
+    url_a: str = "https://example.com/a", url_b: str = "https://example.com/b"
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "submit_research_synthesis",
+                        "arguments": {
+                            "summary": "Two signals.",
+                            "findings": [
+                                {
+                                    "signal": "A",
+                                    "why_it_matters": "m",
+                                    "sources": [{"url": url_a, "note": "n"}],
+                                },
+                                {
+                                    "signal": "B",
+                                    "why_it_matters": "m",
+                                    "sources": [{"url": url_b, "note": "n"}],
+                                },
+                            ],
+                        },
+                    }
+                }
+            ],
+        }
+    ]
+
+
+def _propose_research_two_findings(client, core, gateway) -> dict[str, Any]:
+    started = client.post(f"/campaigns/{_CAMPAIGN}/research").json()
+    for run_id in list(gateway._runs):
+        gateway.complete(run_id)
+    gateway.fire_chain_run(
+        chain_id=started["causation_id"],
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_synthesis_call_two_findings(),
+    )
+    return client.get(f"/campaigns/{_CAMPAIGN}/artefacts/research").json()
+
+
+def test_approve_stamps_ids_on_every_element_of_a_proposed_artefact(ctx) -> None:
+    """Issue #145's core requirement, at the HTTP boundary: ids are assigned
+    at persist time, so every element already has one by the time an operator
+    could even try to select by it."""
+    client, core, gateway = ctx
+    proposed = _propose_research_two_findings(client, core, gateway)
+
+    ids = [f["id"] for f in json.loads(proposed["body"])["findings"]]
+
+    assert all(isinstance(i, str) and i for i in ids)
+    assert len(set(ids)) == len(ids)
+
+
+def test_approve_rejects_an_empty_selection(ctx) -> None:
+    """Design decision #6: an empty `element_ids` is not a distinct way to
+    approve nothing — that is what the reject route is for."""
+    client, core, gateway = ctx
+    proposed = _propose_research(client, core, gateway)
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve", json={"element_ids": []}
+    )
+
+    assert resp.status_code == 422
+    assert core.artefacts[proposed["id"]]["status"] == "proposed"
+
+
+def test_approve_rejects_an_unknown_element_id(ctx) -> None:
+    """A stale page selecting a since-regenerated element must not silently
+    approve nothing — it must be told the selection is stale."""
+    client, core, gateway = ctx
+    proposed = _propose_research(client, core, gateway)
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve",
+        json={"element_ids": ["not-a-real-id"]},
+    )
+
+    assert resp.status_code == 422
+    assert "not-a-real-id" in resp.json()["detail"]
+    assert core.artefacts[proposed["id"]]["status"] == "proposed"
+
+
+def test_approve_with_no_body_leaves_the_selection_null(ctx) -> None:
+    """Today's no-body approve — every existing caller, including the UI,
+    which sends no body at all — keeps working unchanged, and NULL is what
+    makes a downstream read treat it as "everything"."""
+    client, core, gateway = ctx
+    proposed = _propose_research(client, core, gateway)
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/artefacts/research/approve")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"
+    assert core.artefacts[proposed["id"]].get("approved_selection") is None
+
+
+def test_approve_with_a_subset_stores_it(ctx) -> None:
+    client, core, gateway = ctx
+    proposed = _propose_research_two_findings(client, core, gateway)
+    keep_id = json.loads(proposed["body"])["findings"][0]["id"]
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve", json={"element_ids": [keep_id]}
+    )
+
+    assert resp.status_code == 200
+    assert json.loads(core.artefacts[proposed["id"]]["approved_selection"]) == [keep_id]
+
+
+def test_null_selection_behaves_as_everything_against_a_pre_change_artefact(ctx) -> None:
+    """The explicit backwards-compatibility case (issue #145): an artefact
+    approved before this change has a body with no `id` on any element at all
+    (never passed through `with_element_ids`) and `approved_selection` is
+    NULL. It must keep flowing into the next stage's input whole, not empty."""
+    client, core, gateway = ctx
+    proposed = _propose_research(client, core, gateway)
+    # Simulate a pre-#145 row: strip the ids `with_element_ids` stamped, as a
+    # deployment's existing approved research would never have had them.
+    legacy_body = json.loads(proposed["body"])
+    for finding in legacy_body["findings"]:
+        finding.pop("id", None)
+    core.artefacts[proposed["id"]]["body"] = json.dumps(legacy_body)
+
+    client.post(f"/campaigns/{_CAMPAIGN}/artefacts/research/approve")  # no body -> NULL selection
+    assert core.artefacts[proposed["id"]].get("approved_selection") is None
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/positioning")
+
+    assert resp.status_code == 201
+    positioning_requests = [
+        r for r in gateway.requested if r["agent_name"] == "marketing-positioning"
+    ]
+    assert len(positioning_requests[0]["input_payload"]["research"]["findings"]) == 1
+
+
+def test_a_subset_narrows_what_the_next_stage_sees(ctx) -> None:
+    """The behaviour the whole issue exists for: approving fewer than every
+    element removes the rest from what the next stage is shown, not just from
+    what an operator sees on screen — and the provenance check narrows WITH
+    the selection (issue #145's most quietly-breakable requirement)."""
+    client, core, gateway = ctx
+    proposed = _propose_research_two_findings(client, core, gateway)
+    keep = next(f for f in json.loads(proposed["body"])["findings"] if f["signal"] == "A")
+
+    client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve", json={"element_ids": [keep["id"]]}
+    )
+    started = client.post(f"/campaigns/{_CAMPAIGN}/positioning").json()
+
+    positioning_requests = [
+        r for r in gateway.requested if r["agent_name"] == "marketing-positioning"
+    ]
+    sent_findings = positioning_requests[0]["input_payload"]["research"]["findings"]
+    assert [f["signal"] for f in sent_findings] == ["A"]
+    pending = json.loads(started["body"])
+    assert pending["allowed_source_urls"] == ["https://example.com/a"]
+
+
+def test_a_legitimate_citation_of_a_surviving_finding_still_passes(ctx) -> None:
+    """Provenance narrows CORRECTLY, not merely narrows: a positioning run
+    that cites exactly what survived the selection must still be accepted —
+    proving this isn't a check that fails closed on every real citation the
+    moment any selection at all is applied."""
+    client, core, gateway = ctx
+    proposed = _propose_research_two_findings(client, core, gateway)
+    keep = next(f for f in json.loads(proposed["body"])["findings"] if f["signal"] == "A")
+    client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve", json={"element_ids": [keep["id"]]}
+    )
+    started = client.post(f"/campaigns/{_CAMPAIGN}/positioning").json()
+
+    gateway.complete(
+        started["agent_run_id"], messages=_positioning_call(url="https://example.com/a")
+    )
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/positioning")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "proposed"
+
+
+def test_citing_a_dropped_findings_url_now_fails(ctx) -> None:
+    """The other half of "narrows correctly": a positioning run that cites
+    the URL belonging to the finding the operator did NOT approve is treated
+    exactly like any other uncited source — even though that URL was
+    perfectly legitimate before the selection was applied. This is the case
+    issue #145 says is "the one most likely to break quietly" if the
+    provenance check does not narrow along with the selection."""
+    client, core, gateway = ctx
+    proposed = _propose_research_two_findings(client, core, gateway)
+    keep = next(f for f in json.loads(proposed["body"])["findings"] if f["signal"] == "A")
+    client.post(
+        f"/campaigns/{_CAMPAIGN}/artefacts/research/approve", json={"element_ids": [keep["id"]]}
+    )
+    started = client.post(f"/campaigns/{_CAMPAIGN}/positioning").json()
+
+    gateway.complete(
+        started["agent_run_id"], messages=_positioning_call(url="https://example.com/b")
+    )
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/positioning")
+
+    assert resp.status_code == 502
+    assert core.artefacts[started["id"]]["status"] == "pending"


### PR DESCRIPTION
## What

Backend half of #145 — `POST .../artefacts/{kind}/approve` now accepts an
optional `{"element_ids": [...]}` body so an operator can approve a subset of
a proposed artefact's elements instead of all-or-nothing. Scope is explicitly
backend-only per the issue's brief; the selection UI is a separate change.

Refs #145 (backend only — the UI half is not built here, so this does not
close the issue)

## Design decisions taken as given by the issue, implemented as specified

1. **Element identity is server-assigned at persist time**
   (`pipeline.with_element_ids`) — never model-generated, never positional
   (#94's class: reordering must not silently reassign an operator's earlier
   choice to different content). Every `"body": json.dumps(...)` write site
   across `admin_app.py`, `channel_plan_routes.py` and `copy_routes.py`
   routes through this one helper. A static AST guard
   (`tests/test_marketing_element_id_call_sites.py`) asserts every such site
   wraps its argument in it, so a fourth write site cannot forget.

2. **Storage**: new nullable `marketing_artefact.approved_selection` column
   (Text, JSON array of element ids) in `biffo.plugin.json`. `NULL` means
   "everything" — the backwards-compatible reading every artefact approved
   before this ships keeps. This repo carries no instance migrations, so the
   manifest change is correct but the Alembic migration itself is generated
   by `biffo plugin upgrade`'s column-diffing (biffo-template#1551) on the
   next instance refresh — noting that explicitly per the issue's ask.

3. **The approve route**: optional body, absent = approve everything
   (preserves every existing caller, including the UI, unchanged). Unknown
   ids → 422 (a stale page must not silently approve nothing). An **empty**
   `element_ids` is also rejected with 422 — decision made here, stated
   explicitly: an empty selection is not a distinct "approve nothing" action,
   it is what `reject_artefact_route` is for, and letting it through would
   make "approve nothing" silently indistinguishable from reject.

4. **Downstream sees the parent's approved subset.** Every caller of
   `_latest_approved_artefact` — both pipeline starters
   (`start_positioning_route`, `start_channel_plan_route`, `start_copy_route`)
   and both pack surfaces (`pack_routes.py`, `paid_pack_routes.py`,
   `user_app.py`'s founder-facing pack) — now reads its parent through
   `pipeline.selected_body(body, selection)` rather than the raw body.

5. **Provenance narrows with it.** `allowed_source_urls` (the closed set
   `UncitedSourceError` checks against) is now `pipeline.source_urls_from_body`
   over the *narrowed* body, not `citation_source_urls` over the parent's
   unfiltered `citations` column. This is a fresh union over what survived,
   never a subtraction — so a source two elements share is not revoked just
   because one of them was dropped (a case both a unit test and an
   HTTP-level test cover explicitly).

6. **Reject stays its own route**, unchanged.

## Tests

- `tests/test_marketing_element_ids.py` — unit tests for
  `with_element_ids`/`known_element_ids`/`selected_body`/`source_urls_from_body`:
  ids assigned across every element list, distinct, not positional
  (reorder-then-restamp), idempotent, no-op on a pending placeholder body;
  `NULL` selection round-trips to the pre-#145 `citation_source_urls` reading
  exactly; narrowing drops only what's excluded and a shared source survives
  when only one of its two citing elements is dropped.
- `tests/test_marketing_element_id_call_sites.py` — the static guard, with
  its own fail-first self-test (`test_the_guard_can_actually_fail`).
- `tests/test_marketing_pipeline_routes.py` (new "partial approval /
  selection" section) — over the real HTTP routes: ids present at the
  approve boundary, empty selection 422, unknown id 422 (with the id named
  in the message), no-body approve leaves `approved_selection` NULL, a
  simulated pre-#145 artefact (ids stripped) still flows through whole under
  a NULL selection, a subset narrows both the next stage's agent input AND
  `allowed_source_urls`, a citation of a surviving finding still succeeds,
  and a citation of a *dropped* finding's URL now correctly 502s.

Proved fail-first for the two guards this touches most directly: reverted
`pipeline.with_element_ids` to a no-op and watched
`test_with_element_ids_stamps_every_known_list` and the static call-site
guard both fail before restoring it; reverted the `allowed_source_urls`
narrowing in `start_positioning_route` back to the old
`citation_source_urls(citations)` call and watched
`test_citing_a_dropped_findings_url_now_fails` go from 502 to 200 before
restoring it.

`sh scripts/biffo.sh verify` and `uv run pytest` both green (621 tests). Ran
`pnpm install` and the full web-admin lint/typecheck/vitest/build lane too,
even though nothing under `web-admin/` changed — confirmed via a research
pass that no strict runtime validation or type-level exactness there would
be broken by the extra `id` key on each element, and that
`approveArtefact` already sends no body today so the new optional field is
purely additive.

## Not done here (by design)

- The selection UI itself — a separate change, on top of this, in
  `web-admin/src/components/PipelineStage.tsx`.
- The Alembic migration for `approved_selection` — generated on the next
  instance refresh (see point 2 above).
