### PR TITLE
feat(marketing): operator chooses campaign motion and target channels before the plan runs

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -40,6 +40,18 @@
           "description": "Comma-separated: copy,image,video,audio. Which media the operator asked for \u2014 drives which agents run, how long it takes and what it costs."
         },
         {
+          "name": "motion",
+          "type": "String(16)",
+          "nullable": true,
+          "description": "organic | paid | both (#67). The operator's campaign-level position on how this campaign reaches people, set alongside the brief and editable the same way. On the CAMPAIGN rather than per run, because copy, the distribution pack and the paid pack all need one consistent answer downstream and a per-run choice would leave the campaign with no recorded position for them to read. It is a HARD constraint, not a preference: `start_channel_plan_route` filters the taxonomy the agent is shown down to this motion's channels, and `pipeline.extract_channel_plan` re-checks the returned plan against it \u2014 a constraint the model is merely asked to respect is not a constraint (#128). Nullable because every campaign that existed before #67 has none; the channel-plan stage refuses to start until it is set, rather than defaulting to `both` and silently deciding for the operator. Plain String \u2014 plugin tables have no enum type, and the service layer validates against `definitions.CAMPAIGN_MOTIONS`."
+        },
+        {
+          "name": "target_channel_keys",
+          "type": "Text",
+          "nullable": true,
+          "description": "Comma-separated `marketing_channel.key` values \u2014 the channels the operator selected for this campaign before the plan runs (#67). Same comma-separated shape as `media_kinds` above, which is this plugin's existing pattern for per-campaign multi-value state, and `Text` rather than `String(255)` because the seeded taxonomy alone is 30+ keys of up to 64 characters and is designed to grow. Deliberately NOT a join table: plugin tables declare no foreign keys (see the manifest tests), so a join table would buy no referential integrity, only a second table, a second set of CRUD routes and a multi-row write that generic CRUD cannot make atomic \u2014 while this selection is only ever read and written wholesale, with the campaign. Keys that are no longer in the taxonomy are simply skipped when the plan starts; the selection is a filter over the taxonomy, never a source of channels in its own right."
+        },
+        {
           "name": "starts_at",
           "type": "DateTime",
           "nullable": true

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -632,10 +632,20 @@ async def _advance_artefact(
         # increment 2). See `pipeline.extract_channel_plan` for why it must
         # be what the run was shown, not a fresh fetch.
         taxonomy = pending.get("channel_taxonomy") or {}
+        # `allowed_motions` is the campaign's motion as it stood when this run
+        # started (#67), carried the same way and for the same reason.
+        # Absent — a run started before #67 shipped — reads as `None`, i.e.
+        # "this run was never motion-constrained", which skips the check
+        # rather than failing an in-flight artefact for a rule it was never
+        # shown. Exactly the distinction `allowed_source_urls` draws above;
+        # `or None` rather than `or []` because an empty list would read as
+        # "no motion is allowed" and reject everything.
+        allowed_motions = pending.get("allowed_motions") or None
         result = await pipeline.advance_channel_plan(
             gateway,
             run_id=_require_run_id(),
             taxonomy=taxonomy,
+            allowed_motions=allowed_motions,
             allowed_source_urls=allowed_source_urls,
         )
     elif kind == "copy":

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from . import admin_app, pipeline
+from . import admin_app, definitions, pipeline
 
 router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 
@@ -36,6 +36,53 @@ router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 _INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
 
 
+async def _targeting(campaign_id: str, token: str) -> tuple[str, list[str]]:
+    """This campaign's motion and selected channel keys (#67), or a 4xx
+    naming the decision that has not been taken yet.
+
+    Both are operator decisions the channel-plan stage cannot make for
+    itself, and both are refused rather than defaulted. A default motion of
+    `both` and a default selection of "the whole taxonomy" would each be a
+    silent decision taken on the operator's behalf, which is exactly the
+    state #67 exists to end — the agent choosing the channel set with the
+    operator's first involvement being approve-or-reject on a finished plan.
+    So a campaign that predates this feature stops here with a sentence
+    saying what to set, rather than quietly running as it used to.
+    """
+    campaign = await admin_app._core("GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", token)
+    if campaign.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+    campaign.raise_for_status()
+    row = campaign.json() or {}
+
+    motion = (row.get("motion") or "").strip()
+    if motion not in definitions.CAMPAIGN_MOTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                "This campaign has no motion set. Choose organic, paid or both before "
+                "planning channels."
+            ),
+        )
+
+    # Order preserved, duplicates dropped — the operator's selection is a set,
+    # but a stable order keeps the taxonomy the agent is shown (and every
+    # test asserting on it) deterministic.
+    selected = list(
+        dict.fromkeys(key.strip() for key in (row.get("target_channel_keys") or "").split(","))
+    )
+    selected = [key for key in selected if key]
+    if not selected:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                "This campaign has no target channels selected. Choose the channels it "
+                "should run on before planning."
+            ),
+        )
+    return motion, selected
+
+
 @router.post("/campaigns/{campaign_id}/channel-plan", status_code=status.HTTP_201_CREATED)
 async def start_channel_plan_route(
     campaign_id: str,
@@ -47,6 +94,11 @@ async def start_channel_plan_route(
     exactly: `proposed` positioning must not be usable here, or the approval
     step for positioning is decorative."""
     campaign_id = admin_app._validated_campaign_id(campaign_id)
+
+    # The operator's two pre-plan decisions (#67), read BEFORE the approval
+    # gate work below so a campaign missing either is told which decision is
+    # missing rather than having an agent run started for it.
+    campaign_motion, selected_keys = await _targeting(campaign_id, admin.token)
 
     positioning = await admin_app._latest_artefact(campaign_id, "positioning", admin.token)
     if positioning is None:
@@ -97,12 +149,46 @@ async def start_channel_plan_route(
     channels_resp = await admin_app._core("GET", f"{_INTERNAL_PREFIX}/channels", admin.token)
     channels_resp.raise_for_status()
     channel_rows = channels_resp.json() or []
+
+    # The operator's two decisions, applied to the agent's INPUT (#67).
+    #
+    # This is what makes them constraints rather than requests. A channel the
+    # operator did not select, or whose motion this campaign does not run, is
+    # simply not in the list the agent is given — and `extract_channel_plan`
+    # rejects any `channel_key` outside exactly this snapshot (#76 increment
+    # 2), so there is no path by which one reaches the plan. Nothing here
+    # relies on the model choosing to comply; #128 is this estate's evidence
+    # that a constraint the model is merely asked to respect is not one.
+    #
+    # A selected key that is no longer in the taxonomy is skipped rather than
+    # rejected: the selection is a filter over the taxonomy, never a source of
+    # channels of its own, and an admin deleting a channel must not brick
+    # every campaign that had selected it.
+    allowed_motions = definitions.motions_allowed_by(campaign_motion)
+    selected = set(selected_keys)
+    channel_rows = [
+        row for row in channel_rows if row["key"] in selected and row["motion"] in allowed_motions
+    ]
+    if not channel_rows:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"None of this campaign's selected channels are {campaign_motion} channels "
+                "this platform still offers. Adjust its motion or its channel selection "
+                "before planning."
+            ),
+        )
+
     # What the agent is shown, and what it is later validated against
     # (#76 increment 2) — the SAME set, stored on the pending artefact below
     # rather than re-fetched at advance time, so a channel added to the
     # taxonomy between start and advance cannot retroactively legalise (or a
     # deleted one retroactively invalidate) a key this run was actually
-    # shown. See `pipeline.start_channel_plan`'s own docstring.
+    # shown. See `pipeline.start_channel_plan`'s own docstring. Since #67 the
+    # campaign's motion is stashed the same way and for the same reason: an
+    # operator widening a campaign from organic to both while a run is in
+    # flight must not retroactively legalise a paid channel that run was
+    # never allowed to pick.
     taxonomy = [
         {
             "channel_key": row["key"],
@@ -115,7 +201,10 @@ async def start_channel_plan_route(
     taxonomy_motions = {row["key"]: row["motion"] for row in channel_rows}
 
     causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body=positioning_body, taxonomy=taxonomy
+        gateway,
+        positioning_body=positioning_body,
+        taxonomy=taxonomy,
+        campaign_motion=campaign_motion,
     )
 
     created = await admin_app._core(
@@ -135,6 +224,7 @@ async def start_channel_plan_route(
                 pipeline.with_element_ids(
                     {
                         "channel_taxonomy": taxonomy_motions,
+                        "allowed_motions": sorted(allowed_motions),
                         "allowed_source_urls": allowed_source_urls,
                     }
                 )

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -234,6 +234,48 @@ class Positioning(BaseModel):
     ctas: list[CallToAction] = Field(default_factory=list)
 
 
+# ── Campaign motion (#67) ────────────────────────────────────────────────────
+#
+# The operator's campaign-level answer to "how does this campaign reach
+# people": organic, paid, or both. It is CAMPAIGN state (a column on
+# `marketing_campaign`, next to the brief), not a per-run parameter — copy,
+# the distribution pack and the paid pack all need one consistent answer, and
+# a per-run choice would leave the campaign with no recorded position for them
+# to read.
+#
+# Note the two vocabularies are deliberately different sizes: a CHANNEL is
+# `organic` or `paid` (it is one or the other — "Google Search ads" is
+# inherently paid), while a CAMPAIGN may be either or `both`.
+# `motions_allowed_by` is the only sanctioned translation between them, so the
+# widening never happens ad hoc at a call site.
+
+#: The closed set of campaign motions. Validated in the service layer —
+#: plugin tables have no enum type (`biffo.plugin.json`'s own note on
+#: `marketing_campaign.status`).
+CAMPAIGN_MOTIONS: tuple[str, ...] = ("organic", "paid", "both")
+
+
+def motions_allowed_by(campaign_motion: str) -> frozenset[str]:
+    """The `marketing_channel.motion` values a campaign of this motion may
+    use — the whole of #67's motion constraint, in one place.
+
+    Raises `ValueError` on anything outside :data:`CAMPAIGN_MOTIONS` rather
+    than falling back to "allow everything". A permissive default here would
+    turn a typo'd or absent motion into an unconstrained campaign, which is
+    precisely the failure this constraint exists to prevent: the caller must
+    decide what to do about a campaign with no motion (the channel-plan route
+    refuses to start one), not inherit a silent yes.
+    """
+    if campaign_motion == "both":
+        return frozenset({"organic", "paid"})
+    if campaign_motion in CAMPAIGN_MOTIONS:
+        return frozenset({campaign_motion})
+    raise ValueError(
+        f"{campaign_motion!r} is not a campaign motion — expected one of "
+        f"{', '.join(CAMPAIGN_MOTIONS)}."
+    )
+
+
 class ChannelRecommendation(BaseModel):
     """One recommended channel, organic or paid, grounded in the approved
     positioning. Same citation discipline as `Segment`/`MessagePillar`/
@@ -684,16 +726,27 @@ once. Do not answer in prose.
 CHANNEL_PLAN_INSTRUCTIONS = f"""\
 You are the campaign studio's channel strategist. You are given one
 **approved** positioning artefact — audience segments, message pillars and
-calls to action, each carrying the sources that support it — and one
-**channel taxonomy**: a list of `{{channel_key, label, motion, category}}`
-entries naming every channel this platform currently recognises. Nothing
-else. You do not have web access and must not claim to.
+calls to action, each carrying the sources that support it — a
+`campaign_motion` (`organic`, `paid` or `both`), and one **channel
+taxonomy**: a list of `{{channel_key, label, motion, category}}` entries.
+Nothing else. You do not have web access and must not claim to.
 
-Recommend channels for this campaign, covering BOTH motions:
+**The taxonomy you are given is not the whole taxonomy.** It is the set of
+channels the operator selected for this campaign, already narrowed to the
+campaign's motion. Channels the operator did not select, and channels whose
+motion this campaign does not run, are simply absent from it — that is a
+decision already taken, not an omission for you to correct.
+
+Recommend channels for this campaign, covering the motion(s) it runs:
 1. **Organic** channels — where this audience already spends attention,
    reachable without paid distribution.
 2. **Paid** channels — where paid distribution would reach this audience
    fastest or most precisely.
+
+An `organic` campaign wants organic recommendations only; a `paid` campaign,
+paid only; `both` wants both. This is enforced when your answer comes back,
+not merely requested here: a recommendation outside the campaign's motion is
+rejected and the whole plan fails with it.
 
 For EVERY recommendation, set exactly one of:
 - `channel_key` — copy it EXACTLY from the taxonomy you were given, when one
@@ -702,14 +755,16 @@ For EVERY recommendation, set exactly one of:
   not silently accepted. When you set `channel_key`, leave `motion` unset:
   it is derived from the taxonomy entry, not asserted by you.
 - `suggested_label` — free text, ONLY when the evidence strongly supports a
-  channel that genuinely is not in the taxonomy. This is a proposal, not a
-  plan entry: an operator must accept it before it becomes a real channel.
-  When you use `suggested_label`, you MUST also set `motion` yourself, since
-  there is no taxonomy entry to derive it from.
+  channel that genuinely is not in the taxonomy you were given. This is a
+  proposal, not a plan entry: an operator must accept it before it becomes a
+  real channel. When you use `suggested_label`, you MUST also set `motion`
+  yourself, since there is no taxonomy entry to derive it from — and that
+  motion must be one the campaign runs, or the plan is rejected.
 
 Prefer the taxonomy. Reach for `suggested_label` only when nothing in the
 taxonomy is a genuine fit for what the evidence supports — not as a shortcut
-around checking the list first.
+around checking the list first, and never to re-propose a channel the
+operator has already left out for a reason you cannot see.
 
 Rank the channels within each motion (1 = highest priority) and give each a
 rationale an operator can disagree with: name exactly which segment, pillar or

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -180,6 +180,27 @@ class UnknownChannelError(PipelineError):
     """
 
 
+class MotionNotAllowedError(PipelineError):
+    """A channel-plan run returned a recommendation whose motion is outside
+    the campaign's own motion (#67) — an organic campaign being handed a paid
+    channel, or the reverse.
+
+    Distinct from :class:`UnknownChannelError` because the two say different
+    things to an operator: that one means the agent invented a key, this one
+    means it ignored a decision the operator had already taken. Fatal to the
+    whole plan for the same reason that one is: this pipeline's artefacts are
+    all-or-nothing, and dropping the offending entry silently would leave an
+    approved plan that is missing something nobody can see was ever there.
+
+    Structurally, this fires only for a ``suggested_label`` proposal — the one
+    place the agent still asserts a motion of its own — plus a defence-in-depth
+    check on the taxonomy snapshot itself. A ``channel_key`` cannot reach here
+    with the wrong motion: the taxonomy the run was shown was already narrowed
+    to the campaign's motion before it started, and every key is checked against
+    that snapshot (:class:`UnknownChannelError`).
+    """
+
+
 class StaleChannelPlanError(PipelineError):
     """A copy run was started against an approved channel plan that predates
     the taxonomy migration (#76 increment 2) — every one of its entries is
@@ -581,6 +602,7 @@ def extract_channel_plan(
     messages: list[dict[str, Any]],
     *,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    allowed_motions: Collection[str] | None = None,
     allowed_source_urls: Collection[str] | None = None,
     annotations: list[dict[str, Any]] | None = None,
 ) -> ChannelPlan:
@@ -606,6 +628,27 @@ def extract_channel_plan(
     mangling a key) and has its ``motion`` **overwritten** from the taxonomy:
     the agent stops asserting motion independently for a real channel, full
     stop, regardless of what it put in the field.
+
+    ``allowed_motions`` is the campaign's own motion widened to channel
+    motions (#67) — ``{"organic"}``, ``{"paid"}`` or both, from
+    :func:`~marketing.definitions.motions_allowed_by`, stashed on the pending
+    artefact at start time for exactly the reason ``taxonomy`` is. Anything
+    outside it raises :class:`MotionNotAllowedError`. Two things are checked,
+    for two different reasons:
+
+    - a ``suggested_label`` proposal's own asserted motion — the ONE place
+      the model still decides a motion, and therefore the only place the
+      campaign's motion needs enforcing against the model at all;
+    - the motion the taxonomy snapshot gives a ``channel_key`` — defence in
+      depth against a caller that filtered its taxonomy wrongly, not against
+      the model.
+
+    ``None`` means "this run was not constrained", which is what every run
+    started before #67 shipped actually was. It is deliberately not treated as
+    "allow nothing" or defaulted to a motion: retro-fitting a rule onto a run
+    that was never shown it would reject artefacts for a constraint that did
+    not exist when they were produced — the same distinction
+    ``allowed_source_urls=None`` already carries for #22.
     """
     plan = _extract_cited_artefact(
         messages,
@@ -622,15 +665,31 @@ def extract_channel_plan(
         ),
         retry_hint="channel planning",
     )
+    permitted = None if allowed_motions is None else frozenset(allowed_motions)
     for recommendation in plan.channels:
         if recommendation.channel_key is None:
-            continue  # a suggested_label proposal — motion is the agent's own, required already
+            # A `suggested_label` proposal. `motion` is the agent's own — the
+            # model validator already requires it — so this is where the
+            # campaign's motion has to be enforced against the model.
+            if permitted is not None and recommendation.motion not in permitted:
+                raise MotionNotAllowedError(
+                    f"The channel-plan run proposed {recommendation.suggested_label!r} as a "
+                    f"{recommendation.motion} channel, but this campaign runs "
+                    f"{'/'.join(sorted(permitted))} channels only."
+                )
+            continue
         if recommendation.channel_key not in taxonomy:
             raise UnknownChannelError(
                 f"The channel-plan run referenced channel_key {recommendation.channel_key!r}, "
                 "which was not in the taxonomy it was given."
             )
-        recommendation.motion = taxonomy[recommendation.channel_key]  # derived, not asserted
+        motion = taxonomy[recommendation.channel_key]
+        if permitted is not None and motion not in permitted:
+            raise MotionNotAllowedError(
+                f"The channel-plan run recommended {recommendation.channel_key!r}, a {motion} "
+                f"channel, but this campaign runs {'/'.join(sorted(permitted))} channels only."
+            )
+        recommendation.motion = motion  # derived, not asserted
     return plan
 
 
@@ -1366,21 +1425,34 @@ async def start_channel_plan(
     *,
     positioning_body: dict[str, Any],
     taxonomy: list[dict[str, Any]],
+    campaign_motion: str,
     channel_plan_model: str = DEFAULT_CHANNEL_PLAN_MODEL,
 ) -> tuple[str, str]:
     """Request the single channel-plan agent (M4), given the *approved*
-    positioning artefact's body AND the tenant's channel taxonomy as input.
+    positioning artefact's body AND the channels this campaign may plan
+    against as input.
 
     ``taxonomy`` (#76 increment 2) is a list of
     ``{channel_key, label, motion, category}`` dicts — the tenant's
     ``marketing_channel`` rows, fetched by the caller — so the agent can pick
     real, stable ids rather than inventing free text the copy stage and
-    ``marketing_link`` would then have to trust exactly (#75). The caller is
-    also responsible for keeping a ``{channel_key: motion}`` copy of this same
-    taxonomy to validate against later (:func:`extract_channel_plan`'s
-    ``taxonomy`` parameter) — passed here rather than re-derived, because it
-    must be exactly what THIS run was shown, not whatever the taxonomy has
-    grown to by the time the run completes.
+    ``marketing_link`` would then have to trust exactly (#75). Since #67 the
+    caller narrows those rows to the operator's own selection for this
+    campaign, intersected with the campaign's motion, BEFORE passing them
+    here: the selection and the motion are constraints on what the run may
+    produce, and the cheapest place to enforce a constraint on output is the
+    input, where the excluded options are simply not present to be chosen.
+    The caller is also responsible for keeping a ``{channel_key: motion}``
+    copy of this same narrowed taxonomy to validate against later
+    (:func:`extract_channel_plan`'s ``taxonomy`` parameter) — passed there
+    rather than re-derived, because it must be exactly what THIS run was
+    shown, not whatever the taxonomy or the selection has grown to by the
+    time the run completes.
+
+    ``campaign_motion`` is passed to the agent as well as applied to the
+    taxonomy, so it does not spend output on recommendations that would be
+    rejected. That is an efficiency, not the enforcement — see
+    :func:`extract_channel_plan` for where the motion is actually enforced.
 
     Mirrors :func:`start_positioning` otherwise, one stage further down the
     chain: a single-run chain, not fanned out, because nothing fans in on it.
@@ -1393,7 +1465,11 @@ async def start_channel_plan(
             instructions=CHANNEL_PLAN_INSTRUCTIONS,
         ),
         output_tool=channel_plan_tool_schema(),
-        input_payload={"positioning": positioning_body, "channel_taxonomy": taxonomy},
+        input_payload={
+            "positioning": positioning_body,
+            "channel_taxonomy": taxonomy,
+            "campaign_motion": campaign_motion,
+        },
         causation_id=causation_id,
     )
     return causation_id, run_id
@@ -1404,13 +1480,15 @@ async def advance_channel_plan(
     *,
     run_id: str,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    allowed_motions: Collection[str] | None = None,
     allowed_source_urls: Collection[str] | None = None,
 ) -> ChannelPlan | None:
     """Read the channel-plan run, advancing nothing else — mirrors
     :func:`advance_positioning`: a single run, not a chain, so there is no
     fan-in to discover. ``taxonomy`` is ``{channel_key: motion}`` for exactly
-    what :func:`start_channel_plan` gave this run — see
-    :func:`extract_channel_plan` for how it and ``allowed_source_urls`` are
+    what :func:`start_channel_plan` gave this run, and ``allowed_motions``
+    the campaign motion it was started under (#67) — see
+    :func:`extract_channel_plan` for how they and ``allowed_source_urls`` are
     used."""
     view = await gateway.get_agent_run(run_id=run_id)
     if view is None or not view.is_terminal:
@@ -1420,6 +1498,7 @@ async def advance_channel_plan(
     return extract_channel_plan(
         view.messages,
         taxonomy=taxonomy,
+        allowed_motions=allowed_motions,
         allowed_source_urls=allowed_source_urls,
         annotations=view.annotations,
     )

--- a/tests/test_marketing_campaign_targeting.py
+++ b/tests/test_marketing_campaign_targeting.py
@@ -1,0 +1,540 @@
+"""Campaign-level motion and operator channel selection (issue #67).
+
+The channel-plan agent used to choose both the motion mix and the channel set
+on its own, and the operator's first involvement was approving or rejecting a
+finished plan. #67 moves two decisions earlier — to the campaign, before the
+plan runs:
+
+1. **Motion** (`organic` / `paid` / `both`) is campaign state, set alongside
+   the brief.
+2. **Target channels** are selected by the operator from the seeded taxonomy,
+   also campaign state, and the plan runs *within* that selection.
+
+## Why these tests assert a STRUCTURAL constraint, not a prompted one
+
+#128's lesson, stated in this repo's own code: a constraint the model is
+merely *asked* to respect is not a constraint. So the tests below never
+assert "the prompt mentions organic". They assert that:
+
+- the taxonomy the run is **shown** is already narrowed to
+  `selection ∩ motion`, so a paid `channel_key` on an organic campaign is
+  rejected by the taxonomy validator #76 increment 2 already ships
+  (`pipeline.extract_channel_plan`), with no new trust in the model; and
+- the one place the model still asserts a motion of its own — a
+  `suggested_label` proposal for a channel outside the taxonomy — is checked
+  against the campaign's motion when the run comes back
+  (`MotionNotAllowedError`).
+
+Both halves are checked against what **this run** was shown, stashed on the
+pending artefact at start time, exactly as `channel_taxonomy` (#76) and
+`allowed_source_urls` (#22/#113) already are — never re-read at advance time,
+where the campaign may have been edited since.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, definitions, pipeline
+
+_MANIFEST = Path(__file__).resolve().parents[1] / "biffo.plugin.json"
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ce"
+_URL = "https://example.com/thread"
+
+
+class _FakeCore:
+    """An in-memory `marketing_campaign` + `marketing_artefact` + taxonomy
+    store, reached the way `admin_app._core` reaches the real one — the same
+    fake shape `test_marketing_pipeline_routes.py` uses, kept local so this
+    module can vary the campaign's motion/selection per test."""
+
+    CHANNELS: list[dict[str, Any]] = [
+        {
+            "key": "instagram_organic",
+            "label": "Instagram — organic",
+            "motion": "organic",
+            "category": "social",
+            "ad_platform": None,
+        },
+        {
+            "key": "linkedin_organic",
+            "label": "LinkedIn — organic",
+            "motion": "organic",
+            "category": "social",
+            "ad_platform": None,
+        },
+        {
+            "key": "google_search_paid",
+            "label": "Google Search ads",
+            "motion": "paid",
+            "category": "search",
+            "ad_platform": "google",
+        },
+    ]
+
+    def __init__(
+        self,
+        *,
+        motion: str | None = "both",
+        target_channel_keys: str | None = "instagram_organic,linkedin_organic,google_search_paid",
+    ) -> None:
+        self.campaign: dict[str, Any] = {
+            "id": _CAMPAIGN,
+            "brief": "Reach multi-location operators.",
+            "motion": motion,
+            "target_channel_keys": target_channel_keys,
+        }
+        self.artefacts: dict[str, dict[str, Any]] = {}
+        self.channels = [dict(c) for c in self.CHANNELS]
+        self._next_id = 0
+
+    async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
+        request = httpx.Request(method, f"https://core.invalid{path}")
+        prefix = admin_app._INTERNAL_PREFIX
+        if method == "GET" and path == f"{prefix}/campaigns/{_CAMPAIGN}":
+            return httpx.Response(200, json=self.campaign, request=request)
+        if method == "GET" and path.startswith(f"{prefix}/campaigns/"):
+            return httpx.Response(404, json={"detail": "not found"}, request=request)
+        if method == "GET" and path == f"{prefix}/channels":
+            return httpx.Response(200, json=self.channels, request=request)
+        if method == "GET" and path == f"{prefix}/artefacts":
+            params = kw.get("params") or {}
+            rows = [
+                a
+                for a in self.artefacts.values()
+                if a.get("campaign_id") == params.get("campaign_id")
+                and a.get("kind") == params.get("kind")
+            ]
+            return httpx.Response(200, json=rows, request=request)
+        if method == "POST" and path == f"{prefix}/artefacts":
+            self._next_id += 1
+            artefact_id = f"artefact-{self._next_id}"
+            body = dict(kw["json"])
+            body.setdefault("body", None)
+            body.setdefault("citations", None)
+            body.setdefault("agent_run_id", None)
+            row = {
+                "id": artefact_id,
+                "created_at": f"2026-08-14T00:00:{self._next_id:02d}Z",
+                **body,
+            }
+            self.artefacts[artefact_id] = row
+            return httpx.Response(201, json=row, request=request)
+        if method == "PATCH" and path.startswith(f"{prefix}/artefacts/"):
+            artefact_id = path.removeprefix(f"{prefix}/artefacts/")
+            self.artefacts[artefact_id].update(kw["json"])
+            return httpx.Response(200, json=self.artefacts[artefact_id], request=request)
+        raise AssertionError(f"unexpected call {method} {path}")
+
+
+class _FakeGateway:
+    def __init__(self) -> None:
+        self.requested: list[dict[str, Any]] = []
+        self._runs: dict[str, pipeline.AgentRunView] = {}
+        self._next_id = 0
+
+    async def request_agent_run(
+        self, *, agent_name: str, definition, output_tool, input_payload, causation_id
+    ) -> str:
+        del definition, output_tool
+        self._next_id += 1
+        run_id = f"run-{self._next_id}"
+        self.requested.append(
+            {"agent_name": agent_name, "causation_id": causation_id, "input_payload": input_payload}
+        )
+        self._runs[run_id] = pipeline.AgentRunView(id=run_id, status="pending", messages=[])
+        return run_id
+
+    async def find_chain_run(self, *, chain_id: str, agent_name: str):  # pragma: no cover - unused
+        del chain_id, agent_name
+        return None
+
+    async def get_agent_run(self, *, run_id: str):
+        return self._runs.get(run_id)
+
+    def complete(self, run_id: str, *, messages: list) -> None:
+        self._runs[run_id] = pipeline.AgentRunView(id=run_id, status="completed", messages=messages)
+
+
+def _admin_user() -> Any:
+    return type("U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"})()
+
+
+def _client(core: _FakeCore, gateway: _FakeGateway, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(admin_app, "_core", core)
+    app = admin_app.build_app()
+    app.dependency_overrides[admin_app.require_admin] = _admin_user
+    app.dependency_overrides[admin_app.get_agent_gateway] = lambda: gateway
+    return TestClient(app)
+
+
+def _approve_positioning(client: TestClient, gateway: _FakeGateway, core: _FakeCore) -> None:
+    """Drive research + positioning to approved, which is what
+    `start_channel_plan_route` gates on — everything this module cares about
+    happens after that gate."""
+    research = client.post(f"/campaigns/{_CAMPAIGN}/research").json()
+    gateway.complete(
+        research["agent_run_id"] or "run-1",
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "submit_research_synthesis",
+                            "arguments": {
+                                "summary": "s",
+                                "findings": [
+                                    {
+                                        "signal": "s",
+                                        "why_it_matters": "m",
+                                        "sources": [{"url": _URL, "note": "n"}],
+                                    }
+                                ],
+                            },
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+    # Research fans out and fans in via the engine; the positioning stage is
+    # the only approved parent `start_channel_plan_route` actually reads, so
+    # seed that artefact directly rather than simulating the fan-in.
+    core._next_id += 1
+    artefact_id = f"artefact-{core._next_id}"
+    core.artefacts[artefact_id] = {
+        "id": artefact_id,
+        "created_at": "2026-08-14T00:01:00Z",
+        "campaign_id": _CAMPAIGN,
+        "kind": "positioning",
+        "status": "approved",
+        "causation_id": "chain",
+        "agent_run_id": "run-positioning",
+        "body": json.dumps(
+            {
+                "segments": [
+                    {
+                        "id": "seg-1",
+                        "name": "Segment",
+                        "description": "d",
+                        "sources": [{"url": _URL, "note": "n"}],
+                    }
+                ],
+                "pillars": [],
+                "ctas": [],
+            }
+        ),
+        "citations": json.dumps([{"url": _URL, "note": "n"}]),
+    }
+
+
+def _plan_call(channels: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "submit_channel_plan", "arguments": {"channels": channels}}}
+            ],
+        }
+    ]
+
+
+def _recommendation(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "channel_key": "instagram_organic",
+        "rank": 1,
+        "rationale": "r",
+        "sources": [{"url": _URL, "note": "n"}],
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Motion is campaign state, with a closed vocabulary ───────────────────────
+
+
+def test_the_campaign_carries_motion_and_target_channels() -> None:
+    """Both live on `marketing_campaign`, next to the brief — #67 settles
+    motion as a campaign-strategy property, and the selection is per-campaign
+    state read once, wholesale, when the plan starts."""
+    manifest = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    (campaign,) = [t for t in manifest["tables"] if t["name"] == "marketing_campaign"]
+    columns = {c["name"]: c for c in campaign["columns"]}
+
+    assert columns["motion"]["type"] == "String(16)"
+    assert columns["motion"]["nullable"] is True
+    # Text, not String(255) like `media_kinds`: 30+ keys of up to 64
+    # characters each outgrow 255 long before the taxonomy stops growing.
+    assert columns["target_channel_keys"]["type"] == "Text"
+    assert columns["target_channel_keys"]["nullable"] is True
+
+
+def test_campaign_motions_are_exactly_organic_paid_both() -> None:
+    assert definitions.CAMPAIGN_MOTIONS == ("organic", "paid", "both")
+
+
+@pytest.mark.parametrize(
+    ("campaign_motion", "expected"),
+    [
+        ("organic", {"organic"}),
+        ("paid", {"paid"}),
+        ("both", {"organic", "paid"}),
+    ],
+)
+def test_motions_allowed_by_maps_campaign_motion_to_channel_motions(
+    campaign_motion: str, expected: set[str]
+) -> None:
+    assert definitions.motions_allowed_by(campaign_motion) == expected
+
+
+def test_an_unknown_campaign_motion_is_a_hard_failure_not_a_permissive_default() -> None:
+    with pytest.raises(ValueError):
+        definitions.motions_allowed_by("hybrid")
+
+
+# ── The gate: neither decision may be left to the agent ──────────────────────
+
+
+def test_channel_plan_refuses_a_campaign_with_no_motion(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(motion=None)
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    assert resp.status_code == 422
+    assert "motion" in resp.json()["detail"].lower()
+    # Refused before anything was spent: no channel-plan run was requested.
+    assert [r for r in gateway.requested if "channel_taxonomy" in r["input_payload"]] == []
+
+
+def test_channel_plan_refuses_a_campaign_with_no_channel_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = _FakeCore(target_channel_keys=None)
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    assert resp.status_code == 422
+    assert "channel" in resp.json()["detail"].lower()
+
+
+def test_channel_plan_refuses_a_selection_that_resolves_to_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An organic campaign whose only selected channels are paid ones — a
+    real state, reachable by choosing channels and then narrowing the motion.
+    Refused with a sentence naming the disagreement rather than quietly
+    planning against an empty taxonomy, which would return an empty plan and
+    read as "the agent found nothing"."""
+    core = _FakeCore(motion="organic", target_channel_keys="google_search_paid")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    assert resp.status_code == 422
+    assert "organic" in resp.json()["detail"].lower()
+
+
+# ── The constraint is applied to the INPUT, so it needs no trust ─────────────
+
+
+def test_the_run_is_shown_only_the_selected_channels(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore(target_channel_keys="linkedin_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    (plan_run,) = [r for r in gateway.requested if "channel_taxonomy" in r["input_payload"]]
+    assert [c["channel_key"] for c in plan_run["input_payload"]["channel_taxonomy"]] == [
+        "linkedin_organic"
+    ]
+
+
+def test_an_organic_campaign_is_never_shown_a_paid_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hard half of #67's motion constraint. Not "the prompt discourages
+    paid": the paid rows are absent from the taxonomy the run is given, and
+    `extract_channel_plan` rejects any `channel_key` outside that snapshot —
+    so a paid recommendation cannot survive, whatever the model does."""
+    core = _FakeCore(motion="organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    (plan_run,) = [r for r in gateway.requested if "channel_taxonomy" in r["input_payload"]]
+    shown = {c["channel_key"] for c in plan_run["input_payload"]["channel_taxonomy"]}
+    assert shown == {"instagram_organic", "linkedin_organic"}
+    stashed = json.loads(started["body"])
+    assert set(stashed["channel_taxonomy"]) == shown
+    assert sorted(stashed["allowed_motions"]) == ["organic"]
+
+
+def test_the_run_is_told_the_campaign_motion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Told, so it does not spend output proposing what will be rejected —
+    but the telling is not the enforcement; the two tests above are."""
+    core = _FakeCore(motion="paid")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    (plan_run,) = [r for r in gateway.requested if "channel_taxonomy" in r["input_payload"]]
+    assert plan_run["input_payload"]["campaign_motion"] == "paid"
+
+
+def test_the_selection_does_not_widen_the_citation_provenance_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#113's guard threads the approved parent's sources through untouched.
+    A channel selection is a constraint on OUTPUT, never a source of
+    evidence, so `allowed_source_urls` must still be exactly the approved
+    positioning's URLs."""
+    core = _FakeCore()
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    assert json.loads(started["body"])["allowed_source_urls"] == [_URL]
+
+
+# ── The one place the model still asserts a motion: an outside proposal ──────
+
+
+def test_a_proposal_outside_the_campaign_motion_fails_the_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = _FakeCore(motion="organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_plan_call(
+            [
+                _recommendation(),
+                _recommendation(
+                    channel_key=None, suggested_label="Sponsored trade newsletter", motion="paid"
+                ),
+            ]
+        ),
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 502
+    assert "organic" in resp.json()["detail"].lower()
+    # Left pending, not half-written — same discipline as every other
+    # extraction failure in this pipeline.
+    assert core.artefacts[started["id"]]["status"] == "pending"
+
+
+def test_a_proposal_within_the_campaign_motion_is_kept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#67 keeps the agent able to propose outside the operator's selection —
+    the constraint is the motion and the taxonomy, not the ability to
+    suggest."""
+    core = _FakeCore(motion="organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_plan_call(
+            [
+                _recommendation(
+                    channel_key=None, suggested_label="Regional franchise forum", motion="organic"
+                )
+            ]
+        ),
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 200
+    (channel,) = json.loads(resp.json()["body"])["channels"]
+    assert channel["suggested_label"] == "Regional franchise forum"
+    assert channel["channel_key"] is None
+
+
+def test_extract_channel_plan_rejects_a_taxonomy_row_outside_the_allowed_motions() -> None:
+    """Defence in depth: the route filters the taxonomy, and the extractor
+    checks it again. A caller that filtered wrongly cannot smuggle a paid
+    channel into an organic campaign's plan."""
+    with pytest.raises(pipeline.MotionNotAllowedError):
+        pipeline.extract_channel_plan(
+            _plan_call([_recommendation(channel_key="google_search_paid")]),
+            taxonomy={"google_search_paid": "paid"},
+            allowed_motions=frozenset({"organic"}),
+            allowed_source_urls=[_URL],
+        )
+
+
+def test_extract_channel_plan_defaults_to_allowing_both_motions() -> None:
+    """A run started before this change stashed no `allowed_motions`, and was
+    never constrained by one. Failing it retroactively would reject an
+    artefact for a rule it was never shown — the same reasoning
+    `allowed_source_urls=None` already encodes for #22."""
+    plan = pipeline.extract_channel_plan(
+        _plan_call([_recommendation(channel_key="google_search_paid")]),
+        taxonomy={"google_search_paid": "paid"},
+        allowed_source_urls=[_URL],
+    )
+
+    assert plan.channels[0].motion == "paid"
+
+
+def test_a_legacy_pending_artefact_still_advances(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end version of the above, through the advance path: a pending
+    row written before this change has no `allowed_motions` key at all."""
+    core = _FakeCore()
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    legacy = json.loads(core.artefacts[started["id"]]["body"])
+    legacy.pop("allowed_motions", None)
+    core.artefacts[started["id"]]["body"] = json.dumps(legacy)
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_plan_call([_recommendation(channel_key="google_search_paid")]),
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 200
+
+
+def test_channel_plan_still_404s_an_unknown_campaign(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = _FakeCore()
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+
+    resp = client.post(f"/campaigns/{uuid.uuid4()}/channel-plan")
+
+    assert resp.status_code == 404

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -701,7 +701,7 @@ async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body
     taxonomy = [{"channel_key": "instagram_organic", "label": "Instagram", "motion": "organic"}]
 
     causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body=positioning_body, taxonomy=taxonomy
+        gateway, positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
     )
 
     assert len(gateway.requested) == 1
@@ -711,6 +711,10 @@ async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body
     assert requested.input_payload == {
         "positioning": positioning_body,
         "channel_taxonomy": taxonomy,
+        # #67: told the campaign's motion as well as shown a taxonomy already
+        # narrowed to it — see `start_channel_plan` for why the telling is an
+        # efficiency and the narrowing is the enforcement.
+        "campaign_motion": "both",
     }
     assert run_id  # a real id was returned
 
@@ -719,7 +723,7 @@ async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body
 async def test_advance_channel_plan_returns_none_while_running() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body={}, taxonomy=[]
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
 
     result = await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
@@ -731,7 +735,7 @@ async def test_advance_channel_plan_returns_none_while_running() -> None:
 async def test_advance_channel_plan_returns_the_plan_once_succeeded() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body={}, taxonomy=[]
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(
         run_id,
@@ -772,7 +776,7 @@ async def test_advance_channel_plan_returns_the_plan_once_succeeded() -> None:
 async def test_advance_channel_plan_raises_when_the_run_failed() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body={}, taxonomy=[]
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, status="failed")
 
@@ -787,7 +791,7 @@ async def test_advance_channel_plan_propagates_null_annotations_into_the_error()
     retrieval — proven through `advance_channel_plan`."""
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_plan(
-        gateway, positioning_body={}, taxonomy=[]
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(
         run_id,

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -49,7 +49,19 @@ class _FakeCore:
     ]
 
     def __init__(self, *, brief: str | None = "Reach multi-location operators.") -> None:
-        self.campaign = {"id": _CAMPAIGN, "brief": brief}
+        # `motion` and `target_channel_keys` (#67) are the operator's two
+        # pre-plan decisions, and `start_channel_plan_route` refuses without
+        # them. Defaulted here to "both, everything seeded" — the widest
+        # possible targeting — so every test in this module keeps exercising
+        # the behaviour it was written for rather than the new gate. The gate
+        # itself, and what narrower targeting does to the run's input, is
+        # `tests/test_marketing_campaign_targeting.py`.
+        self.campaign = {
+            "id": _CAMPAIGN,
+            "brief": brief,
+            "motion": "both",
+            "target_channel_keys": ",".join(c["key"] for c in self.DEFAULT_CHANNELS),
+        }
         self.artefacts: dict[str, dict[str, Any]] = {}
         self.channels: list[dict[str, Any]] = [dict(c) for c in self.DEFAULT_CHANNELS]
         self._next_id = 0

--- a/web-admin/src/components/CampaignDetail.tsx
+++ b/web-admin/src/components/CampaignDetail.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 
 import { updateCampaign, type Campaign } from '../lib/api'
+import { hasTargeting } from '../lib/campaignTargeting'
 import { useChannelTaxonomy } from '../lib/useChannelTaxonomy'
+import { CampaignTargeting } from './CampaignTargeting'
 import { DistributionPack } from './DistributionPack'
 import { ImageGenerator } from './ImageGenerator'
 import { PaidPack } from './PaidPack'
@@ -77,8 +79,22 @@ export function CampaignDetail({
         </form>
       </section>
 
+      {/* Before the pipeline, deliberately: motion and target channels are
+          decisions the channel-plan stage reads, so they belong upstream of
+          it on the page as well as in the flow (#67). */}
+      <CampaignTargeting
+        campaign={campaign}
+        channelLookup={channelLookup}
+        onCampaignUpdated={onCampaignUpdated}
+      />
+
       <h3>Pipeline</h3>
-      <Pipeline campaignId={campaign.id} hasBrief={hasBrief} channelLookup={channelLookup} />
+      <Pipeline
+        campaignId={campaign.id}
+        hasBrief={hasBrief}
+        hasTargets={hasTargeting(campaign)}
+        channelLookup={channelLookup}
+      />
 
       <h3>Images</h3>
       <ImageGenerator campaignId={campaign.id} />

--- a/web-admin/src/components/CampaignTargeting.test.tsx
+++ b/web-admin/src/components/CampaignTargeting.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Campaign } from '../lib/api'
+import * as auth from '../lib/auth'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+import { CampaignTargeting } from './CampaignTargeting'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function stubSession(jwt = 'test-jwt') {
+  vi.spyOn(auth, 'getCurrentSession').mockResolvedValue({
+    getIdToken: () => ({ getJwtToken: () => jwt }),
+  } as never)
+}
+
+const CAMPAIGN: Campaign = {
+  id: 'c1',
+  name: 'Spring demo push',
+  status: 'draft',
+  destination_url: 'https://example.com/demo',
+  brief: 'Who this is for.',
+  guidance: null,
+  motion: null,
+  target_channel_keys: null,
+}
+
+const ENTRIES = [
+  {
+    key: 'linkedin_organic',
+    label: 'LinkedIn — organic',
+    motion: 'organic' as const,
+    category: 'social',
+    ad_platform: null,
+    publish_url: null,
+  },
+  {
+    key: 'google_search_paid',
+    label: 'Google Search ads',
+    motion: 'paid' as const,
+    category: 'search',
+    ad_platform: 'google',
+    publish_url: null,
+  },
+  {
+    key: 'trade_show_presence',
+    label: 'Trade show / expo presence',
+    motion: 'organic' as const,
+    category: 'events',
+    ad_platform: null,
+    publish_url: null,
+  },
+]
+
+const LOOKUP: ChannelLookup = {
+  get: (key: string) => ENTRIES.find((e) => e.key === key),
+  entries: ENTRIES,
+  loading: false,
+}
+
+function patchStub(response: Partial<Campaign> = {}) {
+  return vi.fn((url: string, init?: RequestInit) => {
+    if (typeof url === 'string' && url.endsWith('/campaigns/c1') && init?.method === 'PATCH') {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ ...CAMPAIGN, ...JSON.parse(String(init.body)), ...response }),
+      })
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+  })
+}
+
+describe('CampaignTargeting', () => {
+  it('offers the three campaign motions and, until one is chosen, no channels', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', patchStub())
+
+    render(
+      <CampaignTargeting
+        campaign={CAMPAIGN}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('radio', { name: /organic/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /^paid$/i })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: /both/i })).toBeInTheDocument()
+    // No motion yet: nothing to pick from, because which channels are even
+    // eligible depends on the motion.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('shows only the channels the chosen motion can run', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', patchStub())
+    const user = userEvent.setup()
+
+    render(
+      <CampaignTargeting
+        campaign={CAMPAIGN}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+    await user.click(screen.getByRole('radio', { name: /organic/i }))
+
+    expect(screen.getByRole('checkbox', { name: /LinkedIn — organic/ })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /Trade show/ })).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: /Google Search ads/ })).not.toBeInTheDocument()
+  })
+
+  it('saves the motion and the selected channel keys onto the campaign', async () => {
+    stubSession()
+    const fetchMock = patchStub()
+    vi.stubGlobal('fetch', fetchMock)
+    const onCampaignUpdated = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CampaignTargeting
+        campaign={CAMPAIGN}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={onCampaignUpdated}
+      />,
+    )
+    await user.click(screen.getByRole('radio', { name: /both/i }))
+    await user.click(screen.getByRole('checkbox', { name: /LinkedIn — organic/ }))
+    await user.click(screen.getByRole('checkbox', { name: /Google Search ads/ }))
+    await user.click(screen.getByRole('button', { name: /save targeting/i }))
+
+    const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      motion: 'both',
+      target_channel_keys: 'linkedin_organic,google_search_paid',
+    })
+    expect(onCampaignUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ motion: 'both', target_channel_keys: 'linkedin_organic,google_search_paid' }),
+    )
+  })
+
+  it('pre-checks what the campaign already targets', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', patchStub())
+
+    render(
+      <CampaignTargeting
+        campaign={{ ...CAMPAIGN, motion: 'organic', target_channel_keys: 'linkedin_organic' }}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('radio', { name: /organic/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /LinkedIn — organic/ })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /Trade show/ })).not.toBeChecked()
+  })
+
+  it('narrowing the motion drops the channels it excludes, and says so', async () => {
+    stubSession()
+    const fetchMock = patchStub()
+    vi.stubGlobal('fetch', fetchMock)
+    const user = userEvent.setup()
+
+    render(
+      <CampaignTargeting
+        campaign={{
+          ...CAMPAIGN,
+          motion: 'both',
+          target_channel_keys: 'linkedin_organic,google_search_paid',
+        }}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+    await user.click(screen.getByRole('radio', { name: /organic/i }))
+
+    // Told, not silently discarded — the paid channel is still stored on the
+    // campaign until this is saved.
+    expect(screen.getByText(/1 selected channel/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /save targeting/i }))
+    const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      motion: 'organic',
+      target_channel_keys: 'linkedin_organic',
+    })
+  })
+
+  it('will not save a motion with no channels selected', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', patchStub())
+    const user = userEvent.setup()
+
+    render(
+      <CampaignTargeting
+        campaign={CAMPAIGN}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+    await user.click(screen.getByRole('radio', { name: /^paid$/i }))
+
+    expect(screen.getByRole('button', { name: /save targeting/i })).toBeDisabled()
+  })
+
+  it('groups the channels by category so a broad taxonomy stays readable', async () => {
+    stubSession()
+    vi.stubGlobal('fetch', patchStub())
+    const user = userEvent.setup()
+
+    render(
+      <CampaignTargeting
+        campaign={CAMPAIGN}
+        channelLookup={LOOKUP}
+        onCampaignUpdated={() => {}}
+      />,
+    )
+    await user.click(screen.getByRole('radio', { name: /both/i }))
+
+    const events = screen.getByRole('group', { name: /events/i })
+    expect(within(events).getByRole('checkbox', { name: /Trade show/ })).toBeInTheDocument()
+    expect(within(events).queryByRole('checkbox', { name: /LinkedIn/ })).not.toBeInTheDocument()
+  })
+})

