### PR TITLE
fix(copy): ask the staleness question of the plan as generated, not as narrowed

### DIFF
--- a/src/marketing/copy_routes.py
+++ b/src/marketing/copy_routes.py
@@ -120,10 +120,23 @@ async def start_copy_route(
     # silently producing copy with no channel to reference, or crashing on a
     # missing key, this campaign must have channel planning re-run before
     # copy can be generated for it.
+    # Asked of the plan as GENERATED, not as narrowed (issue #152). Staleness
+    # means "this plan predates the taxonomy" — a fact about the artefact the
+    # agent produced, which an operator's selection cannot change. Asking it of
+    # the narrowed body told an operator who legitimately kept only a
+    # `suggested_label`-only proposal that their current plan was stale and had
+    # to be re-run, with no way to generate copy for the entry they approved.
     try:
-        channel_plan_channels = pipeline.channel_plan_channel_map(channel_plan_body)
+        pipeline.channel_plan_channel_map(
+            admin_app._parse_artefact_body(approved_channel_plan.get("body"))
+        )
     except pipeline.StaleChannelPlanError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    # The mapping itself comes from the operator's approved subset, and may
+    # legitimately be empty — that is what keeping only an outside-taxonomy
+    # proposal means, and it is not a stale plan.
+    channel_plan_channels = pipeline.channel_key_motions(channel_plan_body)
 
     # The closed set of URLs this run is being shown (issue #22), recomputed
     # from each approved SUBSET rather than read off either parent's

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -1476,6 +1476,35 @@ async def advance_copy(
     )
 
 
+def channel_key_motions(
+    channel_plan_body: dict[str, Any],
+) -> dict[str, Literal["organic", "paid"]]:
+    """``{channel_key: motion}`` for the entries that carry a key. Never raises.
+
+    Split out of :func:`channel_plan_channel_map` for issue #152. That function
+    answers TWO questions at once — "is this plan stale?" and "what are its
+    keyed channels?" — and #145 made answering both from the same body wrong.
+
+    Staleness is a fact about the plan **as generated**: a pre-taxonomy plan
+    (#76) has entries and none carry a ``channel_key``. That was a sound proxy
+    while callers always passed the whole approved plan. Once an operator can
+    approve a SUBSET, a perfectly current plan narrowed to only a
+    ``suggested_label``-only proposal has exactly the same shape — entries, no
+    keys — and the operator was told their valid plan "predates channel
+    taxonomy ids" and to re-run it. Wrong advice, and no route to copy for the
+    entry they actually chose.
+
+    So callers ask the staleness question of the full body and take the mapping
+    from the narrowed one. This helper is the second half, with no opinion
+    about staleness.
+    """
+    return {
+        c["channel_key"]: c["motion"]
+        for c in (channel_plan_body.get("channels") or [])
+        if c.get("channel_key")
+    }
+
+
 def channel_plan_channel_map(
     channel_plan_body: dict[str, Any],
 ) -> dict[str, Literal["organic", "paid"]]:
@@ -1495,7 +1524,7 @@ def channel_plan_channel_map(
     recommend nothing yet — so it returns ``{}`` rather than raising.
     """
     channels = channel_plan_body.get("channels") or []
-    mapping = {c["channel_key"]: c["motion"] for c in channels if c.get("channel_key")}
+    mapping = channel_key_motions(channel_plan_body)
     if channels and not mapping:
         raise StaleChannelPlanError(
             "This campaign's approved channel plan predates channel taxonomy ids (#76) "

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -1024,3 +1024,51 @@ def test_require_channel_keyed_copy_raises_on_a_pre_migration_copy_artefact() ->
         require_channel_keyed_copy(channels)
 
     require_channel_keyed_copy([])  # must not raise on a genuinely empty list
+
+
+# ── issue #152: staleness is about the plan as generated, not as narrowed ────
+
+
+def test_channel_key_motions_never_calls_a_narrowed_plan_stale() -> None:
+    """The #152 defect, at the unit level.
+
+    A plan narrowed (#145) to only a `suggested_label`-only proposal has the
+    same shape a pre-taxonomy plan has — entries, none carrying a
+    `channel_key` — so `channel_plan_channel_map` called it stale and told the
+    operator to re-run a plan that was current and valid, with no route to
+    copy for the entry they had actually approved.
+
+    `channel_key_motions` answers only "what are the keyed channels", with no
+    opinion about staleness, so it returns empty rather than raising.
+    `test_channel_plan_channel_map_raises_on_a_pre_migration_plan` above still
+    covers the genuine legacy case, which must keep raising.
+    """
+    from marketing.pipeline import channel_key_motions
+
+    narrowed = {
+        "channels": [
+            {
+                "id": "e1",
+                "channel_key": None,
+                "suggested_label": "Review platforms",
+                "motion": "organic",
+            }
+        ]
+    }
+
+    assert channel_key_motions(narrowed) == {}
+
+
+def test_channel_key_motions_and_the_map_agree_on_a_healthy_plan() -> None:
+    """Guards the split itself: two functions now derive the same mapping, and
+    nothing else would notice if they drifted apart."""
+    from marketing.pipeline import channel_key_motions, channel_plan_channel_map
+
+    plan = {
+        "channels": [
+            {"id": "a", "channel_key": "search_organic", "motion": "organic"},
+            {"id": "b", "channel_key": "linkedin_paid", "motion": "paid"},
+        ]
+    }
+
+    assert channel_key_motions(plan) == channel_plan_channel_map(plan)


### PR DESCRIPTION
fix(copy): ask the staleness question of the plan as generated, not as narrowed

#145 let an operator approve a SUBSET of a channel plan. #150 then passed
that narrowed body to `channel_plan_channel_map`, which answers two
questions at once — "is this plan stale?" and "what are its keyed
channels?" — and only the second is a question about the subset.

Staleness detects a pre-taxonomy plan (#76) by "entries exist, none carry
a channel_key". That was a sound proxy while callers always passed the
whole approved plan. Narrowing broke it: a perfectly current plan reduced
to only a `suggested_label`-only proposal — an outside-taxonomy channel
the agent flagged for the operator to accept — has exactly that shape.

So an operator who legitimately kept only that proposal was told their
valid plan "predates channel taxonomy ids" and had to re-run channel
planning, and had no route to generate copy for the entry they had just
approved. Wrong advice about their data, on the path the new feature
exists to enable.

The fix splits the two questions rather than loosening the check:

* `pipeline.channel_key_motions` — the mapping, never raises.
* `channel_plan_channel_map` — unchanged behaviour, now built on it.
* `copy_routes.start_copy_route` asks staleness of the FULL approved body
  and takes the mapping from the narrowed one, which may legitimately be
  empty.

A genuinely stale plan still raises;
`test_channel_plan_channel_map_raises_on_a_pre_migration_plan` covers it
and is untouched. A new test pins that the two functions agree on a
healthy plan, since nothing else would notice them drifting apart.

Verified fail-first: with `channel_key_motions` restored to raising, the
narrowed-plan test fails.

Found by a code review of #150 running against another agent's UI branch
— out of that agent's scope, so it filed rather than fixed, and verified
the claim against `copy_routes.py` before filing rather than relaying it.

Closes #152

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
