### PR TITLE
feat(marketing): let an operator choose which elements approve

### DIFF
--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ChannelTaxonomyEntry } from '../lib/api'
+import type { ElementSelection } from '../lib/elementSelection'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import {
   ChannelPlanArtefact,
@@ -445,5 +447,91 @@ describe('CopyArtefact', () => {
     )
     expect(screen.getByText('Faster onboarding, starting today')).toBeInTheDocument()
     expect(screen.queryByText(/budget/)).not.toBeInTheDocument()
+  })
+})
+
+describe('Element selection (issue #145)', () => {
+  /** A selection where nothing is deselected — `isSelected` always true. */
+  function allSelected(): ElementSelection {
+    return { isSelected: () => true, toggle: vi.fn() }
+  }
+
+  it('renders no checkbox at all when no selection is supplied — every pre-#145 render, unchanged', () => {
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'x',
+          findings: [{ id: 'f1', signal: 'Owners want faster onboarding', why_it_matters: 'x', sources: [] }],
+        }}
+      />,
+    )
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('renders no checkbox for an element with no id, even when a selection is supplied (legacy body)', () => {
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'x',
+          findings: [{ signal: 'No id at all', why_it_matters: 'x', sources: [] }],
+        }}
+        selection={allSelected()}
+      />,
+    )
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('renders a checked, accessibly-labelled checkbox per element when a selection is supplied', () => {
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'x',
+          findings: [
+            { id: 'f1', signal: 'Owners want faster onboarding', why_it_matters: 'x', sources: [] },
+            { id: 'f2', signal: 'Competitors take 3 weeks', why_it_matters: 'x', sources: [] },
+          ],
+        }}
+        selection={allSelected()}
+      />,
+    )
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+    for (const box of checkboxes) expect(box).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /owners want faster onboarding/i })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /competitors take 3 weeks/i })).toBeInTheDocument()
+  })
+
+  it('reflects isSelected(id) === false as unchecked, and toggling calls toggle with that id', async () => {
+    const toggle = vi.fn()
+    const selection: ElementSelection = { isSelected: (id) => id !== 'f1', toggle }
+    const user = userEvent.setup()
+    render(
+      <ResearchArtefact
+        body={{
+          summary: 'x',
+          findings: [{ id: 'f1', signal: 'Owners want faster onboarding', why_it_matters: 'x', sources: [] }],
+        }}
+        selection={selection}
+      />,
+    )
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+    await user.click(checkbox)
+    expect(toggle).toHaveBeenCalledOnce()
+    expect(toggle).toHaveBeenCalledWith('f1')
+  })
+
+  it('offers one checkbox per element across segments, pillars and CTAs together (positioning)', () => {
+    render(
+      <PositioningArtefact
+        body={{
+          segments: [{ id: 's1', name: 'Busy owners', description: 'x', sources: [] }],
+          pillars: [{ id: 'p1', pillar: 'Onboard in a day', rationale: 'x', sources: [] }],
+          ctas: [{ id: 'c1', text: 'Book a demo', rationale: 'x', sources: [] }],
+        }}
+        selection={allSelected()}
+      />,
+    )
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3)
   })
 })

--- a/web-admin/src/components/ArtefactBody.tsx
+++ b/web-admin/src/components/ArtefactBody.tsx
@@ -8,6 +8,7 @@ import type {
   ResearchSynthesisBody,
   Source,
 } from '../lib/api'
+import type { ElementSelection } from '../lib/elementSelection'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import { ChannelName } from './ChannelName'
 