--- a/web-admin/src/components/CampaignTargeting.tsx
+++ b/web-admin/src/components/CampaignTargeting.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState } from 'react'
+
+import { updateCampaign, type Campaign, type CampaignMotion } from '../lib/api'
+import {
+  CAMPAIGN_MOTIONS,
+  channelMotionsFor,
+  MOTION_LABELS,
+  targetChannelKeys,
+} from '../lib/campaignTargeting'
+import type { ChannelLookup } from '../lib/useChannelTaxonomy'
+
+/** Category slug → the heading an operator reads. The slugs are the seeded
+ * taxonomy's own (`scripts/seed_marketing_channels.py`'s `CATEGORIES`); an
+ * instance-added channel may carry a category this map has never heard of,
+ * which is why the fallback below humanises rather than dropping the group —
+ * the whole point of the taxonomy living in a table is that an instance can
+ * extend it without a plugin release. */
+const CATEGORY_LABELS: Record<string, string> = {
+  search: 'Search',
+  social: 'Social',
+  video: 'Video',
+  email: 'Email',
+  content: 'Content',
+  communities: 'Communities',
+  partner: 'Partner / affiliate',
+  events: 'Events',
+  trade_press: 'Trade press',
+  direct_mail: 'Direct mail',
+  local_field: 'Local / field',
+}
+
+function categoryLabel(category: string): string {
+  return (
+    CATEGORY_LABELS[category] ??
+    category.replace(/_/g, ' ').replace(/^./, (first) => first.toUpperCase())
+  )
+}
+
+/** The two decisions #67 moves ahead of the channel-plan agent: this
+ * campaign's **motion**, and the **channels** it may plan against.
+ *
+ * Before this, the agent chose both, and the operator's first involvement was
+ * approving or rejecting a finished plan — so a campaign that could only ever
+ * execute organically got a plan half-composed of ad platforms nobody was
+ * going to buy, and the only remedy was to reject the whole run.
+ *
+ * ## This picker is not the constraint
+ *
+ * `start_channel_plan_route` narrows the taxonomy the agent is shown to
+ * exactly `selection ∩ motion`, and `pipeline.extract_channel_plan` re-checks
+ * what comes back. Nothing here is trusted by the server: a stale page can
+ * show the wrong options, never widen what a run may return. What this
+ * component owes the operator is that the choice is *possible* and that its
+ * consequences are visible — which is why narrowing the motion says what it
+ * will drop instead of quietly discarding it.
+ */
+export function CampaignTargeting({
+  campaign,
+  channelLookup,
+  onCampaignUpdated,
+}: {
+  campaign: Campaign
+  channelLookup: ChannelLookup
+  onCampaignUpdated: (campaign: Campaign) => void
+}) {
+  const [motion, setMotion] = useState<CampaignMotion | null>(campaign.motion ?? null)
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(targetChannelKeys(campaign)),
+  )
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const allowedMotions = useMemo(
+    () => (motion === null ? new Set<string>() : channelMotionsFor(motion)),
+    [motion],
+  )
+
+  // Offered in taxonomy order, grouped by category. Order comes from the
+  // taxonomy rather than from the order the operator clicked, so what gets
+  // saved is stable and re-reading a campaign shows the same list twice.
+  const offered = useMemo(
+    () => channelLookup.entries.filter((entry) => allowedMotions.has(entry.motion)),
+    [channelLookup.entries, allowedMotions],
+  )
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, typeof offered>()
+    for (const entry of offered) {
+      const existing = groups.get(entry.category)
+      if (existing === undefined) groups.set(entry.category, [entry])
+      else existing.push(entry)
+    }
+    return [...groups.entries()]
+  }, [offered])
+
+  /** What will actually be saved: the selection, narrowed to what this motion
+   * can run. */
+  const keepable = offered.filter((entry) => selected.has(entry.key)).map((entry) => entry.key)
+  // Selected keys this motion excludes, or that are no longer in the taxonomy
+  // at all. Counted rather than silently dropped — the campaign still holds
+  // them until this form is saved, and an operator who narrows a motion by
+  // accident should be able to see what it cost before committing.
+  const droppedCount = selected.size - keepable.length
+
+  function toggle(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  async function save(event: React.FormEvent) {
+    event.preventDefault()
+    if (motion === null || keepable.length === 0) return
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await updateCampaign(campaign.id, {
+        motion,
+        target_channel_keys: keepable.join(','),
+      })
+      setSelected(new Set(keepable))
+      onCampaignUpdated(updated)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="targeting" aria-label="Campaign targeting">
+      <h3>Motion and target channels</h3>
+      <p className="hint">
+        How this campaign reaches people, and which channels it may plan against. Both are
+        required before the channel plan can run — the agent plans within this selection rather
+        than choosing the channel set for you. It may still propose a channel outside it where
+        its evidence is strong; a proposal is flagged as such and needs your acceptance before
+        anything is written for it.
+      </p>
+
+      <form onSubmit={save}>
+        <fieldset className="motion">
+          <legend>Motion</legend>
+          {CAMPAIGN_MOTIONS.map((value) => (
+            <label key={value} htmlFor={`motion-${value}`}>
+              <input
+                type="radio"
+                id={`motion-${value}`}
+                name="motion"
+                value={value}
+                checked={motion === value}
+                onChange={() => setMotion(value)}
+              />
+              {MOTION_LABELS[value]}
+            </label>
+          ))}
+        </fieldset>
+
+        {motion === null && (
+          <p className="empty">
+            Choose a motion first — it decides which channels are even eligible.
+          </p>
+        )}
+
+        {motion !== null && channelLookup.loading && <p className="empty">Loading channels…</p>}
+
+        {motion !== null && !channelLookup.loading && offered.length === 0 && (
+          <p className="empty">
+            No {motion === 'both' ? '' : `${motion} `}channels are available on this platform yet.
+            An admin seeds the channel taxonomy.
+          </p>
+        )}
+
+        {grouped.map(([category, entries]) => (
+          <fieldset key={category} className="channel-group">
+            <legend>{categoryLabel(category)}</legend>
+            {entries.map((entry) => (
+              <label key={entry.key} htmlFor={`channel-${entry.key}`}>
+                <input
+                  type="checkbox"
+                  id={`channel-${entry.key}`}
+                  checked={selected.has(entry.key)}
+                  onChange={() => toggle(entry.key)}
+                />
+                {entry.label}
+              </label>
+            ))}
+          </fieldset>
+        ))}
+
+        {droppedCount > 0 && (
+          <p className="hint">
+            {droppedCount} selected channel{droppedCount === 1 ? '' : 's'}{' '}
+            {droppedCount === 1 ? 'is' : 'are'} outside this motion and will be dropped when you
+            save.
+          </p>
+        )}
+
+        <button type="submit" disabled={saving || motion === null || keepable.length === 0}>
+          {saving ? 'Saving…' : 'Save targeting'}
+        </button>
+        {motion !== null && keepable.length === 0 && !channelLookup.loading && (
+          <p className="hint">Select at least one channel.</p>
+        )}
+        {error !== null && <p className="error">{error}</p>}
+      </form>
+    </section>
+  )
+}