@@ -128,12 +129,41 @@ function CitationMarkers({
 
 interface FindingItem {
   key: string
+  /** Server-assigned (issue #145) — `undefined` for an artefact body from
+   * before #150, which this item then renders exactly as it always did:
+   * no checkbox, because there is nothing stable to select it by. */
+  id?: string
+  /** A plain-text identifier for this item, used only for the checkbox's
+   * accessible name (`aria-label`) — never rendered, so it does not need to
+   * match `heading`'s exact wording, only to say which item this is. */
+  label: string
   /** The item's own heading, as a full element — callers vary the tag
    * (`<h4>`/`<h5>`/`<p className="pillar">`) and content (plain text, or
    * text plus a motion badge), so this is a rendered node, not a string. */
   heading: ReactNode
   body: ReactNode
   sources: Source[]
+}
+
+/** One element's carry-forward checkbox (issue #145) — rendered only when
+ * both the item has a server-assigned `id` and the caller actually supplied
+ * `selection` (every existing `ArtefactBody` test omits it, and renders
+ * exactly as before #145: no `selection` prop, no checkbox, unchanged
+ * markup). A real `<input type="checkbox">` with its own accessible name,
+ * not a styled `<div>`, so it is reachable and operable the same way as
+ * every other control on the page (#98's design pass: real keyboard access,
+ * a visible focus-visible ring). */
+function ElementCheckbox({ id, label, selection }: { id: string; label: string; selection: ElementSelection }) {
+  return (
+    <label className="element-select">
+      <input
+        type="checkbox"
+        checked={selection.isSelected(id)}
+        onChange={() => selection.toggle(id)}
+        aria-label={`Carry "${label}" forward when this stage is approved`}
+      />
+    </label>
+  )
 }
 
 /** One list of cited items — a research finding, a positioning segment,
@@ -149,15 +179,26 @@ interface FindingItem {
 function FindingGroup({
   items,
   renderSources,
+  selection,
 }: {
   items: FindingItem[]
   renderSources: (sources: Source[]) => ReactNode
+  /** Omitted entirely by every render site that has no selection to offer
+   * (a `pending`/`approved`/`rejected` artefact — `Pipeline.tsx` only ever
+   * builds one for a `proposed` stage) and by every existing test, which is
+   * exactly the pre-#145 rendering this preserves byte for byte. */
+  selection?: ElementSelection
 }) {
   return (
     <>
       {items.map((item) => (
         <div className="finding" key={item.key}>
-          {item.heading}
+          <div className="finding-head">
+            {selection !== undefined && item.id !== undefined && (
+              <ElementCheckbox id={item.id} label={item.label} selection={selection} />
+            )}
+            {item.heading}
+          </div>
           {item.body}
           {renderSources(item.sources)}
         </div>
@@ -183,7 +224,15 @@ function summaryParagraphs(summary: string): string[] {
     .filter((p) => p !== '')
 }
 
-export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
+export function ResearchArtefact({
+  body,
+  selection,
+}: {
+  body: ResearchSynthesisBody
+  /** See {@link FindingGroup}'s own doc — omitted for every non-`proposed`
+   * render and every existing test. */
+  selection?: ElementSelection
+}) {
   // One canonical, deduplicated citation list for the whole artefact — a URL
   // cited by several findings (common: two findings from different angles
   // independently landing on the same source) used to print its full URL and
@@ -204,11 +253,14 @@ export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
       <FindingGroup
         items={body.findings.map((f, i) => ({
           key: `${f.signal}-${i}`,
+          id: f.id,
+          label: f.signal,
           heading: <h4>{f.signal}</h4>,
           body: <p>{f.why_it_matters}</p>,
           sources: f.sources,
         }))}
         renderSources={(sources) => <CitationMarkers sources={sources} indexByUrl={indexByUrl} />}
+        selection={selection}
       />
       <h4>Sources cited</h4>
       <SourceList sources={allSources} />
@@ -216,40 +268,59 @@ export function ResearchArtefact({ body }: { body: ResearchSynthesisBody }) {
   )
 }
 
-export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
+export function PositioningArtefact({
+  body,
+  selection,
+}: {
+  body: PositioningBodyT
+  /** See {@link FindingGroup}'s own doc. One selection covers all three
+   * lists — segments, pillars and CTAs share one artefact and one approval,
+   * so a single set of ids is exactly what `pipeline.ELEMENT_LIST_KEYS`
+   * already treats them as. */
+  selection?: ElementSelection
+}) {
   return (
     <div className="artefact-body">
       <h4>Segments</h4>
       <FindingGroup
         items={body.segments.map((s, i) => ({
           key: `${s.name}-${i}`,
+          id: s.id,
+          label: s.name,
           heading: <h5>{s.name}</h5>,
           body: <p>{s.description}</p>,
           sources: s.sources,
         }))}
         renderSources={(sources) => <SourceRefs sources={sources} />}
+        selection={selection}
       />
 
       <h4>Message pillars</h4>
       <FindingGroup
         items={body.pillars.map((p, i) => ({
           key: `${p.pillar}-${i}`,
+          id: p.id,
+          label: p.pillar,
           heading: <p className="pillar">{p.pillar}</p>,
           body: <p>{p.rationale}</p>,
           sources: p.sources,
         }))}
         renderSources={(sources) => <SourceRefs sources={sources} />}
+        selection={selection}
       />
 
       <h4>Calls to action</h4>
       <FindingGroup
         items={body.ctas.map((c, i) => ({
           key: `${c.text}-${i}`,
+          id: c.id,
+          label: c.text,
           heading: <p className="pillar">{c.text}</p>,
           body: <p>{c.rationale}</p>,
           sources: c.sources,
         }))}
         renderSources={(sources) => <SourceRefs sources={sources} />}
+        selection={selection}
       />
     </div>
   )
@@ -258,9 +329,12 @@ export function PositioningArtefact({ body }: { body: PositioningBodyT }) {
 export function ChannelPlanArtefact({
   body,
   channelLookup,
+  selection,
 }: {
   body: ChannelPlanBodyT
   channelLookup: ChannelLookup
+  /** See {@link FindingGroup}'s own doc. */
+  selection?: ElementSelection
 }) {
   const byRank = [...body.channels].sort((a, b) => a.rank - b.rank)
   return (
@@ -268,6 +342,8 @@ export function ChannelPlanArtefact({
       <FindingGroup
         items={byRank.map((c, i) => ({
           key: `${c.channel_key ?? c.suggested_label ?? 'proposal'}-${i}`,
+          id: c.id,
+          label: c.channel_key ?? c.suggested_label ?? 'this channel',
           heading: (
             <h4>
               #{c.rank}{' '}
@@ -279,6 +355,7 @@ export function ChannelPlanArtefact({
           sources: c.sources,
         }))}
         renderSources={(sources) => <SourceRefs sources={sources} />}
+        selection={selection}
       />
     </div>
   )
@@ -309,12 +386,23 @@ function OverBudget({ overages, field }: { overages: LengthOverage[] | undefined
   )
 }
 
-export function CopyArtefact({ body, channelLookup }: { body: CopySetBody; channelLookup: ChannelLookup }) {
+export function CopyArtefact({
+  body,
+  channelLookup,
+  selection,
+}: {
+  body: CopySetBody
+  channelLookup: ChannelLookup
+  /** See {@link FindingGroup}'s own doc. */
+  selection?: ElementSelection
+}) {
   return (
     <div className="artefact-body">
       <FindingGroup
         items={body.channels.map((c, i) => ({
           key: `${c.channel_key}-${i}`,
+          id: c.id,
+          label: `${c.channel_key} — ${c.headline}`,
           heading: (
             <h4>
               <ChannelName channelKey={c.channel_key} suggestedLabel={null} lookup={channelLookup} />{' '}
@@ -337,6 +425,7 @@ export function CopyArtefact({ body, channelLookup }: { body: CopySetBody; chann
           sources: c.sources,
         }))}
         renderSources={(sources) => <SourceRefs sources={sources} />}
+        selection={selection}
       />
     </div>
   )

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -9,6 +9,7 @@ import {
   startCopy,
   startPositioning,
   startResearch,
+  StaleArtefactError,
   type Artefact,
   type ArtefactKind,
   type ChannelPlanBody,
@@ -16,6 +17,7 @@ import {
   type PositioningBody,
   type ResearchSynthesisBody,
 } from '../lib/api'
+import { elementsOf, type ElementSelection } from '../lib/elementSelection'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
 import { POLL_CEILING_MS, usePendingPolling } from '../lib/usePendingPolling'
 import { ChannelPlanArtefact, CopyArtefact, PositioningArtefact, ResearchArtefact } from './ArtefactBody'
@@ -25,7 +27,17 @@ interface StageState {
   artefact: Artefact | null
   loading: boolean
   error: string | null
+  /** See `PipelineStage`'s own doc — true only for an unknown-element-id 422
+   * from `approveArtefact` (issue #145), never for any other failure this
+   * stage can report. */
+  stale: boolean
   busy: boolean
+  /** Element ids the operator has unchecked for this stage's current
+   * `proposed` artefact (issue #145) — reset to empty the moment a NEW
+   * artefact (a different `id`) arrives for this stage, so a selection made
+   * against a previous run's elements can never silently carry over onto a
+   * fresh one's. */
+  deselected: Set<string>
 }
 
 interface Gate {
@@ -54,8 +66,11 @@ interface StageConfig {
   /** The stage's real output, once it has one — never called for a `null`
    * or still-`pending` artefact (see `Pipeline`'s render loop). `channelLookup`
    * is only read by the channel-plan and copy stages; research and
-   * positioning's renderers simply ignore the second argument. */
-  renderBody: (artefact: Artefact, channelLookup: ChannelLookup) => ReactNode
+   * positioning's renderers simply ignore the second argument. `selection`
+   * (issue #145) is passed straight through to the `ArtefactBody` renderer,
+   * which is the one place that actually knows how to draw a checkbox next
+   * to each of ITS shape's elements. */
+  renderBody: (artefact: Artefact, channelLookup: ChannelLookup, selection: ElementSelection) => ReactNode
   gate: (approved: Approved, hasBrief: boolean) => Gate
 }
 
@@ -67,9 +82,13 @@ const STAGES: StageConfig[] = [
     kind: 'research',
     title: 'Research',
     start: startResearch,
-    renderBody: (artefact) => {
+    renderBody: (artefact, _channelLookup, selection) => {
       const body = parseArtefactBody<ResearchSynthesisBody>(artefact)
-      return body !== null ? <ResearchArtefact body={body} /> : <p className="empty">No content to show.</p>
+      return body !== null ? (
+        <ResearchArtefact body={body} selection={selection} />
+      ) : (
+        <p className="empty">No content to show.</p>
+      )
     },
     gate: (_approved, hasBrief) =>
       reason(hasBrief, 'This campaign has no brief yet — add one above before starting research.'),
@@ -78,9 +97,13 @@ const STAGES: StageConfig[] = [
     kind: 'positioning',
     title: 'Positioning',
     start: startPositioning,
-    renderBody: (artefact) => {
+    renderBody: (artefact, _channelLookup, selection) => {
       const body = parseArtefactBody<PositioningBody>(artefact)
-      return body !== null ? <PositioningArtefact body={body} /> : <p className="empty">No content to show.</p>
+      return body !== null ? (
+        <PositioningArtefact body={body} selection={selection} />
+      ) : (
+        <p className="empty">No content to show.</p>
+      )
     },
     gate: (approved) => reason(approved.research, 'Approve the research stage first.'),
   },
@@ -88,10 +111,10 @@ const STAGES: StageConfig[] = [
     kind: 'channel_plan',
     title: 'Channel plan',
     start: startChannelPlan,
-    renderBody: (artefact, channelLookup) => {
+    renderBody: (artefact, channelLookup, selection) => {
       const body = parseArtefactBody<ChannelPlanBody>(artefact)
       return body !== null ? (
-        <ChannelPlanArtefact body={body} channelLookup={channelLookup} />
+        <ChannelPlanArtefact body={body} channelLookup={channelLookup} selection={selection} />
       ) : (
         <p className="empty">No content to show.</p>
       )
@@ -102,10 +125,10 @@ const STAGES: StageConfig[] = [
     kind: 'copy',
     title: 'Copy',
     start: startCopy,
-    renderBody: (artefact, channelLookup) => {
+    renderBody: (artefact, channelLookup, selection) => {
       const body = parseArtefactBody<CopySetBody>(artefact)
       return body !== null ? (
-        <CopyArtefact body={body} channelLookup={channelLookup} />
+        <CopyArtefact body={body} channelLookup={channelLookup} selection={selection} />
       ) : (
         <p className="empty">No content to show.</p>
       )
@@ -127,7 +150,14 @@ const STAGES: StageConfig[] = [
 ]
 
 function initialState(): Record<ArtefactKind, StageState> {
-  const empty = (): StageState => ({ artefact: null, loading: true, error: null, busy: false })
+  const empty = (): StageState => ({
+    artefact: null,
+    loading: true,
+    error: null,
+    stale: false,
+    busy: false,
+    deselected: new Set<string>(),
+  })
   return { research: empty(), positioning: empty(), channel_plan: empty(), copy: empty() }
 }
 
@@ -155,6 +185,40 @@ export function Pipeline({
     setState((prev) => ({ ...prev, [kind]: { ...prev[kind], ...next } }))
   }
 
+  /** Set a stage's freshly-read/mutated `artefact`, and reset its selection
+   * (issue #145) the moment the artefact's own `id` changes — a new pipeline
+   * run, which must never inherit a previous run's deselections onto
+   * whatever now sits at the same position in a regenerated list (`with_
+   * element_ids`' own reasoning against positional ids, one level up: the
+   * SAME failure shape — an earlier choice silently reattaching to different
+   * content — is just as real for the OPERATOR'S selection as it is for the
+   * element ids themselves). Always clears `stale`: whatever the previous
+   * error meant, a fresh artefact read is the resolution to it. */
+  function applyArtefact(kind: ArtefactKind, artefact: Artefact | null, extra: Partial<StageState> = {}) {
+    setState((prev) => {
+      const idChanged = prev[kind].artefact?.id !== artefact?.id
+      return {
+        ...prev,
+        [kind]: {
+          ...prev[kind],
+          artefact,
+          stale: false,
+          ...(idChanged ? { deselected: new Set<string>() } : {}),
+          ...extra,
+        },
+      }
+    })
+  }
+
+  function toggleElement(kind: ArtefactKind, id: string) {
+    setState((prev) => {
+      const next = new Set(prev[kind].deselected)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return { ...prev, [kind]: { ...prev[kind], deselected: next } }
+    })
+  }
+
   /** Read a stage's artefact.
    *
    * `quiet` is the difference between a read somebody ASKED for and one the
@@ -176,13 +240,13 @@ export function Pipeline({
    * the stage rather than in place of it.
    */
   async function load(kind: ArtefactKind, { quiet = false }: { quiet?: boolean } = {}) {
-    if (!quiet) patch(kind, { loading: true, error: null })
+    if (!quiet) patch(kind, { loading: true, error: null, stale: false })
     try {
       const artefact = await getArtefact(campaignId, kind)
-      patch(kind, quiet ? { artefact } : { artefact, loading: false })
+      applyArtefact(kind, artefact, quiet ? {} : { loading: false })
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e)
-      patch(kind, quiet ? { error: message } : { loading: false, error: message })
+      patch(kind, quiet ? { error: message } : { loading: false, error: message, stale: false })
     }
   }
 
@@ -198,12 +262,20 @@ export function Pipeline({
   }, [campaignId])
 
   async function runMutation(kind: ArtefactKind, mutate: () => Promise<Artefact | null>) {
-    patch(kind, { busy: true, error: null })
+    patch(kind, { busy: true, error: null, stale: false })
     try {
       const artefact = await mutate()
-      patch(kind, { artefact, busy: false })
+      applyArtefact(kind, artefact, { busy: false })
     } catch (e: unknown) {
-      patch(kind, { busy: false, error: e instanceof Error ? e.message : String(e) })
+      // `StaleArtefactError` (issue #145) is `approveArtefact`'s "unknown
+      // element id" 422 — the artefact changed under the operator, so
+      // `PipelineStage` offers "Reload" instead of leaving them to resubmit
+      // the exact selection that just failed.
+      patch(kind, {
+        busy: false,
+        error: e instanceof Error ? e.message : String(e),
+        stale: e instanceof StaleArtefactError,
+      })
     }
   }
 
@@ -248,12 +320,25 @@ export function Pipeline({
       {STAGES.map((stage) => {
         const s = state[stage.kind]
         const gate = stage.gate(approved, hasBrief)
+        // Every operator-selectable element in this stage's CURRENT
+        // artefact (issue #145) — `[]` while there is nothing proposed yet,
+        // computed fresh every render rather than cached in state, since it
+        // is a pure read of `s.artefact.body` and keeping a second copy in
+        // sync with it is exactly the kind of drift this file elsewhere
+        // avoids (see `StageConfig` itself).
+        const elements = elementsOf(s.artefact)
+        const selection: ElementSelection = {
+          isSelected: (id) => !s.deselected.has(id),
+          toggle: (id) => toggleElement(stage.kind, id),
+        }
         // `pending`'s body is bookkeeping (e.g. research's in-flight run
         // ids), not the real stage output — see `Artefact`'s own doc
         // comment. Nothing to render until the gate has actually produced
         // something.
         const body =
-          s.artefact !== null && s.artefact.status !== 'pending' ? stage.renderBody(s.artefact, channelLookup) : null
+          s.artefact !== null && s.artefact.status !== 'pending'
+            ? stage.renderBody(s.artefact, channelLookup, selection)
+            : null
         return (
           <PipelineStage
             key={stage.kind}
@@ -262,13 +347,18 @@ export function Pipeline({
             artefact={s.artefact}
             loading={s.loading}
             error={s.error}
+            stale={s.stale}
             canStart={gate.canStart}
             blockedReason={gate.blockedReason}
             busy={s.busy}
             onStart={() => runMutation(stage.kind, () => stage.start(campaignId))}
             onRefresh={() => runMutation(stage.kind, () => getArtefact(campaignId, stage.kind))}
-            onApprove={() => runMutation(stage.kind, () => approveArtefact(campaignId, stage.kind))}
+            onApprove={(elementIds) =>
+              runMutation(stage.kind, () => approveArtefact(campaignId, stage.kind, elementIds))
+            }
             onReject={() => runMutation(stage.kind, () => rejectArtefact(campaignId, stage.kind))}
+            elements={elements}
+            deselectedIds={s.deselected}
           >
             {body}
           </PipelineStage>

--- a/web-admin/src/components/PipelineStage.test.tsx
+++ b/web-admin/src/components/PipelineStage.test.tsx
@@ -159,4 +159,160 @@ describe('PipelineStage', () => {
     expect(screen.getByText(/no brief yet/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /run research again/i })).toBeDisabled()
   })
+
+  // ── Partial approval (issue #145) ─────────────────────────────────────────
+
+  const TWO_ELEMENTS = [
+    { id: 'e1', label: 'Owners want faster onboarding' },
+    { id: 'e2', label: 'Competitors take 3 weeks' },
+  ]
+
+  it('defaults to everything selected: approving untouched sends no body, exactly as before #145', async () => {
+    const onApprove = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={onApprove}
+        onReject={noop}
+        elements={TWO_ELEMENTS}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    // Nothing deselected: the button is plain "Approve", not "Approve N of
+    // M" — the one-click common case must not change shape just because
+    // there is now something to select from.
+    const approveButton = screen.getByRole('button', { name: /^approve$/i })
+    expect(screen.queryByText(/will drop/i)).not.toBeInTheDocument()
+    await user.click(approveButton)
+    expect(onApprove).toHaveBeenCalledOnce()
+    expect(onApprove).toHaveBeenCalledWith(null)
+  })
+
+  it('deselecting one element sends only the remaining ids, and shows what will be dropped', async () => {
+    const onApprove = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={onApprove}
+        onReject={noop}
+        elements={TWO_ELEMENTS}
+        deselectedIds={new Set(['e1'])}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    // The dropped element is named, so an operator sees exactly what they
+    // are about to lose before committing — not just a bare count.
+    expect(screen.getByText(/will drop 1 of 2/i)).toBeInTheDocument()
+    expect(screen.getByText('Owners want faster onboarding')).toBeInTheDocument()
+    expect(screen.queryByText('Competitors take 3 weeks')).not.toBeInTheDocument()
+
+    const approveButton = screen.getByRole('button', { name: /approve 1 of 2/i })
+    await user.click(approveButton)
+    expect(onApprove).toHaveBeenCalledOnce()
+    expect(onApprove).toHaveBeenCalledWith(['e2'])
+  })
+
+  it('blocks approving when everything is deselected, pointing at reject instead', async () => {
+    const onApprove = vi.fn()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error={null}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={onApprove}
+        onReject={noop}
+        elements={TWO_ELEMENTS}
+        deselectedIds={new Set(['e1', 'e2'])}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    expect(screen.getByText(/nothing is selected/i)).toBeInTheDocument()
+    expect(screen.getByText(/use "reject"/i)).toBeInTheDocument()
+    const approveButton = screen.getByRole('button', { name: /approve 0 of 2/i })
+    expect(approveButton).toBeDisabled()
+    // A disabled button ignores clicks outright, but assert the intent too:
+    // this route must never be reachable from the UI, since the server 422s
+    // an empty selection on purpose (issue #145).
+    expect(onApprove).not.toHaveBeenCalled()
+  })
+
+  it('offers a Reload action on a stale-selection error, not just the raw message', async () => {
+    const onRefresh = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error="Unknown element id(s): e9. This selection may be stale — refresh the artefact and try again. (422)"
+        stale={true}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={onRefresh}
+        onApprove={noop}
+        onReject={noop}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    expect(screen.getByText(/unknown element id/i)).toBeInTheDocument()
+    const reloadButton = screen.getByRole('button', { name: /reload/i })
+    await user.click(reloadButton)
+    expect(onRefresh).toHaveBeenCalledOnce()
+  })
+
+  it('does not offer Reload for an ordinary error', () => {
+    render(
+      <PipelineStage
+        kind="research"
+        title="Research"
+        artefact={artefact('proposed')}
+        loading={false}
+        error="could not approve the research stage (500)"
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      >
+        <p>the research findings</p>
+      </PipelineStage>,
+    )
+    expect(screen.queryByRole('button', { name: /reload/i })).not.toBeInTheDocument()
+  })
 })

--- a/web-admin/src/components/PipelineStage.tsx
+++ b/web-admin/src/components/PipelineStage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import type { Artefact, ArtefactKind, ArtefactStatus } from '../lib/api'
+import type { SelectableElement } from '../lib/elementSelection'
 
 const STATUS_LABEL: Record<ArtefactStatus, string> = {
   pending: 'Running…',
@@ -15,6 +16,12 @@ interface PipelineStageProps {
   artefact: Artefact | null
   loading: boolean
   error: string | null
+  /** True when `error` is `approveArtefact` failing with `StaleArtefactError`
+   * (issue #145) — an unknown-element-id 422, which means the artefact
+   * changed under the operator (a re-run, or a page left open) rather than
+   * anything wrong with the choice they made. Offers "Reload" instead of
+   * leaving them to retry the exact request that just failed. */
+  stale?: boolean
   /** Whether the upstream gate this stage needs is satisfied. */
   canStart: boolean
   /** Human reason `canStart` is false, shown instead of a start button that
@@ -23,8 +30,24 @@ interface PipelineStageProps {
   busy: boolean
   onStart: () => void
   onRefresh: () => void
-  onApprove: () => void
+  /** `elementIds`: `null` to approve everything — sends no request body, the
+   * pre-#145 behaviour and still what a click with nothing deselected sends
+   * (issue #145: "approving without touching anything must behave exactly
+   * as it does now"). A non-empty array to approve only that subset. Never
+   * called with an empty array — {@link PipelineStage} itself disables the
+   * button rather than letting that request reach the server's 422. */
+  onApprove: (elementIds: string[] | null) => void
   onReject: () => void
+  /** Every operator-selectable element in this stage's `proposed` artefact —
+   * omitted (or `[]`) for a stage with nothing to select from yet (no
+   * artefact, still pending, or a legacy body with no element ids at all),
+   * in which case the Approve button behaves exactly as it always has. */
+  elements?: SelectableElement[]
+  /** Element ids the operator has unchecked — always a subset of
+   * `elements`'s ids. Everything else in `elements` is selected; an empty
+   * (or omitted) set is "everything selected", the default this stage opens
+   * in every time a fresh `proposed` artefact arrives. */
+  deselectedIds?: Set<string>
   /** The rendered artefact body — `null` while there is nothing approved,
    * proposed or rejected to show yet. */
   children?: ReactNode
@@ -37,6 +60,14 @@ interface PipelineStageProps {
  * positioning, channel plan, copy) rather than four near-identical copies,
  * because the gate shape is exactly the same for all of them; only the start
  * action and the body renderer differ, and both are supplied by the caller.
+ *
+ * **Owns the approve/reject controls (issue #145).** `elements`/
+ * `deselectedIds` are supplied by `Pipeline.tsx`, which is where the
+ * selection actually lives (one `Set<string>` per stage, alongside
+ * `artefact`/`busy`/`error`) — this component's job is turning that state
+ * into what `onApprove` is called with, and into what the operator sees
+ * before they commit: what a partial approval would drop, and why an empty
+ * selection is blocked rather than silently sent.
  */
 export function PipelineStage({
   kind,
@@ -44,6 +75,7 @@ export function PipelineStage({
   artefact,
   loading,
   error,
+  stale = false,
   canStart,
   blockedReason,
   busy,
@@ -51,9 +83,31 @@ export function PipelineStage({
   onRefresh,
   onApprove,
   onReject,
+  elements = [],
+  deselectedIds,
   children,
 }: PipelineStageProps) {
   const status = artefact?.status ?? null
+  const deselected = deselectedIds ?? new Set<string>()
+  const dropped = elements.filter((el) => deselected.has(el.id))
+  const selectedCount = elements.length - dropped.length
+  // Only meaningful when there is something to select from at all — an
+  // artefact with no ids yet (legacy, or before this stage has ever run)
+  // must not be treated as "nothing selected".
+  const noneSelected = elements.length > 0 && selectedCount === 0
+  const hasDeselection = dropped.length > 0
+
+  function handleApprove() {
+    if (!hasDeselection) {
+      // Untouched: send no body at all. This is the one branch that must
+      // behave byte-for-byte as it did before #145 — see this file's own
+      // `onApprove` doc.
+      onApprove(null)
+      return
+    }
+    const ids = elements.filter((el) => !deselected.has(el.id)).map((el) => el.id)
+    onApprove(ids)
+  }
 
   return (
     <section className="stage" aria-label={title} data-testid={`stage-${kind}`}>
@@ -63,7 +117,16 @@ export function PipelineStage({
       </div>
 
       {loading && <p className="empty">Loading…</p>}
-      {error !== null && <p className="error">{error}</p>}
+      {error !== null && (
+        <div className="error-panel">
+          <p className="error">{error}</p>
+          {stale && (
+            <button type="button" className="secondary" onClick={onRefresh}>
+              Reload
+            </button>
+          )}
+        </div>
+      )}
 
       {!loading && (
         <>
@@ -95,13 +158,41 @@ export function PipelineStage({
           {(status === 'proposed' || status === 'approved' || status === 'rejected') && children}
 
           {status === 'proposed' && (
-            <div className="stage-actions">
-              <button type="button" onClick={onApprove} disabled={busy}>
-                {busy ? 'Approving…' : 'Approve'}
-              </button>
-              <button type="button" className="secondary" onClick={onReject} disabled={busy}>
-                {busy ? 'Rejecting…' : 'Reject'}
-              </button>
+            <div className="stage-actions-group">
+              {elements.length > 0 && hasDeselection && (
+                <div className="selection-summary" aria-live="polite">
+                  {noneSelected ? (
+                    <p className="hint">
+                      Nothing is selected. Approving nothing is not the same as rejecting — use "Reject" below if
+                      none of this is usable, or tick at least one item to approve a subset.
+                    </p>
+                  ) : (
+                    <>
+                      <p className="hint">
+                        Approving now will drop {dropped.length} of {elements.length} item
+                        {elements.length === 1 ? '' : 's'}:
+                      </p>
+                      <ul className="dropped-elements">
+                        {dropped.map((el) => (
+                          <li key={el.id}>{el.label}</li>
+                        ))}
+                      </ul>
+                    </>
+                  )}
+                </div>
+              )}
+              <div className="stage-actions">
+                <button type="button" onClick={handleApprove} disabled={busy || noneSelected}>
+                  {busy
+                    ? 'Approving…'
+                    : hasDeselection
+                      ? `Approve ${selectedCount} of ${elements.length}`
+                      : 'Approve'}
+                </button>
+                <button type="button" className="secondary" onClick={onReject} disabled={busy}>
+                  {busy ? 'Rejecting…' : 'Reject'}
+                </button>
+              </div>
             </div>
           )}
         </>

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -670,6 +670,59 @@ details.mint-toggle[open] > .mint {
   margin-top: 0.75rem;
 }
 
+/* ── Partial approval (issue #145) ────────────────────────────────────────
+ *
+ * `.selection-summary` sits above the Approve/Reject row, only while at
+ * least one element is unchecked — the drop-consequence preview the issue
+ * asks for ("show what will be dropped before they commit"), not a second
+ * confirmation step: it is on screen for as long as the deselection is, so
+ * approving is still one click once it has been read.
+ */
+
+.stage-actions-group {
+  margin-top: 0.75rem;
+}
+
+.stage-actions-group .stage-actions {
+  margin-top: 0.5rem;
+}
+
+.selection-summary {
+  padding: 0.6rem 0.75rem;
+  background: var(--warning-bg);
+  border-radius: var(--radius-sm);
+}
+
+.selection-summary .hint {
+  margin: 0;
+  color: var(--warning-text);
+}
+
+.dropped-elements {
+  margin: 0.4rem 0 0;
+  padding-left: 1.25rem;
+  font-size: 0.8rem;
+  color: var(--warning-text);
+}
+
+.dropped-elements li {
+  margin-bottom: 0.15rem;
+}
+
+/* The error message and its optional "Reload" action (a stale-selection 422,
+   issue #145) sit on one row so Reload reads as attached to the message it
+   answers, not as an unrelated extra control. */
+.error-panel {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+
+.error-panel .error {
+  margin: 0;
+}
+
 /* ── Artefact bodies ───────────────────────────────────────────────────────
  *
  * Constrained to a readable measure regardless of how wide the card around
@@ -697,6 +750,51 @@ details.mint-toggle[open] > .mint {
 .artefact-body .finding {
   padding: 0.5rem 0;
   border-top: 1px solid var(--border);
+}
+
+/* One element's carry-forward checkbox (issue #145), beside its own heading
+   rather than above or below it — the operator is deciding about THIS
+   heading, and the checkbox needs to read as attached to it. Only rendered
+   at all when the artefact is `proposed` and the element has a
+   server-assigned id (`ArtefactBody.tsx`'s `FindingGroup`), so `.finding` on
+   every other status still renders with `.finding-head` holding just the
+   heading — no layout shift when the controls disappear. */
+.artefact-body .finding-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.artefact-body .finding-head h4,
+.artefact-body .finding-head h5,
+.artefact-body .finding-head .pillar,
+.artefact-body .finding-head .headline {
+  margin-top: 0;
+}
+
+.element-select {
+  display: inline-flex;
+  align-items: center;
+  /* Nudges the checkbox onto the heading's own cap-height rather than its
+     line-box top, so it does not read as floating above the text. */
+  margin-top: 0.2rem;
+  cursor: pointer;
+}
+
+.element-select input[type='checkbox'] {
+  /* Overrides the generic `input { width: 100%; margin-bottom: 1rem }`
+     rule above — correct for a text field, not for an inline checkbox. */
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.element-select input[type='checkbox']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus-ring) 25%, transparent);
+  border-radius: var(--radius-sm);
 }
 
 /* The research summary is "reconciled into a few paragraphs"

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -11,6 +11,7 @@ import {
   listChannels,
   mintLinks,
   parseArtefactBody,
+  StaleArtefactError,
   startResearch,
   updateCampaign,
   type ResearchSynthesisBody,
@@ -200,6 +201,76 @@ describe('pipeline artefacts', () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/plugins/marketing/admin/campaigns/c1/artefacts/channel_plan/approve')
     expect(init.method).toBe('POST')
+  })
+
+  // ── Partial approval (issue #145) ─────────────────────────────────────────
+
+  it('sends no body when approving with no element ids — the pre-#145 caller, unchanged', async () => {
+    stubSession('abc123')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: 'a1', status: 'approved' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await approveArtefact('c1', 'research')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    // `api-core.ts`'s `request` only serialises a body when one is passed at
+    // all — a `null`/omitted `elementIds` must reach `fetch` as no body,
+    // not as `{"element_ids": null}`, or a stale reader on the server that
+    // treats "key present" differently from "key absent" would see a
+    // different request than every existing caller sends today.
+    expect(init.body).toBeUndefined()
+  })
+
+  it('sends exactly the given element ids when a subset is approved', async () => {
+    stubSession('abc123')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: 'a1', status: 'approved' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await approveArtefact('c1', 'research', ['e2', 'e3'])
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(init.body as string)).toEqual({ element_ids: ['e2', 'e3'] })
+  })
+
+  it('throws StaleArtefactError, not a plain Error, for the unknown-element-id 422', async () => {
+    stubSession('abc123')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: "Unknown element id(s): e9. This selection may be stale — refresh the artefact and try again.",
+        }),
+      }),
+    )
+    await expect(approveArtefact('c1', 'research', ['e9'])).rejects.toBeInstanceOf(StaleArtefactError)
+  })
+
+  it('does NOT throw StaleArtefactError for the empty-selection 422 from the same route', async () => {
+    // A different failure from the same endpoint (issue #145's own route):
+    // the operator deselected everything, which `PipelineStage` already
+    // stops them from submitting, but a defensive caller must still read
+    // this as an ordinary error, not "reload" — there is nothing stale
+    // about it.
+    stubSession('abc123')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          detail: 'An empty selection is not a valid approval — it is indistinguishable from approving nothing by accident.',
+        }),
+      }),
+    )
+    const failure = approveArtefact('c1', 'research', [])
+    await expect(failure).rejects.not.toBeInstanceOf(StaleArtefactError)
+    await expect(failure).rejects.toThrow(/empty selection/i)
   })
 })
 

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -21,6 +21,16 @@
 import { getCurrentSession } from './auth'
 import { createRequest } from './api-core'
 
+/** Thrown by {@link approveArtefact} specifically for `approve_artefact_route`'s
+ * "Unknown element id(s)" 422 (issue #145, `admin_app.py`) — the artefact
+ * changed under the operator (someone re-ran the stage, or the page has been
+ * open since before this run) so the ids it is holding are no longer the
+ * artefact's own. Distinguished from every other failure this route can
+ * return (403, "not proposed" 409, an empty-selection 422) because it is the
+ * one case where the right response is not "read the message" but "reload
+ * and choose again" — a stale id cannot be retried into success. */
+export class StaleArtefactError extends Error {}
+
 export interface Campaign {
   id: string
   name: string
@@ -182,6 +192,23 @@ async function onError(response: Response, context: string | undefined): Promise
       if (response.status === 403) {
         throw new Error(detail !== null ? `${detail} (403)` : `you need the admin role to ${context} (403)`)
       }
+      // `approve_artefact_route`'s "Unknown element id(s)" 422 (issue #145):
+      // the artefact changed under the operator, so the selection they are
+      // holding cannot succeed no matter how many times it is retried — the
+      // one 422 this route returns that means "reload", not "read this and
+      // adjust". Matched on the context (only an approve call reaches this
+      // shape) and the detail text itself, since a "not proposed" 409 or the
+      // empty-selection 422 from the very same route are NOT this case and
+      // must keep their own plain-error rendering.
+      if (
+        response.status === 422 &&
+        context !== undefined &&
+        context.startsWith('approve the ') &&
+        detail !== null &&
+        detail.startsWith('Unknown element id')
+      ) {
+        throw new StaleArtefactError(detail)
+      }
       if (detail !== null) {
         throw new Error(`${detail} (${response.status})`)
       }
@@ -328,7 +355,16 @@ export interface Source {
   note: string
 }
 
+/** `id` is server-assigned at persist time (`pipeline.with_element_ids`,
+ * issue #145) — never model-generated, never positional. **Optional**, not
+ * required: an artefact body written before #150 shipped has none, and
+ * carries none until it is re-run. Every element written from here on
+ * always has one; the optionality only covers that legacy gap, and the
+ * selection UI (`PipelineStage`/`ArtefactBody`) treats an id-less element as
+ * not independently selectable — it rides along with whatever the approval
+ * decides for the rest of the artefact, exactly as it did before this issue. */
 export interface ResearchFinding {
+  id?: string
   signal: string
   why_it_matters: string
   sources: Source[]
@@ -340,18 +376,21 @@ export interface ResearchSynthesisBody {
 }
 
 export interface Segment {
+  id?: string
   name: string
   description: string
   sources: Source[]
 }
 
 export interface MessagePillar {
+  id?: string
   pillar: string
   rationale: string
   sources: Source[]
 }
 
 export interface CallToAction {
+  id?: string
   text: string
   rationale: string
   sources: Source[]
@@ -368,6 +407,7 @@ export interface PositioningBody {
  * outside it (#67). Never both, never neither — enforced server-side by
  * `definitions.ChannelRecommendation`'s own validator, not re-checked here. */
 export interface ChannelRecommendation {
+  id?: string
   channel_key: string | null
   suggested_label: string | null
   motion: 'organic' | 'paid'
@@ -394,6 +434,7 @@ export interface LengthOverage {
 }
 
 export interface ChannelCopy {
+  id?: string
   channel_key: string
   motion: 'organic' | 'paid'
   headline: string
@@ -473,11 +514,27 @@ export async function getArtefact(campaignId: string, kind: ArtefactKind): Promi
   return (await response.json()) as Artefact
 }
 
-export async function approveArtefact(campaignId: string, kind: ArtefactKind): Promise<Artefact> {
+/** Approve a `proposed` artefact, optionally narrowed to a subset of its
+ * elements (issue #145).
+ *
+ * `elementIds` is `null`/omitted for "approve everything" — the ONLY body
+ * this function sent before #145, and the one every existing caller must
+ * keep sending unchanged: `undefined` here means no request body goes out at
+ * all (`api-core.ts`'s `request` only serialises a body when one is passed),
+ * matching `approve_artefact_route`'s own "no body = approve everything"
+ * reading. A non-empty array narrows the approval to exactly those ids; the
+ * route itself rejects an empty array (422) — see {@link StaleArtefactError}
+ * for the other 422 this call can throw, which is a different failure and
+ * needs a different response from the caller. */
+export async function approveArtefact(
+  campaignId: string,
+  kind: ArtefactKind,
+  elementIds?: string[] | null,
+): Promise<Artefact> {
   return request<Artefact>(
     'POST',
     `/campaigns/${campaignId}/artefacts/${kind}/approve`,
-    undefined,
+    elementIds != null ? { element_ids: elementIds } : undefined,
     ADMIN_BASE,
     `approve the ${kind.replace('_', ' ')} stage`,
   )

--- a/web-admin/src/lib/elementSelection.test.ts
+++ b/web-admin/src/lib/elementSelection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Artefact } from './api'
+import { elementsOf } from './elementSelection'
+
+function artefact(body: unknown): Artefact {
+  return {
+    id: 'a1',
+    campaign_id: 'c1',
+    kind: 'research',
+    status: 'proposed',
+    body: JSON.stringify(body),
+    citations: null,
+    causation_id: null,
+    agent_run_id: null,
+  }
+}
+
+describe('elementsOf', () => {
+  it('returns nothing for no artefact, no body, or an unparseable body', () => {
+    expect(elementsOf(null)).toEqual([])
+    expect(elementsOf({ ...artefact({}), body: null })).toEqual([])
+    expect(elementsOf({ ...artefact({}), body: 'not json' })).toEqual([])
+  })
+
+  it('collects every findings id and its signal as the label (research)', () => {
+    const result = elementsOf(
+      artefact({
+        summary: 'x',
+        findings: [
+          { id: 'f1', signal: 'Owners want faster onboarding', why_it_matters: 'x', sources: [] },
+          { id: 'f2', signal: 'Competitors take 3 weeks', why_it_matters: 'x', sources: [] },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      { id: 'f1', label: 'Owners want faster onboarding' },
+      { id: 'f2', label: 'Competitors take 3 weeks' },
+    ])
+  })
+
+  it('collects segments, pillars and ctas together (positioning)', () => {
+    const result = elementsOf(
+      artefact({
+        segments: [{ id: 's1', name: 'Busy owners', description: 'x', sources: [] }],
+        pillars: [{ id: 'p1', pillar: 'Onboard in a day', rationale: 'x', sources: [] }],
+        ctas: [{ id: 'c1', text: 'Book a demo', rationale: 'x', sources: [] }],
+      }),
+    )
+    expect(result).toEqual([
+      { id: 's1', label: 'Busy owners' },
+      { id: 'p1', label: 'Onboard in a day' },
+      { id: 'c1', label: 'Book a demo' },
+    ])
+  })
+
+  it('labels a channel-plan recommendation from its channel_key or suggested_label (#67)', () => {
+    const result = elementsOf(
+      artefact({
+        channels: [
+          {
+            id: 'ch1',
+            channel_key: 'linkedin_organic',
+            suggested_label: null,
+            motion: 'organic',
+            rank: 1,
+            rationale: 'x',
+            sources: [],
+          },
+          {
+            id: 'ch2',
+            channel_key: null,
+            suggested_label: 'Reddit r/franchise',
+            motion: 'organic',
+            rank: 2,
+            rationale: 'x',
+            sources: [],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([
+      { id: 'ch1', label: 'linkedin_organic' },
+      { id: 'ch2', label: 'Reddit r/franchise' },
+    ])
+  })
+
+  it('labels a piece of copy with its channel and headline together, distinct from a channel-plan entry', () => {
+    const result = elementsOf(
+      artefact({
+        channels: [
+          {
+            id: 'cp1',
+            channel_key: 'linkedin_organic',
+            motion: 'organic',
+            headline: 'Faster onboarding, starting today',
+            body: 'x',
+            cta: 'x',
+            sources: [],
+          },
+        ],
+      }),
+    )
+    expect(result).toEqual([{ id: 'cp1', label: 'linkedin_organic — Faster onboarding, starting today' }])
+  })
+
+  it('skips an element with no id — a legacy body from before #150', () => {
+    const result = elementsOf(
+      artefact({
+        summary: 'x',
+        findings: [
+          { signal: 'No id at all', why_it_matters: 'x', sources: [] },
+          { id: 'f2', signal: 'Has an id', why_it_matters: 'x', sources: [] },
+        ],
+      }),
+    )
+    expect(result).toEqual([{ id: 'f2', label: 'Has an id' }])
+  })
+})

--- a/web-admin/src/lib/elementSelection.ts
+++ b/web-admin/src/lib/elementSelection.ts
@@ -1,0 +1,82 @@
+/** Element identity + operator selection, the frontend half of issue #145.
+ *
+ * Mirrors `pipeline.py`'s `ELEMENT_LIST_KEYS`/`known_element_ids` on the
+ * backend deliberately: the server stamps a stable `id` onto every element
+ * of every one of these lists at persist time
+ * (`pipeline.with_element_ids`), and this is the one place the frontend
+ * reads that same set back out of a parsed artefact body — generically,
+ * over the raw JSON, rather than four kind-specific copies (one per
+ * `ResearchSynthesisBody`/`PositioningBody`/`ChannelPlanBody`/`CopySetBody`)
+ * that the four artefact kinds would otherwise need to keep in step by hand.
+ */
+
+import type { Artefact } from './api'
+import { parseArtefactBody } from './api'
+
+/** Same four field names `pipeline.ELEMENT_LIST_KEYS` (Python) lists —
+ * `findings` (research), `segments`/`pillars`/`ctas` (positioning),
+ * `channels` (channel_plan AND copy, which share the field name but not the
+ * item shape; nothing here needs to tell them apart). */
+const ELEMENT_LIST_KEYS = ['findings', 'segments', 'pillars', 'ctas', 'channels'] as const
+
+/** One operator-selectable element, generic across every artefact kind — an
+ * `id` to select/deselect by, and a short human-readable `label` for the
+ * drop-consequence preview (`PipelineStage`'s "this will be dropped" list). */
+export interface SelectableElement {
+  id: string
+  label: string
+}
+
+/** The single text field that best identifies one element, whichever of the
+ * five shapes it is. Checked in an order that cannot collide: a research
+ * finding, a segment, a pillar and a CTA each have exactly one of
+ * `signal`/`name`/`pillar`/`text`; a channel-plan recommendation and a piece
+ * of copy both use `channel_key`/`suggested_label`, distinguished from each
+ * other only by copy also carrying `headline` — so copy's richer label is
+ * checked first. */
+function labelOf(item: Record<string, unknown>): string {
+  if (typeof item.signal === 'string') return item.signal
+  if (typeof item.name === 'string') return item.name
+  if (typeof item.pillar === 'string') return item.pillar
+  if (typeof item.text === 'string') return item.text
+  const channel =
+    typeof item.channel_key === 'string'
+      ? item.channel_key
+      : typeof item.suggested_label === 'string'
+        ? item.suggested_label
+        : 'this item'
+  return typeof item.headline === 'string' ? `${channel} — ${item.headline}` : channel
+}
+
+/** Every element in `artefact`'s body that carries a server-assigned `id` —
+ * `[]` for no artefact, an unparseable body, or a body from before #150
+ * whose elements have none. An element with no `id` is not offered here:
+ * `pipeline.selected_body` on the server drops an id-less item the moment
+ * ANY selection is submitted (it cannot have been named in one), so
+ * offering it a checkbox that silently does nothing the moment a sibling
+ * element is deselected would be worse than not offering one at all. */
+export function elementsOf(artefact: Artefact | null): SelectableElement[] {
+  const body = parseArtefactBody<Record<string, unknown>>(artefact)
+  if (body === null) return []
+  const elements: SelectableElement[] = []
+  for (const key of ELEMENT_LIST_KEYS) {
+    const items = body[key]
+    if (!Array.isArray(items)) continue
+    for (const item of items) {
+      if (item === null || typeof item !== 'object') continue
+      const record = item as Record<string, unknown>
+      if (typeof record.id !== 'string' || record.id === '') continue
+      elements.push({ id: record.id, label: labelOf(record) })
+    }
+  }
+  return elements
+}
+
+/** The controls an artefact-body renderer needs to show and toggle a
+ * per-element checkbox, without knowing where the selection state actually
+ * lives (`Pipeline.tsx`, per stage) — the same seam `channelLookup` already
+ * uses for the taxonomy. */
+export interface ElementSelection {
+  isSelected: (id: string) => boolean
+  toggle: (id: string) => void
+}


### PR DESCRIPTION
## What

The UI half of #145, built on top of #150's backend. Lets an operator choose
which elements of a `proposed` artefact carry forward, at each of the four
pipeline gates (research findings; positioning segments/pillars/CTAs;
channel-plan recommendations; copy entries), and approves with that
selection.

## Where it lives

- `web-admin/src/components/PipelineStage.tsx` — owns the approve/reject
  controls. Computes what `onApprove` is called with from `elements` +
  `deselectedIds` (both supplied by `Pipeline.tsx`): `null` (no request
  body) when nothing is deselected, an explicit id list otherwise. Renders
  the drop-consequence preview and blocks Approve when the selection would
  be empty. Also renders a "Reload" action beside a stale-selection error.
- `web-admin/src/components/ArtefactBody.tsx` — renders the elements, now
  with an optional per-element checkbox (`ElementCheckbox`/`FindingGroup`).
  Every existing render site that omits `selection` renders exactly as it
  did before this issue — no prop, no checkbox, unchanged markup.
- `web-admin/src/components/Pipeline.tsx` — owns the selection *state*
  (one `deselected: Set<string>` per stage, reset whenever the stage's
  artefact gets a new `id` — a fresh run must never inherit a previous
  run's deselections onto regenerated content), and now distinguishes
  `StaleArtefactError` from every other approve failure.
- `web-admin/src/lib/elementSelection.ts` (new) — the one place that reads
  a parsed artefact body generically for its selectable elements (`id` +
  a human label), mirroring `pipeline.ELEMENT_LIST_KEYS` on the backend.
- `web-admin/src/lib/api.ts` — `approveArtefact` takes an optional
  `elementIds`; a new `StaleArtefactError` is thrown specifically for the
  "Unknown element id(s)" 422 (matched on the approve context + the
  detail text), distinct from every other failure the route can return.

## Requirements from the issue, and how each is met

- **Default to everything selected, one click.** Untouched, the button
  reads "Approve" (not "Approve N of M") and calls `onApprove(null)` — no
  request body, byte-for-byte the pre-#145 behaviour.
- **Send no body when nothing was deselected.** `approveArtefact`'s
  `elementIds` only becomes a request body when non-`null`;
  `PipelineStage` only ever passes a non-`null` array when at least one
  element is unchecked.
- **Deselecting everything is blocked**, not silently sent — the Approve
  button disables and a hint points at Reject instead, before the 422 is
  ever reachable from the UI.
- **Shows what will be dropped before committing** — a summary panel
  above Approve/Reject lists the dropped elements by name the moment
  anything is unchecked, so it's visible for as long as the deselection is,
  not a separate confirmation step.
- **422s are handled meaningfully.** A `StaleArtefactError` (matched on
  the approve route's own "Unknown element id(s)" wording) renders a
  "Reload" button next to the message instead of a raw string; any other
  approve failure (403, 409, the empty-selection 422) still just shows its
  message, since a retry can succeed for those.

## Tests

`PipelineStage.test.tsx`, `ArtefactBody.test.tsx`, `api.test.ts`,
`elementSelection.test.ts` (new) cover: default-all-selected sends no body;
deselecting one sends only the rest, with the drop preview naming it;
deselecting everything disables Approve and points at Reject; a checkbox
renders only when both an id and a `selection` are present (so every
pre-#145 render is provably unchanged); `approveArtefact` serialises
`element_ids` only when given a non-null array; the 422 → `StaleArtefactError`
classification is exact (an unrelated 422 from the same route does NOT
become one).

**Fail-first, proved by temporarily breaking each piece and re-running:**
- `PipelineStage.handleApprove` forced to always send `null` regardless of
  selection → "deselecting one element sends only the remaining ids" failed
  (asserted `null` instead of `['e2']`); restored, green.
- `api.ts`'s stale-422 detection disabled (`if (false)`) →
  "throws StaleArtefactError, not a plain Error" failed (`Error` instead of
  `StaleArtefactError`); restored, green.
- `ArtefactBody.tsx`'s checkbox render gated to never render → 3 of 4 new
  selection tests failed (`getAllByRole('checkbox')` found none); restored,
  green.

## Verified locally

`pnpm run lint`, `pnpm run typecheck`, `pnpm vitest run` (191 tests),
`pnpm run build` — all green. `uv run pytest` (621 tests, untouched) also
green; no Python changed in this PR.

## Not verified

No running deployment to click through — this is component/unit-level
only. The checkbox's keyboard/focus-visible behaviour is asserted via
`toBeChecked()`/click-and-assert-callback in jsdom, not visually confirmed
in a real browser.

Closes #145