--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -63,7 +63,7 @@ describe('Pipeline', () => {
     stubSession()
     vi.stubGlobal('fetch', fetchStub())
 
-    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
     expect(await screen.findByRole('button', { name: /start research/i })).toBeEnabled()
 
@@ -78,11 +78,53 @@ describe('Pipeline', () => {
     stubSession()
     vi.stubGlobal('fetch', fetchStub())
 
-    render(<Pipeline campaignId={CAMPAIGN} hasBrief={false} channelLookup={EMPTY_LOOKUP} />)
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={false} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
     const research = await screen.findByTestId('stage-research')
     expect(within(research).getByRole('button', { name: /start research/i })).toBeDisabled()
     expect(within(research).getByText(/no brief yet/i)).toBeInTheDocument()
+  })
+
+  it('blocks the channel plan until the campaign has a motion and target channels (#67)', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({
+        research: { status: 'approved', body: JSON.stringify({ summary: 's', findings: [] }) },
+        positioning: {
+          status: 'approved',
+          body: JSON.stringify({ segments: [], pillars: [], ctas: [] }),
+        },
+      }),
+    )
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={false} channelLookup={EMPTY_LOOKUP} />)
+
+    const plan = await screen.findByTestId('stage-channel_plan')
+    // Approved positioning is no longer enough on its own — the operator's
+    // own two decisions come first, and `start_channel_plan_route` 422s
+    // without them, so the button must not offer to make that call.
+    expect(within(plan).getByRole('button', { name: /start channel plan/i })).toBeDisabled()
+    expect(within(plan).getByText(/motion and target channels/i)).toBeInTheDocument()
+  })
+
+  it('unlocks the channel plan once positioning is approved and targeting is set', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      fetchStub({
+        research: { status: 'approved', body: JSON.stringify({ summary: 's', findings: [] }) },
+        positioning: {
+          status: 'approved',
+          body: JSON.stringify({ segments: [], pillars: [], ctas: [] }),
+        },
+      }),
+    )
+
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
+
+    const plan = await screen.findByTestId('stage-channel_plan')
+    expect(within(plan).getByRole('button', { name: /start channel plan/i })).toBeEnabled()
   })
 
   it('unlocks positioning once research is approved, and renders its findings', async () => {
@@ -106,7 +148,7 @@ describe('Pipeline', () => {
       }),
     )
 
-    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
     expect(await screen.findByText('The market wants faster onboarding.')).toBeInTheDocument()
 
@@ -152,7 +194,7 @@ describe('Pipeline', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const user = userEvent.setup()
-    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
     const research = await screen.findByTestId('stage-research')
     await user.click(within(research).getByRole('button', { name: /^approve$/i }))
@@ -176,7 +218,7 @@ describe('Pipeline', () => {
       }),
     )
 
-    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+    render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
     const copy = await screen.findByTestId('stage-copy')
     expect(await within(copy).findByText(/approve the channel plan stage first/i)).toBeInTheDocument()
@@ -240,7 +282,7 @@ describe('Pipeline', () => {
       })
       vi.stubGlobal('fetch', fetchMock)
 
-      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
       const research = await screen.findByTestId('stage-research')
       expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
@@ -268,7 +310,7 @@ describe('Pipeline', () => {
       })
       vi.stubGlobal('fetch', fetchMock)
 
-      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
       const research = await screen.findByTestId('stage-research')
       expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
@@ -331,7 +373,7 @@ describe('Pipeline', () => {
       })
       vi.stubGlobal('fetch', fetchMock)
 
-      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} channelLookup={EMPTY_LOOKUP} />)
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
 
       // Let mount's fetches settle under fake timers.
       await act(async () => {

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -71,7 +71,18 @@ interface StageConfig {
    * which is the one place that actually knows how to draw a checkbox next
    * to each of ITS shape's elements. */
   renderBody: (artefact: Artefact, channelLookup: ChannelLookup, selection: ElementSelection) => ReactNode
-  gate: (approved: Approved, hasBrief: boolean) => Gate
+  gate: (approved: Approved, ready: Readiness) => Gate
+}
+
+/** The campaign-level facts a gate reads that are not another stage's
+ * approval — both of them decisions the operator has to have taken before
+ * the stage's own route will accept a start. */
+interface Readiness {
+  hasBrief: boolean
+  /** #67: the campaign has a motion AND at least one target channel.
+   * `start_channel_plan_route` 422s without them, so offering the button
+   * would only ever produce that error. */
+  hasTargets: boolean
 }
 
 /** Everything that varies per stage, in one place — a fifth stage is one new
@@ -90,8 +101,11 @@ const STAGES: StageConfig[] = [
         <p className="empty">No content to show.</p>
       )
     },
-    gate: (_approved, hasBrief) =>
-      reason(hasBrief, 'This campaign has no brief yet — add one above before starting research.'),
+    gate: (_approved, ready) =>
+      reason(
+        ready.hasBrief,
+        'This campaign has no brief yet — add one above before starting research.',
+      ),
   },
   {
     kind: 'positioning',
@@ -119,7 +133,17 @@ const STAGES: StageConfig[] = [
         <p className="empty">No content to show.</p>
       )
     },
-    gate: (approved) => reason(approved.positioning, 'Approve the positioning stage first.'),
+    gate: (approved, ready) => {
+      // Targeting is named FIRST when both are outstanding: it is the one
+      // the operator can act on right now, without waiting for a run.
+      if (!ready.hasTargets) {
+        return reason(
+          false,
+          'Choose this campaign\u2019s motion and target channels above before planning.',
+        )
+      }
+      return reason(approved.positioning, 'Approve the positioning stage first.')
+    },
   },
   {
     kind: 'copy',
@@ -173,10 +197,12 @@ function initialState(): Record<ArtefactKind, StageState> {
 export function Pipeline({
   campaignId,
   hasBrief,
+  hasTargets,
   channelLookup,
 }: {
   campaignId: string
   hasBrief: boolean
+  hasTargets: boolean
   channelLookup: ChannelLookup
 }) {
   const [state, setState] = useState<Record<ArtefactKind, StageState>>(initialState)
@@ -319,7 +345,7 @@ export function Pipeline({
     <div className="pipeline">
       {STAGES.map((stage) => {
         const s = state[stage.kind]
-        const gate = stage.gate(approved, hasBrief)
+        const gate = stage.gate(approved, { hasBrief, hasTargets })
         // Every operator-selectable element in this stage's CURRENT
         // artefact (issue #145) — `[]` while there is nothing proposed yet,
         // computed fresh every render rather than cached in state, since it

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -514,6 +514,46 @@ details.mint-toggle[open] > .mint {
   margin-top: 1rem;
 }
 
+/* ── Motion and target channels (#67) ─────────────────────────────────────
+ *
+ * A radio group and a grouped checkbox list. Both need the same override the
+ * mint panel's own checkbox already needs: the global `input` rule sets
+ * `width: 100%` and a bottom margin, which is right for a text field and
+ * wrong for a control that sits inline with its label. Grouped by category
+ * because the taxonomy is deliberately broad (digital AND offline/field), so
+ * an ungrouped list of 30+ boxes is a wall rather than a choice.
+ */
+
+.targeting fieldset {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem 0.25rem;
+  margin: 0 0 1rem;
+}
+
+.targeting legend {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  padding: 0 0.35rem;
+}
+
+.targeting label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 400;
+  margin: 0 1.25rem 0.6rem 0;
+}
+
+.targeting input[type='radio'],
+.targeting input[type='checkbox'] {
+  width: auto;
+  margin: 0;
+}
+
 /* ── The pipeline (a sequence, not a stack) ───────────────────────────────
  *
  * Numbered, connected stage cards — a CSS counter and a connector line, no

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -31,6 +31,10 @@ import { createRequest } from './api-core'
  * and choose again" — a stale id cannot be retried into success. */
 export class StaleArtefactError extends Error {}
 
+/** How a campaign reaches people (#67). Wider than a channel's own motion:
+ * a channel is organic OR paid, a campaign may run `both`. */
+export type CampaignMotion = 'organic' | 'paid' | 'both'
+
 export interface Campaign {
   id: string
   name: string
@@ -38,6 +42,15 @@ export interface Campaign {
   destination_url: string | null
   brief?: string | null
   guidance?: string | null
+  /** #67. `null`/absent on every campaign created before targeting existed —
+   * the channel-plan stage refuses to start until it is set, rather than
+   * defaulting to `both` and deciding for the operator. */
+  motion?: CampaignMotion | null
+  /** Comma-separated `marketing_channel.key` values — the channels this
+   * campaign may plan against (#67). Stored as one string on the campaign,
+   * the same shape `media_kinds` uses; parse with
+   * `lib/campaignTargeting`'s `targetChannelKeys`. */
+  target_channel_keys?: string | null
 }
 
 const BASE = '/api/v1/plugins/marketing'
@@ -343,7 +356,12 @@ async function throwForResponse(response: Response, context: string): Promise<ne
  * pipeline's first stage can never start. */
 export async function updateCampaign(
   campaignId: string,
-  patch: Partial<Pick<Campaign, 'name' | 'destination_url' | 'brief' | 'guidance'>>,
+  patch: Partial<
+    Pick<
+      Campaign,
+      'name' | 'destination_url' | 'brief' | 'guidance' | 'motion' | 'target_channel_keys'
+    >
+  >,
 ): Promise<Campaign> {
   return request<Campaign>('PATCH', `/campaigns/${campaignId}`, patch, BASE, 'update the campaign')
 }

--- a/web-admin/src/lib/campaignTargeting.test.ts
+++ b/web-admin/src/lib/campaignTargeting.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Campaign } from './api'
+import { channelMotionsFor, hasTargeting, targetChannelKeys } from './campaignTargeting'
+
+const CAMPAIGN: Campaign = {
+  id: 'c1',
+  name: 'Spring demo push',
+  status: 'draft',
+  destination_url: null,
+}
+
+function campaign(patch: Partial<Campaign>): Campaign {
+  return { ...CAMPAIGN, ...patch }
+}
+
+describe('channelMotionsFor', () => {
+  it('widens only `both`', () => {
+    expect([...channelMotionsFor('organic')]).toEqual(['organic'])
+    expect([...channelMotionsFor('paid')]).toEqual(['paid'])
+    expect([...channelMotionsFor('both')].sort()).toEqual(['organic', 'paid'])
+  })
+})
+
+describe('targetChannelKeys', () => {
+  it('parses the campaign’s one comma-separated column', () => {
+    expect(targetChannelKeys(campaign({ target_channel_keys: 'a,b' }))).toEqual(['a', 'b'])
+  })
+
+  it('is empty for a campaign that has never been targeted', () => {
+    expect(targetChannelKeys(CAMPAIGN)).toEqual([])
+    expect(targetChannelKeys(campaign({ target_channel_keys: null }))).toEqual([])
+    expect(targetChannelKeys(campaign({ target_channel_keys: '' }))).toEqual([])
+  })
+
+  it('drops blank entries rather than yielding keys nothing matches', () => {
+    expect(targetChannelKeys(campaign({ target_channel_keys: 'a,, b ,' }))).toEqual(['a', 'b'])
+  })
+})
+
+describe('hasTargeting', () => {
+  it('needs BOTH decisions, since either alone still cannot plan', () => {
+    expect(hasTargeting(campaign({ motion: 'organic', target_channel_keys: 'a' }))).toBe(true)
+    expect(hasTargeting(campaign({ motion: 'organic' }))).toBe(false)
+    expect(hasTargeting(campaign({ target_channel_keys: 'a' }))).toBe(false)
+    expect(hasTargeting(CAMPAIGN)).toBe(false)
+  })
+
+  it('rejects a motion outside the closed set rather than trusting the row', () => {
+    expect(
+      hasTargeting(campaign({ motion: 'hybrid' as never, target_channel_keys: 'a' })),
+    ).toBe(false)
+  })
+})

--- a/web-admin/src/lib/campaignTargeting.ts
+++ b/web-admin/src/lib/campaignTargeting.ts
@@ -1,0 +1,48 @@
+import type { Campaign, CampaignMotion } from './api'
+
+/** The three campaign motions, in the order an operator reads them (#67).
+ * Mirrors `definitions.CAMPAIGN_MOTIONS` server-side — the server is the
+ * authority, and refuses anything outside this set, so this list exists to
+ * render the choice, never to decide what is valid. */
+export const CAMPAIGN_MOTIONS: readonly CampaignMotion[] = ['organic', 'paid', 'both']
+
+export const MOTION_LABELS: Record<CampaignMotion, string> = {
+  organic: 'Organic',
+  paid: 'Paid',
+  both: 'Both',
+}
+
+/** The `marketing_channel.motion` values a campaign of this motion may run —
+ * the browser-side twin of `definitions.motions_allowed_by`. Used to narrow
+ * what the picker OFFERS; it is not the enforcement (the plan route filters
+ * the agent's taxonomy and the extractor re-checks the result), so a stale
+ * page can only ever show the wrong options, never smuggle a channel past
+ * the constraint. */
+export function channelMotionsFor(motion: CampaignMotion): ReadonlySet<string> {
+  return motion === 'both' ? new Set(['organic', 'paid']) : new Set([motion])
+}
+
+/** A campaign's selected channel keys, parsed from its one comma-separated
+ * column. Blank entries are dropped, so `''`, `null` and `'a,,b'` all behave
+ * the way a reader expects rather than yielding empty keys nothing matches. */
+export function targetChannelKeys(campaign: Campaign): string[] {
+  return (campaign.target_channel_keys ?? '')
+    .split(',')
+    .map((key) => key.trim())
+    .filter((key) => key !== '')
+}
+
+/** Whether this campaign has BOTH of the operator decisions the channel-plan
+ * stage requires (#67). The stage's own route 422s without them, so this is
+ * what stops the UI offering a button whose only outcome is that error.
+ *
+ * Deliberately not "motion or channels": each without the other is a campaign
+ * that cannot plan, and reporting it as ready would move the failure from a
+ * disabled button to a red error after a click. */
+export function hasTargeting(campaign: Campaign): boolean {
+  return (
+    campaign.motion != null &&
+    CAMPAIGN_MOTIONS.includes(campaign.motion) &&
+    targetChannelKeys(campaign).length > 0
+  )
+}


### PR DESCRIPTION
Refs #67 — increment 1 of what remained. What is deliberately NOT in it is listed at the bottom.

## What moved

Two decisions move off the channel-plan agent and onto the campaign, before the plan runs:

| | Where it lives | Why there |
|---|---|---|
| **Motion** (`organic`/`paid`/`both`) | `marketing_campaign.motion`, `String(16)` | #67 settles it as campaign strategy: copy, the distribution pack and the paid pack all need one consistent answer, and a per-run choice leaves the campaign with no recorded position for them to read. |
| **Target channels** | `marketing_campaign.target_channel_keys`, `Text`, comma-separated `marketing_channel.key` | The same shape `media_kinds` already uses for per-campaign multi-value state. |

**Why a column and not a join table.** Plugin tables declare no foreign keys (`test_no_table_declares_a_foreign_key`), so a join table buys no referential integrity — only a second table, a second set of CRUD routes, and a multi-row write generic CRUD cannot make atomic. The selection is only ever read and written *wholesale*, with the campaign; a join table's one real advantage is the query "which campaigns target LinkedIn", which nothing asks. `Text` rather than `String(255)` because the seeded taxonomy alone is 30+ keys of up to 64 characters and is designed to grow.

## Motion is a hard constraint, and it is not the prompt that enforces it

1. **The taxonomy the agent is shown is narrowed to `selection ∩ motion`** before the run starts. `extract_channel_plan` already rejects any `channel_key` outside exactly that snapshot (#76 increment 2), so a paid channel cannot reach an organic campaign's plan — with no new trust in the model and, in fact, no new validation code.
2. **A `suggested_label` proposal is the one place the model still asserts a motion of its own**, so that motion is checked against the campaign's on the way back — new `MotionNotAllowedError`, fatal to the plan exactly as `UnknownChannelError` is, because this pipeline's artefacts are all-or-nothing and a silently-dropped entry leaves an approved plan missing something nobody can see was ever there. The same check is applied to the taxonomy snapshot as defence in depth against a caller that filtered wrongly.

#128 is this estate's evidence that a constraint the model is merely *asked* to respect is not a constraint. The prompt is told `campaign_motion` only so the run does not spend output on recommendations that will be rejected; the tests never assert on prompt prose.

**Selection is a shortlist, not a cage** — #67's design is preserved: the agent can still propose outside the operator's selection, through the existing free-text `suggested_label` path, which is already structurally distinct and already needs operator acceptance.

## What was left alone, on purpose

- **#113 citation provenance.** `allowed_source_urls` is still recomputed from the approved positioning subset and stashed unchanged. A selection constrains OUTPUT and is never a source of evidence — asserted by a test.
- **#141 model selection.** Nothing in this PR touches any stage's model.
- `allowed_motions` is stashed on the pending artefact at start time for the same reason `channel_taxonomy` is: widening a campaign mid-flight must not retroactively legalise a channel the run was never allowed to pick. Absent (a run started before this change) reads as "never constrained", not "allow nothing" — no in-flight artefact is failed for a rule it was never shown.

## The UI — the half that repeatedly has not been built

A `Motion and target channels` section above the pipeline: motion radios, channels grouped by category and filtered to the chosen motion, one PATCH to the campaign. Narrowing a motion *says what it will drop* rather than discarding it silently. The channel-plan stage stays disabled with a reason until both decisions exist, so the UI never offers a button whose only outcome is the route's 422.

## Behaviour change to call out

An existing campaign with approved positioning **cannot start a channel plan until motion and channels are set**. That is deliberate and is #67's "Done when": defaulting to `both`/everything would be a silent decision taken on the operator's behalf, which is the state this issue exists to end. The UI to set it ships in the same PR.

## Fail-first evidence

Python, before the fix (`pytest tests/test_marketing_campaign_targeting.py`): **14 failed, 5 passed** — `KeyError: 'motion'` on the manifest, `module 'marketing.pipeline' has no attribute 'MotionNotAllowedError'`, and every gate/narrowing test failing. The 5 that passed are the ones asserting nothing regressed (provenance, legacy advance, a within-motion proposal, 404).

Web, before the fix: `CampaignTargeting.test.tsx` failed to load at all (`Failed to resolve import "./CampaignTargeting"`), and the new Pipeline gate test failed with `Received element is not disabled`.

After: **642 python tests pass**, **206 web-admin tests pass** (13 new), ruff/ruff-format/pyright/eslint/tsc/vite build all clean.

## Deliberately NOT built

- **Promoting an accepted proposal into a real taxonomy channel.** The accept/dismiss workflow for an outside-selection proposal is still absent; a proposal remains free text with no UI to act on it. This is the largest remaining piece of #67 and wants its own issue.
- **Rendering a proposal as visually distinct in the channel-plan artefact.** It is already structurally distinct (`suggested_label` vs `channel_key`) and downstream stages already skip it, but `ArtefactBody` does not yet flag it as "outside your selection".
- **Motion on the create-campaign form.** Motion is set in the studio next to the brief, which is where the brief itself actually lives in this UI.
- **Browser verification on a real deployment.** Not done — hence `Refs`, not a closing keyword.

Already true before this PR, verified rather than rebuilt: `_platform_for_channel` is an `ad_platform` lookup (#76 increment 2), and re-seeding idempotence plus preservation of instance-added channels is genuinely covered by `test_marketing_seed_marketing_channels.py` (`test_seeding_twice_is_a_no_op`, `test_reseeding_preserves_an_instance_added_channel`, `test_an_upgrade_adding_a_default_channel_reaches_an_existing_install`) — all passing, and asserting on the recorded HTTP methods rather than only on the row count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)