### PR TITLE
feat(channel-plan): ground the channel plan in its own live conversion search

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -644,6 +644,10 @@ async def _advance_artefact(
         result = await pipeline.advance_channel_plan(
             gateway,
             run_id=_require_run_id(),
+            # Carried purely so this stage's retrieval-breadth line (#65 — the
+            # instrument #101 built for research, now pointed here too) can be
+            # joined to the rest of this campaign's runs.
+            causation_id=artefact.get("causation_id"),
             taxonomy=taxonomy,
             allowed_motions=allowed_motions,
             allowed_source_urls=allowed_source_urls,

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -729,7 +729,32 @@ You are the campaign studio's channel strategist. You are given one
 calls to action, each carrying the sources that support it — a
 `campaign_motion` (`organic`, `paid` or `both`), and one **channel
 taxonomy**: a list of `{{channel_key, label, motion, category}}` entries.
-Nothing else. You do not have web access and must not claim to.
+
+**You also have live web search, and you are expected to use it.** The
+positioning you were given answers a different question from yours. It was
+researched to establish who this audience is and what competitors say to
+them; you are deciding where this audience actually converts. Its sources
+cannot answer that, and a channel plan justified entirely by them is the
+failure this stage was rebuilt to end.
+
+## Search for conversion evidence, not for description
+
+Search before you decide, and search for the numbers a media planner would
+ask for:
+
+- Where this audience demonstrably **converts** — not where it merely has
+  attention. Intent expressed beats attention observed.
+- Reported **conversion rates, cost per acquisition, cost per click or lead
+  cost** for this kind of buyer, on these channels, in this market.
+- What **comparable campaigns** report — case studies, published results,
+  benchmark reports for this sector and geography.
+- Channel **economics and saturation** for this segment: what it costs to be
+  seen there now, and what that buys.
+
+Prefer the specific page carrying the number — a benchmark report, a results
+write-up, a case study — over a vendor home page or an agency's "top 10
+channels" listicle. A retrieved page of generic channel wisdom is still
+generic channel wisdom; it has simply been fetched.
 
 **The taxonomy you are given is not the whole taxonomy.** It is the set of
 channels the operator selected for this campaign, already narrowed to the
@@ -767,25 +792,45 @@ around checking the list first, and never to re-propose a channel the
 operator has already left out for a reason you cannot see.
 
 Rank the channels within each motion (1 = highest priority) and give each a
-rationale an operator can disagree with: name exactly which segment, pillar or
-CTA the recommendation follows from. A channel recommendation with no evidence
-behind it is the most confident-sounding fabrication in this pipeline —
+rationale an operator can disagree with: name the conversion evidence you
+found — the figure, the comparable campaign, the observed intent — and name
+which segment, pillar or CTA it serves. Rank on what the evidence says
+converts, not on what is conventionally listed first. A channel recommendation
+with no evidence behind it is the most confident-sounding fabrication in this
+pipeline —
 "run paid social" or "post on LinkedIn" reads as correct whether or not
 anyone researched it, so generic channel wisdom is not an acceptable
 rationale.
 
-Every recommendation must carry `sources`: copy the `url` of each relevant
-`Source` from the positioning you were given, exactly as written. This is
-checked mechanically against that positioning, exactly as `channel_key` is
-checked against the taxonomy: a `url` that does not appear in it is rejected
-and the whole plan fails with it. For `note`,
-do not paste the positioning item's note verbatim — your `rationale` already
-says why this channel follows from the evidence, so repeat only what a
-`note` genuinely adds beyond that, or leave it empty. Never invent a source,
-and never recommend a channel that cites nothing: if the positioning does not
-support recommending a channel, do not recommend it.
+## Sources: two legitimate origins, and one of them is required
 
-If the positioning is too thin to support any recommendation in a motion,
+Every recommendation must carry `sources`, and a `url` may come from exactly
+two places:
+
+1. **Your own search results** — copied exactly as the result gives it,
+   character for character. Do not tidy a URL, do not shorten it, and do not
+   cite a link you saw quoted *inside* a page rather than in your results.
+2. **The positioning you were given** — the `url` of a `Source` on a segment,
+   pillar or CTA, again exactly as written.
+
+Both are checked mechanically, against the runtime's own record of what your
+search actually returned and against the positioning you were given. A `url`
+in neither is rejected and the whole plan fails with it, so a plausible-looking
+source you did not read is worse than a recommendation you leave out.
+
+**Every recommendation needs at least one source from your own search
+results.** This is checked per recommendation, not across the plan: a channel
+justified only by positioning's sources is justified by evidence about a
+different question, and is rejected along with the whole plan. If you searched
+and found nothing about a channel's performance for this audience, do not
+recommend that channel — say nothing rather than reach for the positioning to
+dress it up.
+
+For `note`, do not paste the positioning item's note verbatim — your
+`rationale` already says why this channel follows from the evidence, so repeat
+only what a `note` genuinely adds beyond that, or leave it empty.
+
+If your search turns up nothing that supports any recommendation in a motion,
 return fewer channels (or none) for that motion rather than inventing content
 to fill it — a channel plan that recommends nothing beats one that recommends
 plausibly.
@@ -993,6 +1038,92 @@ def research_search_query(*, agent_name: str, brief: Mapping[str, Any] | None) -
     return f"{topic} — {framing}" if topic else framing
 
 
+#: What the channel-plan stage's retrieval is aimed at (issue #65).
+#:
+#: The counterpart to ``RESEARCH_SEARCH_FRAMING``, and deliberately a
+#: *different question* from either research angle: research asks who this
+#: audience is and what competitors say to them, this asks where that audience
+#: converts. Both halves of that distinction are load-bearing — "conversion,
+#: not description" is the phrase issue #65 uses — so the framing names the
+#: figures a media planner would ask for rather than saying "search for
+#: channels", which retrieves the same listicles for every campaign.
+CHANNEL_PLAN_SEARCH_FRAMING = (
+    "where this audience actually converts — reported conversion rates, cost per "
+    "acquisition, lead cost and results from comparable campaigns on these channels "
+    "in this market; the specific benchmark, case study or published results page "
+    "carrying the number, not a vendor home page or a listicle"
+)
+
+#: How many of the positioning's segment names, and how many channel labels,
+#: ride in the searched query. Bounded for the same reason
+#: ``SEARCH_QUERY_BRIEF_CHARS`` is: the whole positioning body still travels in
+#: the payload for the *model* to read, and a query assembled from nine
+#: segments and thirty channels is a worse query than one built from the few
+#: that lead.
+CHANNEL_PLAN_QUERY_SEGMENTS = 3
+CHANNEL_PLAN_QUERY_CHANNELS = 6
+
+
+def _named_items(body: Mapping[str, Any] | None, key: str, field: str, limit: int) -> list[str]:
+    """Up to ``limit`` non-empty ``field`` values from ``body[key]``.
+
+    Tolerant by construction, exactly like ``_brief_topic``: the positioning
+    body is JSON this plugin persisted but a model wrote, and a malformed or
+    partially-approved one must degrade to a thinner query rather than fail
+    the run before it starts.
+    """
+    if not isinstance(body, Mapping):
+        return []
+    items = body.get(key)
+    if not isinstance(items, list):
+        return []
+    found: list[str] = []
+    for item in items:
+        value = item.get(field) if isinstance(item, Mapping) else None
+        if isinstance(value, str) and value.strip() and value not in found:
+            found.append(" ".join(value.split()))
+        if len(found) == limit:
+            break
+    return found
+
+
+def channel_plan_search_query(
+    *,
+    positioning_body: Mapping[str, Any] | None,
+    taxonomy: list[dict[str, Any]],
+    campaign_motion: str,
+) -> str:
+    """The text the channel-plan run's retrieval is derived from (issue #65).
+
+    Sent as the FIRST key of the run's ``input_payload`` (see
+    ``marketing.pipeline.start_channel_plan``), for exactly the reason
+    ``research_search_query`` is: an ``:online`` run's provider searches
+    *before* the model is invoked, from the payload, so the payload — not the
+    instructions — is the only place this stage can influence what comes back.
+    Issue #101 measured what happens when that is left alone: two agents sent
+    identical payloads received 4 of 5 identical pages.
+
+    A channel-plan payload that led with the positioning body would retrieve
+    the positioning question a second time, which is precisely the defect
+    #65 reports one layer up. So the query is assembled from the three things
+    that make this campaign's channel question specific — its audience, the
+    channels actually on the table, and the motion it runs — and closed with
+    :data:`CHANNEL_PLAN_SEARCH_FRAMING`.
+    """
+    audience = _named_items(positioning_body, "segments", "name", CHANNEL_PLAN_QUERY_SEGMENTS)
+    labels = [
+        " ".join(str(entry["label"]).split())
+        for entry in taxonomy
+        if isinstance(entry, Mapping) and entry.get("label")
+    ][:CHANNEL_PLAN_QUERY_CHANNELS]
+
+    who = ", ".join(audience) if audience else "this audience"
+    topic = f"{campaign_motion} channels for {who}"
+    if labels:
+        topic += f" — {', '.join(labels)}"
+    return f"{topic} — {CHANNEL_PLAN_SEARCH_FRAMING}"
+
+
 #: Every stage runs on the Claude 5 family (issue #62). The tier is chosen per
 #: stage rather than uniformly: research is the fan-out, reading-heavy leg and
 #: runs on the Sonnet tier; the four stages that turn evidence into artefacts an
@@ -1045,11 +1176,39 @@ def research_search_query(*, agent_name: str, brief: Mapping[str, Any] | None) -
 #: training and read ``annotations``. Do not move this constant on the strength
 #: of a model being newer — that is exactly what #108 did.
 DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-4:online"
-#: Neither synthesis, positioning nor channel planning searches — all three
-#: reason over what they are given — so none of them needs `:online`.
+#: Neither synthesis nor positioning searches — both reason over what they are
+#: given — so neither needs `:online`.
 DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-5"
 DEFAULT_POSITIONING_MODEL = "anthropic/claude-opus-5"
-DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-opus-5"
+#: Channel planning **does** search (issue #65), so it carries `:online` — and
+#: therefore lands on the same route research does, for the same measured
+#: reason rather than a stylistic one.
+#:
+#: **This is a deliberate tier downgrade, and the trade is worth stating.**
+#: Every artefact-producing stage runs on Opus above, because a
+#: confident-sounding fabrication is their failure mode. Channel planning is
+#: the stage where that is *least* visible — "run paid social" reads as
+#: correct whether or not anyone researched it — so the Opus tier was doing
+#: real work here. It is given up because the alternative is worse: the
+#: question this stage has to answer ("where does this audience convert") is
+#: not answerable from weights at all, and #136's table says plainly that a
+#: Claude 5 route with `:online` attached returns **zero** annotations. A
+#: better model that cannot retrieve produces a more persuasive version of
+#: exactly the defect #65 was filed about.
+#:
+#: What replaces the tier is mechanical rather than aspirational, which is the
+#: only kind of replacement worth having: provenance is now checked against
+#: the union of the approved parent's citations and the run's OWN
+#: `annotations` (so an invented URL is still refused), and every single
+#: recommendation must cite at least one URL the runtime recorded this run
+#: retrieving (`pipeline.UngroundedRecommendationError`). A plan resting on
+#: positioning's carried-over sources fails whatever tier produced it.
+#:
+#: Revisit exactly as `DEFAULT_RESEARCH_MODEL` says to: run the stage against
+#: a fact that post-dates training, read `annotations`, and move it only on
+#: that evidence. Not because a model is newer — that is what #108 did, and it
+#: cost a day.
+DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-sonnet-4:online"
 #: Copy reasons over what it is given, same as positioning and channel
 #: planning — no `:online` needed.
 DEFAULT_COPY_MODEL = "anthropic/claude-opus-5"
@@ -1058,11 +1217,26 @@ DEFAULT_COPY_MODEL = "anthropic/claude-opus-5"
 # and still answer. Every turn has an invoice attached and this plugin fans out
 # two of these per research run, so raising it is a cost decision.
 RESEARCH_MAX_TURNS = 8
-# Neither synthesis, positioning nor channel planning searches; one turn to
-# answer, plus headroom for a retried tool call.
+# Neither synthesis nor positioning searches; one turn to answer, plus
+# headroom for a retried tool call.
 SYNTHESIS_MAX_TURNS = 3
 POSITIONING_MAX_TURNS = 3
-CHANNEL_PLAN_MAX_TURNS = 3
+# Channel planning searches (issue #65), so it needs research's budget rather
+# than a reasoning stage's: at 3 turns it could search once and then had to
+# answer, which is not a stage that researches anything. Matched to
+# `RESEARCH_MAX_TURNS` deliberately — same retrieval shape, same provider,
+# same wall clock — so the two move together rather than drifting apart.
+#
+# **This makes the stage materially more expensive**, and that is the accepted
+# trade: `:online` bills per result, every turn can carry a retrieval, and the
+# stage now runs several. Issue #65 states the position explicitly ("I don't
+# mind making this an expensive/time consuming query. This is key to
+# success"), because channel choice is what every downstream artefact is
+# generated per. What it does NOT buy is more wall clock: every agent is
+# already at `AGENT_TIMEOUT_SECONDS` = the runtime ceiling, so these turns
+# have to fit in the same 240s research's do, and raising that is an instance
+# change (see `RUNTIME_TIMEOUT_CEILING_SECONDS`), not a plugin one.
+CHANNEL_PLAN_MAX_TURNS = RESEARCH_MAX_TURNS
 COPY_MAX_TURNS = 3
 
 #: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_SECONDS` — the
@@ -1182,8 +1356,16 @@ def positioning_definition(*, model: str, instructions: str) -> dict[str, Any]:
 
 
 def channel_plan_definition(*, model: str, instructions: str) -> dict[str, Any]:
-    """The channel-plan agent's run definition — no tools; it reasons over
-    the approved positioning artefact it is given in ``input_payload``."""
+    """The channel-plan agent's run definition.
+
+    ``tools`` is empty and that is **not** because this agent does not search —
+    since issue #65 it does. It reaches the web the same way research does,
+    through OpenRouter's ``:online`` model suffix rather than a registry tool,
+    for the reason ``research_definition`` records: a registered-but-
+    unconfigured ``web_search`` is silently dropped rather than failed, so an
+    agent that declared it would return no findings with no error anywhere —
+    which is the exact shape of failure this stage is least able to survive.
+    """
     return {
         "instructions": instructions,
         "model": model,

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -87,6 +87,7 @@ from .definitions import (
     ResearchSynthesis,
     Source,
     channel_plan_definition,
+    channel_plan_search_query,
     channel_plan_tool_schema,
     copy_definition,
     copy_tool_schema,
@@ -151,6 +152,36 @@ class UncitedSourceError(PipelineError):
     refusal to salvage ``annotations`` into ``sources`` in
     :func:`_no_citations_message`: the honest response to "this attribution is
     not real" is to say so, not to tidy it away.
+    """
+
+
+class UngroundedRecommendationError(PipelineError):
+    """A channel recommendation cited nothing this run itself retrieved
+    (issue #65) — every one of its sources was carried over from the approved
+    positioning it was handed.
+
+    **A different failure from :class:`UncitedSourceError`, and the one that
+    check cannot see.** Provenance asks "could this source have been read";
+    carried-over positioning sources pass that trivially, because they
+    demonstrably were. This asks the question the citation count never did:
+    was the recommendation grounded in evidence gathered for the CHANNEL
+    question, or in evidence gathered to answer a different one.
+
+    That distinction is the whole of issue #65. Research asks who this
+    audience is and what competitors say to them; channel planning asks where
+    that audience converts. A source about a competitor's pricing page can
+    legitimately support "recommend Google Search ads" under a count-based
+    guard, and nothing detects that the evidence is about the wrong question —
+    while channel choice is what every downstream artefact is generated *per*,
+    so a wrong one is not one wrong artefact, it is every artefact after it.
+
+    Raised per recommendation rather than per plan, deliberately: a plan-level
+    check passes the moment one channel is researched, and the rest ride along
+    on it.
+
+    Only askable when the run's own retrieval is **known** — see
+    :func:`extract_channel_plan` for the tri-state, which is the same one
+    ``annotations`` and ``allowed_source_urls`` already carry.
     """
 
 
@@ -598,6 +629,76 @@ def extract_positioning(
     )
 
 
+def annotation_source_urls(annotations: list[dict[str, Any]] | None) -> list[str] | None:
+    """Every URL the runtime recorded this run retrieving, deduplicated in
+    first-seen order — or ``None`` when there is no record to read.
+
+    The tri-state of :attr:`AgentRunView.annotations` is preserved exactly,
+    because collapsing it is the mistake every check in this module is careful
+    not to make: ``None`` is "not known", ``[]`` is "retrieval genuinely
+    returned nothing", and those two lead to opposite decisions in
+    :func:`extract_channel_plan` — skip the check, versus fail the run.
+
+    Reads both annotation shapes via :func:`_annotation_url`, for the same
+    reason the breadth instrument does.
+    """
+    if annotations is None:
+        return None
+    urls: list[str] = []
+    for entry in annotations:
+        url = _annotation_url(entry)
+        if url and url not in urls:
+            urls.append(url)
+    return urls
+
+
+def _require_retrieved_evidence(
+    plan: ChannelPlan, *, retrieved_source_urls: Collection[str]
+) -> None:
+    """Every recommendation must cite at least one URL **this run retrieved**
+    (issue #65), or :class:`UngroundedRecommendationError`.
+
+    See that class for why this is a different question from provenance and
+    why it is asked per recommendation. Two things about the shape:
+
+    - The comparison is on :func:`_url_key`, not the raw string, exactly as
+      provenance is: a model that retypes a retrieved URL with a trailing
+      slash has cited what it retrieved, and failing that would make the guard
+      fire on honest runs — which is how a guard ends up switched off.
+    - ``retrieved_source_urls`` being empty is not a special case here. It
+      falls through to "every recommendation is ungrounded", which is exactly
+      right — a run whose retrieval returned nothing cannot have grounded
+      anything in it — and the message says which of the two happened, since
+      "search found nothing" and "the search results never reached the plan"
+      need different responses from an operator.
+    """
+    allowed = {_url_key(url) for url in retrieved_source_urls}
+    ungrounded = [
+        recommendation.channel_key or recommendation.suggested_label or "(unnamed channel)"
+        for recommendation in plan.channels
+        if not any(_url_key(source.url) in allowed for source in recommendation.sources)
+    ]
+    if not ungrounded:
+        return
+
+    named = ", ".join(ungrounded[:_MAX_REPORTED_UNCITED])
+    if len(ungrounded) > _MAX_REPORTED_UNCITED:
+        named += f" (and {len(ungrounded) - _MAX_REPORTED_UNCITED} more)"
+    cause = (
+        "this run's own search returned nothing, so there is no conversion evidence "
+        "behind any of it"
+        if not allowed
+        else "they rest entirely on sources carried over from the approved positioning, "
+        "which was researched to answer a different question"
+    )
+    raise UngroundedRecommendationError(
+        f"The channel-plan run recommended {len(ungrounded)} channel"
+        f"{'s' if len(ungrounded) != 1 else ''} with no evidence it retrieved itself "
+        f"({named}): {cause}. Channel choice decides where the whole campaign goes, so "
+        "nothing was produced — try running channel planning again."
+    )
+
+
 def extract_channel_plan(
     messages: list[dict[str, Any]],
     *,
@@ -614,10 +715,51 @@ def extract_channel_plan(
     not anyone researched it. ``annotations`` — see
     :func:`extract_research_synthesis`.
 
+    ## What provenance means for a stage that retrieves (issue #65 vs #22/#113)
+
+    Since #65 this stage performs its own live retrieval, which breaks the
+    assumption the provenance check was built on. ``positioning``,
+    ``channel_plan`` and ``copy`` were guarded because their legitimate source
+    set was **closed and already known**: exactly the approved parent's
+    ``citations``. Citing evidence the parent did not contain was, by
+    definition, fabrication. #65's whole purpose is to make this stage cite
+    evidence the parent does not contain, so carrying that rule over unchanged
+    would reject every grounded run — and simply dropping it would switch off
+    the fabrication guard at the stage where fabrication is least visible.
+
+    Neither. **The set stays closed; it stops being the parent alone.** A
+    channel-plan run can legitimately have read exactly two things: the
+    approved positioning it was handed, and whatever its own retrieval
+    returned. The runtime records the second independently of the model, on
+    ``annotations`` — that is the point of the column (#82) — so the union of
+    the two is a set this repo can check against without trusting the model
+    for any of it. A URL in neither was not read by anything, which is the
+    same sentence :class:`UncitedSourceError` always meant.
+
+    The tri-state is preserved and matters more here than anywhere else:
+
+    - ``annotations`` non-empty — allowed set is ``allowed_source_urls`` ∪
+      retrieved.
+    - ``annotations == []`` — retrieval genuinely returned nothing, so the
+      allowed set is the parent's alone, exactly as before #65.
+    - ``annotations is None`` — there is **no record of what this run
+      retrieved**, so no closed set exists to check against and the check is
+      skipped rather than guessed at. Enforcing the parent-only set here would
+      fail a genuinely grounded run whose annotations were not recorded, which
+      is how a guard gets switched off for real; the module already treats
+      "not known" this way for ``allowed_source_urls`` itself.
+
+    Provenance alone is then *necessary and not sufficient*, which is the
+    other half of #65: carried-over positioning sources satisfy it perfectly
+    while answering the wrong question. So each recommendation must also cite
+    at least one URL this run retrieved — :class:`UngroundedRecommendationError`,
+    :func:`_require_retrieved_evidence` — asked only when retrieval is known,
+    for the same reason.
+
     ``allowed_source_urls`` is the approved **positioning** artefact's
     citation URLs (issue #22) — see :func:`extract_positioning` for the full
     reasoning; this is that same check one stage further down, which is where
-    the issue was filed from.
+    the issue was filed from, now widened as described above.
 
     ``taxonomy`` is ``{channel_key: motion}`` for exactly the taxonomy this
     run was shown (#76 increment 2) — stored on the artefact at start time,
@@ -650,21 +792,42 @@ def extract_channel_plan(
     not exist when they were produced — the same distinction
     ``allowed_source_urls=None`` already carries for #22.
     """
+    retrieved = annotation_source_urls(annotations)
+    if retrieved is None:
+        # No record of this run's retrieval: the legitimate set is unknowable,
+        # so neither evidence check can be adjudicated. Said out loud rather
+        # than passed over in silence — a stage that is meant to ground and
+        # cannot be shown to have grounded is exactly what #65 was filed
+        # about, and the failure mode is invisible by construction.
+        widened: Collection[str] | None = None
+        logger.warning(
+            "channel plan evidence checks skipped: the run reported no annotations, so "
+            "there is no record of what it retrieved to check its sources against"
+        )
+    else:
+        widened = [*(allowed_source_urls or []), *retrieved]
+
     plan = _extract_cited_artefact(
         messages,
         annotations=annotations,
-        allowed_source_urls=allowed_source_urls,
-        parent_description="the approved positioning it was given",
+        allowed_source_urls=widened,
+        parent_description=(
+            "the evidence this run actually had — the approved positioning it was "
+            "given, plus what its own search returned —"
+        ),
         tool_name=CHANNEL_PLAN_TOOL_NAME,
         model_cls=ChannelPlan,
         citation_groups=lambda r: [c.sources for c in r.channels],
         malformed_message=f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call",
         no_citations_message=(
-            "The channel-plan run cited nothing from the approved positioning. Nothing "
-            "was produced — try running channel planning again."
+            "The channel-plan run cited nothing at all — neither its own search results "
+            "nor the approved positioning. Nothing was produced — try running channel "
+            "planning again."
         ),
         retry_hint="channel planning",
     )
+    if retrieved is not None:
+        _require_retrieved_evidence(plan, retrieved_source_urls=retrieved)
     permitted = None if allowed_motions is None else frozenset(allowed_motions)
     for recommendation in plan.channels:
         if recommendation.channel_key is None:
@@ -1185,7 +1348,9 @@ def evidence_profile(views: Collection[AgentRunView | None]) -> EvidenceProfile:
     )
 
 
-def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | None]) -> None:
+def _log_evidence_profile(
+    *, chain_id: str | None, views: Collection[AgentRunView | None], stage: str = "research"
+) -> None:
     """Record this chain's retrieval breadth where an operator investigating a
     thin artefact will find it, without failing the run over it.
 
@@ -1200,12 +1365,26 @@ def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | Non
     while reporting on a failure replaces a diagnosable error with a spurious
     one, so every step here is wrapped. Nothing this function can do is worth
     more than the exception the caller is already carrying.
+
+    ``stage`` names which stage's retrieval is being measured (issue #65).
+    It defaults to ``research`` because that is the stage this instrument was
+    built for and every existing filter is written against — the message
+    prefix and the structured keys are unchanged for it, byte for byte.
+    Channel planning retrieves too now, and "is the channel plan grounded?" is
+    the same question about the same kind of evidence: #101 was settled only
+    because somebody measured research's retrieval by hand and then
+    instrumented it, and asking the new question without the instrument buys
+    the same day of archaeology a second time. One implementation rather than
+    a near-copy, so a fix to the tri-state reasoning below cannot apply to one
+    stage and not the other.
     """
+    label = stage.replace("_", " ")
     try:
         profile = evidence_profile(views)
     except Exception:  # pragma: no cover - defensive; a report must not raise
         logger.warning(
-            "research retrieval breadth: not measured — the profile could not be computed",
+            "%s retrieval breadth: not measured — the profile could not be computed",
+            label,
             exc_info=True,
             extra={"causation_id": chain_id},
         )
@@ -1222,23 +1401,26 @@ def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | Non
         # reason: a filter on this field must not be able to average unknowns
         # in as zeroes.
         logger.info(
-            "research retrieval breadth: not measured — no research run reported "
+            "%s retrieval breadth: not measured — no %s run reported "
             "annotations (%d run view(s) seen)",
+            label,
+            label,
             len(views),
             extra={
                 "causation_id": chain_id,
-                "research_runs_measured": 0,
-                "research_distinct_urls": None,
-                "research_shared_urls": None,
-                "research_deep_pages": None,
-                "research_site_roots": None,
+                f"{stage}_runs_measured": 0,
+                f"{stage}_distinct_urls": None,
+                f"{stage}_shared_urls": None,
+                f"{stage}_deep_pages": None,
+                f"{stage}_site_roots": None,
             },
         )
         return
 
     logger.info(
-        "research retrieval breadth: %d distinct URLs across %d grounded run(s) "
+        "%s retrieval breadth: %d distinct URLs across %d grounded run(s) "
         "(%d shared by more than one, %d deep pages, %d site roots)",
+        label,
         profile.distinct_urls,
         profile.runs_measured,
         profile.shared_urls,
@@ -1246,11 +1428,11 @@ def _log_evidence_profile(*, chain_id: str, views: Collection[AgentRunView | Non
         profile.site_roots,
         extra={
             "causation_id": chain_id,
-            "research_runs_measured": profile.runs_measured,
-            "research_distinct_urls": profile.distinct_urls,
-            "research_shared_urls": profile.shared_urls,
-            "research_deep_pages": profile.deep_pages,
-            "research_site_roots": profile.site_roots,
+            f"{stage}_runs_measured": profile.runs_measured,
+            f"{stage}_distinct_urls": profile.distinct_urls,
+            f"{stage}_shared_urls": profile.shared_urls,
+            f"{stage}_deep_pages": profile.deep_pages,
+            f"{stage}_site_roots": profile.site_roots,
         },
     )
 
@@ -1465,7 +1647,20 @@ async def start_channel_plan(
             instructions=CHANNEL_PLAN_INSTRUCTIONS,
         ),
         output_tool=channel_plan_tool_schema(),
+        # `search_query` FIRST, exactly as `start_research`'s payload is and
+        # for exactly the same reason (issue #101, now #65): this is an
+        # `:online` run, so the provider searches from the payload BEFORE the
+        # model is invoked, and the payload is therefore the only place this
+        # stage can decide what its retrieval is about. Leading with
+        # `positioning` would retrieve the positioning question all over
+        # again — the audience/competitive evidence this stage already has
+        # too much of — instead of the conversion question it exists to ask.
         input_payload={
+            "search_query": channel_plan_search_query(
+                positioning_body=positioning_body,
+                taxonomy=taxonomy,
+                campaign_motion=campaign_motion,
+            ),
             "positioning": positioning_body,
             "channel_taxonomy": taxonomy,
             "campaign_motion": campaign_motion,
@@ -1480,6 +1675,7 @@ async def advance_channel_plan(
     *,
     run_id: str,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    causation_id: str | None = None,
     allowed_motions: Collection[str] | None = None,
     allowed_source_urls: Collection[str] | None = None,
 ) -> ChannelPlan | None:
@@ -1489,10 +1685,29 @@ async def advance_channel_plan(
     what :func:`start_channel_plan` gave this run, and ``allowed_motions``
     the campaign motion it was started under (#67) — see
     :func:`extract_channel_plan` for how they and ``allowed_source_urls`` are
-    used."""
+    used.
+
+    Since #65 this stage retrieves, so its breadth is measured and logged on
+    every terminal path exactly as :func:`advance_research`'s is — including
+    the failed one, which is where the measurement is worth most: "the
+    retrieval was thin" and "the run died" produce the same dead artefact and
+    this line is the only thing that separates them. It is a report, never a
+    gate; it changes nothing this function returns or raises.
+
+    ``causation_id`` is the chain this run belongs to, carried only so the
+    breadth line can be joined to the rest of the campaign's runs. Optional
+    because it is diagnostic: a caller that has not got one still gets the
+    measurement, with the id reading as unknown rather than the measurement
+    being withheld.
+    """
     view = await gateway.get_agent_run(run_id=run_id)
     if view is None or not view.is_terminal:
         return None
+    # Once, here, before either branch: emitted exactly one time per terminal
+    # advance, on the success and failure paths alike, and never while the run
+    # is still in flight (this function is polled, so that would be a stream of
+    # partial snapshots rather than one measurement).
+    _log_evidence_profile(chain_id=causation_id, views=[view], stage="channel_plan")
     if not view.succeeded:
         raise RunNotSucceededError("The channel-plan run did not complete successfully.")
     return extract_channel_plan(

--- a/tests/test_marketing_channel_plan_grounding.py
+++ b/tests/test_marketing_channel_plan_grounding.py
@@ -1,0 +1,512 @@
+"""The channel plan must be grounded in its OWN retrieval, not positioning's
+leftovers (issue #65).
+
+Research asks "who is this audience and what do competitors say". Channel
+planning asks "where does this audience convert". Those are different
+questions needing different evidence, and until this module existed the second
+was answered entirely with the first's: the channel-plan agent ran on a
+non-searching model, was told in as many words that it had no web access, and
+was required to copy its `Source` objects verbatim out of the approved
+positioning artefact. Every channel recommendation — the decision the whole
+campaign's budget follows — was therefore justified by evidence gathered to
+answer a different question, and nothing in the system could tell that apart
+from a channel plan somebody had actually researched.
+
+Four things are pinned here, because each of them fails silently:
+
+1. **The route.** `:online` is how grounded retrieval works in this estate
+   (Biffo's native `web_search` is silently never offered on dev), and not
+   every `:online` route grounds — `sonnet-5:online` returns zero annotations
+   (#136/#141). A model id is a plain string nothing validates.
+2. **The prompt.** A searching agent still told "you do not have web access"
+   will not search.
+3. **Provenance, re-derived for a stage that retrieves (issue #113/#22).**
+   The old rule — every cited URL must appear in the approved parent — is
+   exactly what #65 exists to break, so it cannot simply carry over. The rule
+   that replaces it is stated in `pipeline.extract_channel_plan` and proved
+   below: the legitimate set is the parent's citations UNION what the
+   runtime's own `annotations` record says this run retrieved.
+4. **That the retrieval actually reached the recommendations.** A run can
+   search, and then cite nothing it found. The count-based guard passes on
+   positioning's carried-over URLs exactly as well as on a conversion
+   benchmark, which is the gap issue #65 names in its own words: "re-using
+   positioning's citations should stop being sufficient — otherwise the guard
+   passes on the old evidence and nothing changes".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+
+from marketing import pipeline
+from marketing.definitions import (
+    CHANNEL_PLAN_AGENT_NAME,
+    CHANNEL_PLAN_INSTRUCTIONS,
+    CHANNEL_PLAN_MAX_TURNS,
+    DEFAULT_CHANNEL_PLAN_MODEL,
+    POSITIONING_MAX_TURNS,
+    channel_plan_definition,
+)
+
+# ── Fixtures: one parent URL, one retrieved URL, one invented one ────────────
+#
+# Deliberately three different hosts. The point of the widened provenance rule
+# is that "retrieved" and "carried over from the parent" are BOTH legitimate
+# and distinguishable, and that anything in neither set is still refused —
+# which a shared host would blur (`_url_key` keeps the path, so "same domain"
+# has never been provenance here).
+
+_PARENT_URL = "https://positioning.example.com/segment-evidence"
+_RETRIEVED_URL = "https://benchmarks.example.com/paid-search-cpa-2026"
+_FABRICATED_URL = "https://invented.example.com/statistics"
+
+_ANNOTATIONS = [{"type": "url_citation", "url": _RETRIEVED_URL, "title": "CPA benchmarks"}]
+
+_TAXONOMY: dict[str, Literal["organic", "paid"]] = {
+    "google_search_paid": "paid",
+    "linkedin_organic": "organic",
+}
+
+
+def _tool_call(arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "submit_channel_plan", "arguments": arguments}}],
+        }
+    ]
+
+
+def _channel(channel_key: str, *urls: str, rank: int = 1) -> dict[str, Any]:
+    return {
+        "channel_key": channel_key,
+        "rank": rank,
+        "rationale": "Where this segment demonstrably converts.",
+        "sources": [{"url": url, "note": "n"} for url in urls],
+    }
+
+
+def _plan_call(*channels: dict[str, Any]) -> list[dict[str, Any]]:
+    return _tool_call({"channels": list(channels)})
+
+
+class _FakeGateway:
+    """Records the requested run and lets a test complete it — the same shape
+    `test_marketing_pipeline_orchestration.py` uses, kept local because this
+    module only ever drives the one stage."""
+
+    def __init__(self) -> None:
+        self.requested: list[dict[str, Any]] = []
+        self._runs: dict[str, pipeline.AgentRunView] = {}
+
+    async def request_agent_run(
+        self,
+        *,
+        agent_name: str,
+        definition: dict[str, Any],
+        output_tool: dict[str, Any],
+        input_payload: dict[str, Any],
+        causation_id: str,
+    ) -> str:
+        del output_tool
+        run_id = f"run-{len(self.requested) + 1}"
+        self.requested.append(
+            {
+                "agent_name": agent_name,
+                "definition": definition,
+                "input_payload": input_payload,
+                "causation_id": causation_id,
+            }
+        )
+        self._runs[run_id] = pipeline.AgentRunView(id=run_id, status="pending")
+        return run_id
+
+    async def find_chain_run(self, *, chain_id: str, agent_name: str):  # pragma: no cover
+        del chain_id, agent_name
+        return None
+
+    async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView | None:
+        return self._runs.get(run_id)
+
+    def complete(
+        self,
+        run_id: str,
+        *,
+        status: str = "completed",
+        messages: list[dict[str, Any]] | None = None,
+        annotations: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._runs[run_id] = pipeline.AgentRunView(
+            id=run_id, status=status, messages=messages or [], annotations=annotations
+        )
+
+
+_POSITIONING_BODY = {
+    "segments": [
+        {
+            "name": "Multi-location operators",
+            "description": "Run 3+ sites and cannot see them in one place.",
+            "sources": [{"url": _PARENT_URL, "note": "n"}],
+        }
+    ],
+    "pillars": [],
+    "ctas": [],
+}
+
+_TAXONOMY_ROWS = [
+    {
+        "channel_key": "google_search_paid",
+        "label": "Google Search ads",
+        "motion": "paid",
+        "category": "search",
+    }
+]
+
+
+# ── 1. The route ─────────────────────────────────────────────────────────────
+
+
+def test_the_channel_plan_stage_runs_on_a_grounded_route() -> None:
+    """Without `:online` the stage cannot retrieve at all, and this is a plain
+    string nothing else validates."""
+    assert DEFAULT_CHANNEL_PLAN_MODEL.endswith(":online"), (
+        "channel planning must retrieve its own conversion evidence (#65), and "
+        f"`:online` is how retrieval works here; got {DEFAULT_CHANNEL_PLAN_MODEL!r}"
+    )
+
+
+def test_the_channel_plan_route_is_one_whose_grounding_has_been_observed_live() -> None:
+    """`:online` is necessary and not sufficient. `sonnet-5:online` carries the
+    suffix and returns **zero** annotations (#136) — the failure that cost a
+    day because it presents as good output on familiar topics and honest
+    emptiness on unfamiliar ones. So the route is pinned to the one this
+    estate has actually watched ground, and moving it means running the cheap
+    probe in `DEFAULT_RESEARCH_MODEL`'s docstring first."""
+    assert DEFAULT_CHANNEL_PLAN_MODEL == "anthropic/claude-sonnet-4:online", (
+        "channel planning must run on a route whose `:online` grounding has "
+        f"been observed live (#136/#141); got {DEFAULT_CHANNEL_PLAN_MODEL!r}. If "
+        "you are moving it, run the stage against a fact that post-dates "
+        "training and confirm `annotations` comes back non-empty first."
+    )
+
+
+# ── 2. The prompt and the budget ─────────────────────────────────────────────
+
+
+def test_the_prompt_no_longer_tells_the_agent_it_has_no_web_access() -> None:
+    """The instruction that made #65 true, quoted in the issue itself."""
+    assert "do not have web access" not in CHANNEL_PLAN_INSTRUCTIONS
+
+
+def test_the_prompt_asks_for_conversion_evidence_specifically() -> None:
+    """Not "search the web" — the whole point is *which* question the search
+    answers. Generic channel wisdom retrieved live is still generic channel
+    wisdom."""
+    lowered = CHANNEL_PLAN_INSTRUCTIONS.lower()
+    assert "convert" in lowered
+    assert "search results" in lowered
+
+
+def test_the_turn_budget_leaves_room_to_search_and_then_answer() -> None:
+    """`POSITIONING_MAX_TURNS` is the budget of a stage that only reasons over
+    what it is given. A searching stage that keeps it can search once, at
+    most, and then must answer — which is not a stage that researches."""
+    assert CHANNEL_PLAN_MAX_TURNS > POSITIONING_MAX_TURNS
+
+
+def test_the_definition_still_declares_no_registry_tool() -> None:
+    """Retrieval travels with the model id, never as a declared `web_search`
+    tool: on dev that tool is silently unavailable, so an agent that declares
+    it fabricates rather than errors."""
+    assert channel_plan_definition(model="m", instructions="i")["tools"] == []
+
+
+# ── 3. The searched query is derived from the CHANNEL question ───────────────
+
+
+@pytest.mark.asyncio
+async def test_the_run_leads_with_a_conversion_search_query() -> None:
+    """An `:online` run's retrieval is derived from its input payload — the
+    provider searches before the model is invoked — so the payload, not the
+    instructions, is the only place this stage can affect what comes back
+    (issue #101, measured: identical payloads produced identical pages). A
+    channel-plan payload that leads with the positioning body would retrieve
+    the positioning question all over again."""
+    gateway = _FakeGateway()
+
+    await pipeline.start_channel_plan(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+
+    payload = gateway.requested[0]["input_payload"]
+    assert next(iter(payload)) == "search_query", (
+        "the searched query must be the FIRST key of the payload, for the same "
+        "reason research's is (#101)"
+    )
+    query = payload["search_query"].lower()
+    assert "convert" in query  # the channel question, not the audience question
+    assert "multi-location operators" in query  # this campaign's audience, not any audience
+    assert "google search ads" in query  # the channels actually on the table
+    assert gateway.requested[0]["agent_name"] == CHANNEL_PLAN_AGENT_NAME
+
+
+# ── 4. Provenance, for a stage that retrieves (issue #113/#22 re-derived) ────
+
+
+def test_a_url_this_run_retrieved_is_not_treated_as_fabricated() -> None:
+    """The check that had to change. `channel_plan` is a guarded stage: every
+    cited URL used to be checked against the approved positioning's set, and
+    citing evidence the parent did NOT contain is now the whole point of the
+    stage. The rule is not dropped — it is widened to the set that can
+    actually have been read: the parent's citations UNION the runtime's own
+    record of what this run retrieved."""
+    messages = _plan_call(_channel("google_search_paid", _RETRIEVED_URL))
+
+    plan = pipeline.extract_channel_plan(
+        messages,
+        taxonomy=_TAXONOMY,
+        allowed_source_urls=[_PARENT_URL],
+        annotations=_ANNOTATIONS,
+    )
+
+    assert [s.url for s in plan.channels[0].sources] == [_RETRIEVED_URL]
+
+
+def test_a_url_in_neither_the_parent_nor_the_retrieval_is_still_refused() -> None:
+    """The fabrication guard has to survive the widening, or #65 silently
+    switches off the most dangerous check in the pipeline. A URL the runtime
+    never recorded retrieving, and the parent never contained, cannot have
+    been read by anything."""
+    messages = _plan_call(_channel("google_search_paid", _RETRIEVED_URL, _FABRICATED_URL))
+
+    with pytest.raises(pipeline.UncitedSourceError) as excinfo:
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy=_TAXONOMY,
+            allowed_source_urls=[_PARENT_URL],
+            annotations=_ANNOTATIONS,
+        )
+
+    assert _FABRICATED_URL in str(excinfo.value)
+    assert _RETRIEVED_URL not in str(excinfo.value)  # only the offending one is named
+
+
+def test_the_parents_own_sources_are_still_legitimate_alongside_retrieval() -> None:
+    """Widened, not replaced. A recommendation may still lean on the
+    positioning that justified the campaign — it simply may not lean on that
+    ALONE (the check below)."""
+    messages = _plan_call(_channel("google_search_paid", _PARENT_URL, _RETRIEVED_URL))
+
+    plan = pipeline.extract_channel_plan(
+        messages,
+        taxonomy=_TAXONOMY,
+        allowed_source_urls=[_PARENT_URL],
+        annotations=_ANNOTATIONS,
+    )
+
+    assert {s.url for s in plan.channels[0].sources} == {_PARENT_URL, _RETRIEVED_URL}
+
+
+def test_unknown_retrieval_cannot_adjudicate_provenance_either_way() -> None:
+    """`annotations is None` is "not known", never "retrieved nothing" — the
+    tri-state this module keeps everywhere. With no record of what the run
+    retrieved there is no closed set to check against, so the check is skipped
+    rather than guessed at: enforcing the parent-only set would fail a
+    genuinely grounded run whose annotations the runtime did not record, which
+    is how a guard ends up switched off for real."""
+    messages = _plan_call(_channel("google_search_paid", _FABRICATED_URL))
+
+    plan = pipeline.extract_channel_plan(
+        messages,
+        taxonomy=_TAXONOMY,
+        allowed_source_urls=[_PARENT_URL],
+        annotations=None,
+    )
+
+    assert plan.channels[0].sources[0].url == _FABRICATED_URL
+
+
+# ── 5. Retrieval must actually reach the recommendations ────────────────────
+
+
+def test_a_plan_resting_entirely_on_positionings_sources_is_refused() -> None:
+    """Issue #65's central demand. This run searched — `annotations` says so —
+    and then justified its channel choice with the audience research it was
+    handed. Every count-based check passes; the plan is exactly as ungrounded
+    as it was before the stage could search at all."""
+    messages = _plan_call(_channel("google_search_paid", _PARENT_URL))
+
+    with pytest.raises(pipeline.UngroundedRecommendationError) as excinfo:
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy=_TAXONOMY,
+            allowed_source_urls=[_PARENT_URL],
+            annotations=_ANNOTATIONS,
+        )
+
+    assert "google_search_paid" in str(excinfo.value)
+
+
+def test_every_recommendation_needs_its_own_retrieved_evidence() -> None:
+    """Per recommendation, not per plan. A plan-level check passes as soon as
+    one channel is researched, and the other four then ride along on it — and
+    a channel recommendation is generated-per-channel work downstream, so a
+    wrong one is not one wrong artefact, it is every artefact after it."""
+    messages = _plan_call(
+        _channel("google_search_paid", _RETRIEVED_URL),
+        _channel("linkedin_organic", _PARENT_URL),
+    )
+
+    with pytest.raises(pipeline.UngroundedRecommendationError) as excinfo:
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy=_TAXONOMY,
+            allowed_source_urls=[_PARENT_URL],
+            annotations=_ANNOTATIONS,
+        )
+
+    assert "linkedin_organic" in str(excinfo.value)
+    assert "google_search_paid" not in str(excinfo.value)
+
+
+def test_a_zero_url_channel_plan_run_fails() -> None:
+    """`annotations == []` is the one state that genuinely means retrieval
+    returned nothing. The plan can then only be resting on carried-over
+    sources, whatever it looks like — the same reasoning research already
+    applies, and stated as a requirement in #65's own "done when"."""
+    messages = _plan_call(_channel("google_search_paid", _PARENT_URL))
+
+    with pytest.raises(pipeline.UngroundedRecommendationError) as excinfo:
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy=_TAXONOMY,
+            allowed_source_urls=[_PARENT_URL],
+            annotations=[],
+        )
+
+    # ...and the message says WHICH of the two ungrounded shapes this is:
+    # "the search found nothing" and "the search results never reached the
+    # plan" need different responses from the operator reading it.
+    assert "own search returned nothing" in str(excinfo.value)
+
+
+def test_the_grounding_check_is_skipped_when_retrieval_is_not_known() -> None:
+    """Same tri-state as provenance above, and the reason every existing
+    channel-plan test keeps passing: a run this repo has no retrieval record
+    for is not retroactively failed for a rule it was never run under."""
+    messages = _plan_call(_channel("google_search_paid", _PARENT_URL))
+
+    plan = pipeline.extract_channel_plan(
+        messages, taxonomy=_TAXONOMY, allowed_source_urls=[_PARENT_URL], annotations=None
+    )
+
+    assert plan.channels[0].channel_key == "google_search_paid"
+
+
+def test_an_ungrounded_recommendation_is_a_pipeline_error() -> None:
+    """`admin_app._pipeline_error_to_http` maps the BASE class, so a new error
+    type that missed it would fall through as a bare 500 rather than the 502
+    every other agent-output failure produces."""
+    assert issubclass(pipeline.UngroundedRecommendationError, pipeline.PipelineError)
+
+
+# ── 6. The retrieval-breadth instrument, pointed at this stage ───────────────
+
+
+def _breadth_records(caplog: pytest.LogCaptureFixture) -> list[Any]:
+    prefix = "channel plan retrieval breadth"
+    return [r for r in caplog.records if r.getMessage().startswith(prefix)]
+
+
+@pytest.mark.asyncio
+async def test_channel_plan_retrieval_breadth_is_measured_like_researchs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#101 was settled only because somebody measured research's retrieval by
+    hand and then instrumented it. "Is the channel plan grounded?" is now
+    exactly the same question about exactly the same kind of evidence, and
+    without the same instrument it is answerable only by the same day of
+    archaeology."""
+    gateway = _FakeGateway()
+    causation_id, run_id = await pipeline.start_channel_plan(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+    gateway.complete(
+        run_id,
+        messages=_plan_call(_channel("google_search_paid", _RETRIEVED_URL)),
+        annotations=[*_ANNOTATIONS, {"type": "url_citation", "url": "https://roots.example.com/"}],
+    )
+
+    with caplog.at_level("INFO"):
+        plan = await pipeline.advance_channel_plan(
+            gateway,
+            run_id=run_id,
+            causation_id=causation_id,
+            taxonomy=_TAXONOMY,
+            allowed_source_urls=[_PARENT_URL],
+        )
+
+    assert plan is not None
+    (record,) = _breadth_records(caplog)
+    assert "2 distinct URLs across 1 grounded run(s)" in record.getMessage()
+    assert record.causation_id == causation_id
+    assert record.channel_plan_distinct_urls == 2
+    assert record.channel_plan_deep_pages == 1
+    assert record.channel_plan_site_roots == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_plan_breadth_is_logged_when_the_run_failed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The path an operator most needs it on, exactly as for research: "the
+    retrieval was thin" and "the run died" produce the same dead artefact."""
+    gateway = _FakeGateway()
+    causation_id, run_id = await pipeline.start_channel_plan(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+    gateway.complete(run_id, status="failed", annotations=_ANNOTATIONS)
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_channel_plan(
+            gateway, run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
+        )
+
+    (record,) = _breadth_records(caplog)
+    assert record.channel_plan_distinct_urls == 1
+
+
+@pytest.mark.asyncio
+async def test_channel_plan_breadth_says_unmeasured_rather_than_a_false_zero(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`0 distinct URLs` and "we have no record" must not read the same — the
+    second sends nobody hunting a retrieval outage that never happened."""
+    gateway = _FakeGateway()
+    causation_id, run_id = await pipeline.start_channel_plan(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+    gateway.complete(run_id, status="failed", annotations=None)
+
+    with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_channel_plan(
+            gateway, run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
+        )
+
+    (record,) = _breadth_records(caplog)
+    assert "not measured" in record.getMessage()
+    assert record.channel_plan_distinct_urls is None

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -447,7 +447,14 @@ def test_positioning_is_refused_even_when_it_also_cites_a_real_url() -> None:
 def test_channel_plan_citing_a_url_the_approved_positioning_never_contained_is_refused() -> None:
     """The same check one stage down, which is why this issue was filed during
     M4: channel advice reads as generic wisdom whether or not anyone
-    researched it, so an invented citation is least visible here."""
+    researched it, so an invented citation is least visible here.
+
+    `annotations=[]` since issue #65 gave this stage its own retrieval: the
+    parent's citations are the whole legitimate set only when retrieval is
+    known to have returned nothing. The widened set, and what each of the
+    three `annotations` states means for it, is proved in
+    `tests/test_marketing_channel_plan_grounding.py`.
+    """
     messages = _tool_call("submit_channel_plan", _channel_plan_args(_FABRICATED))
 
     with pytest.raises(UncitedSourceError) as excinfo:
@@ -455,12 +462,20 @@ def test_channel_plan_citing_a_url_the_approved_positioning_never_contained_is_r
             messages,
             taxonomy={"instagram_organic": "organic"},
             allowed_source_urls=_APPROVED,
+            annotations=[],
         )
 
     assert "approved positioning" in str(excinfo.value)
 
 
-def test_channel_plan_citing_only_approved_positioning_urls_succeeds() -> None:
+def test_channel_plan_citing_only_approved_positioning_urls_survives_provenance() -> None:
+    """Provenance-wise this is fine — every URL came from the parent. It is
+    refused one check later, by the grounding guard #65 added, because a plan
+    that cites only the positioning is answering the audience question rather
+    than the channel one; that is proved in
+    `tests/test_marketing_channel_plan_grounding.py`. Here the run has no
+    retrieval record at all, so neither evidence check can be adjudicated and
+    the artefact stands, exactly as every pre-#65 artefact must continue to."""
     messages = _tool_call("submit_channel_plan", _channel_plan_args(*_APPROVED))
 
     plan = extract_channel_plan(

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -709,6 +709,15 @@ async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body
     assert requested.agent_name == CHANNEL_PLAN_AGENT_NAME
     assert requested.causation_id == causation_id
     assert requested.input_payload == {
+        # #65: the stage retrieves now, and an `:online` run's provider
+        # searches from the payload before the model is invoked — so the
+        # searched query leads, exactly as research's does (#101). Its
+        # CONTENT is asserted in `test_marketing_channel_plan_grounding.py`;
+        # what matters here is that the payload's other keys are unchanged
+        # and this one is present.
+        "search_query": pipeline.channel_plan_search_query(
+            positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
+        ),
         "positioning": positioning_body,
         "channel_taxonomy": taxonomy,
         # #67: told the campaign's motion as well as shown a taxonomy already
@@ -716,6 +725,7 @@ async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body
         # efficiency and the narrowing is the enforcement.
         "campaign_motion": "both",
     }
+    assert next(iter(requested.input_payload)) == "search_query"
     assert run_id  # a real id was returned
 
 

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -135,10 +135,20 @@ class _FakeGateway:
         return self._runs.get(run_id)
 
     def complete(
-        self, run_id: str, *, status: str = "completed", messages: list | None = None
+        self,
+        run_id: str,
+        *,
+        status: str = "completed",
+        messages: list | None = None,
+        annotations: list[dict[str, Any]] | None = None,
     ) -> None:
+        """`annotations` defaults to `None` — "no record of what this run
+        retrieved" — which is what every run in this module was until issue
+        #65 gave the channel-plan stage its own retrieval. Tests that care
+        about the evidence guards pass it explicitly; the rest keep exercising
+        the routes rather than the guards, which is what they are for."""
         self._runs[run_id] = pipeline.AgentRunView(
-            id=run_id, status=status, messages=messages or []
+            id=run_id, status=status, messages=messages or [], annotations=annotations
         )
 
     def fire_chain_run(self, *, chain_id: str, agent_name: str, messages: list) -> None:
@@ -658,7 +668,17 @@ def test_start_channel_plan_stashes_the_approved_positioning_citation_urls(ctx) 
 def test_get_channel_plan_artefact_502s_a_fabricated_citation_and_leaves_it_pending(ctx) -> None:
     """The issue's case one stage down: a channel recommendation citing a URL
     the approved positioning never contained is the most confident-sounding
-    fabrication in the pipeline."""
+    fabrication in the pipeline.
+
+    `annotations=[]` since #65, and that is the point of the case rather than
+    test bookkeeping: this stage retrieves now, so "a URL the positioning never
+    contained" is only a fabrication once retrieval is *known* not to have
+    returned it. An empty list is the state that establishes that — retrieval
+    ran and came back with nothing — so the parent's citations are again the
+    entire legitimate set, exactly as before this stage could search. The
+    `None` (no record at all) case is a different answer and is proved in
+    `tests/test_marketing_channel_plan_grounding.py`.
+    """
     client, core, gateway = ctx
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
@@ -666,12 +686,59 @@ def test_get_channel_plan_artefact_502s_a_fabricated_citation_and_leaves_it_pend
     gateway.complete(
         started["agent_run_id"],
         messages=_channel_plan_call(url="https://marketing-statistics.example/benchmarks"),
+        annotations=[],
     )
 
     resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 502
     assert "marketing-statistics.example" in resp.json()["detail"]
+    assert core.artefacts[started["id"]]["status"] == "pending", "must not have been proposed"
+
+
+def test_channel_plan_grounded_in_its_own_retrieval_is_proposed_and_cites_it(ctx) -> None:
+    """Issue #65 end to end, through the real route: the stage retrieved a
+    conversion source the approved positioning never contained, cited it, and
+    the artefact is proposed with that URL in `citations` — which is what makes
+    the evidence reviewable by the operator, and what the copy stage below may
+    then legitimately draw on."""
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    retrieved = "https://benchmarks.example/paid-search-cpa-by-sector"
+
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_channel_plan_call(url=retrieved),
+        annotations=[{"type": "url_citation", "url": retrieved, "title": "CPA by sector"}],
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 200
+    assert core.artefacts[started["id"]]["status"] == "proposed"
+    assert retrieved in core.artefacts[started["id"]]["citations"]
+
+
+def test_channel_plan_that_only_re_cites_positioning_is_refused_by_the_route(ctx) -> None:
+    """The defect issue #65 was filed about, at the seam an operator meets it:
+    the run searched (`annotations` says so) and then justified both channels
+    with the audience research it was handed. Every count-based check passes,
+    so before #65 this was proposed as evidenced."""
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_channel_plan_call(),  # the approved positioning's own URL
+        annotations=[{"type": "url_citation", "url": "https://benchmarks.example/cpa"}],
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    assert resp.status_code == 502
+    assert "instagram_organic" in resp.json()["detail"]
     assert core.artefacts[started["id"]]["status"] == "pending", "must not have been proposed"
 
 

--- a/tests/test_marketing_stage_models.py
+++ b/tests/test_marketing_stage_models.py
@@ -10,13 +10,21 @@ The two invariants worth pinning are the ones whose breakage is silent:
 
 * **Family.** A stage left behind on an older generation still runs and still
   bills — nothing fails — so the only way to notice is to assert it.
-* **``:online`` on research, and only research.** The suffix is what gives
-  research grounded retrieval, and it is the sole reason the zero-citation
-  guard has anything to cite (Biffo's native ``web_search`` is silently never
-  offered on dev, so an agent that declares it fabricates rather than errors).
-  Losing it on research would produce confident, uncited findings; gaining it
-  on a downstream stage would bill for retrieval that stage does not use and
-  would make issue #90's "this run was never grounded" reasoning wrong.
+* **``:online`` on exactly the stages that retrieve.** The suffix is what
+  gives a stage grounded retrieval, and it is the sole reason the
+  zero-citation guard has anything to cite (Biffo's native ``web_search`` is
+  silently never offered on dev, so an agent that declares it fabricates
+  rather than errors). Losing it on a retrieving stage produces confident,
+  uncited output; gaining it on a stage that only reasons would bill for
+  retrieval that stage does not use and would make issue #90's "this run was
+  never grounded" reasoning wrong about it.
+
+  Since issue #65 that set is ``research`` **and** ``channel_plan``. Channel
+  planning asks "where does this audience convert", which research's evidence
+  — gathered to answer "who is this audience and what do competitors say" —
+  cannot answer; it now retrieves its own. See
+  ``tests/test_marketing_channel_plan_grounding.py`` for the guards that make
+  that retrieval mean something rather than merely happen.
 """
 
 from __future__ import annotations
@@ -41,11 +49,25 @@ _STAGE_MODELS = {
 }
 
 
-#: Research is deliberately NOT on Claude 5 — see issue #136 and
-#: `DEFAULT_RESEARCH_MODEL`'s docstring. Named here rather than special-cased
-#: inline so the exception is one reviewable fact, not a condition buried in an
-#: assertion.
-_GROUNDED_STAGE = "research"
+#: The stages that retrieve, and are therefore deliberately NOT on Claude 5 —
+#: see issue #136 and `DEFAULT_RESEARCH_MODEL`'s docstring. Named here rather
+#: than special-cased inline so the exception is one reviewable fact, not a
+#: condition buried in an assertion.
+#:
+#: `channel_plan` joined `research` in issue #65: it retrieves its own
+#: conversion evidence now, so it needs `:online`, and `:online` only
+#: demonstrably grounds on `sonnet-4` in this estate. That is a tier
+#: *downgrade* for an artefact-producing stage, taken deliberately — grounding
+#: that has been observed beats a tier whose grounding has been observed to be
+#: absent, and the fabrication risk the Opus tier was standing in for is now
+#: carried by mechanical guards (`UngroundedRecommendationError`, and
+#: provenance widened to the run's own `annotations`) rather than by trusting
+#: a better model.
+_GROUNDED_STAGES = frozenset({"research", "channel_plan"})
+
+#: The one route in this estate whose `:online` grounding has actually been
+#: watched to work. #136's table, in one constant.
+_OBSERVED_GROUNDED_ROUTE = "anthropic/claude-sonnet-4:online"
 
 
 @pytest.mark.parametrize(("stage", "model"), sorted(_STAGE_MODELS.items()))
@@ -65,14 +87,14 @@ def test_every_stage_runs_on_the_claude_5_family(stage: str, model: str) -> None
 
     assert base.startswith("anthropic/claude-"), f"{stage} is not on an Anthropic slug: {model!r}"
 
-    if stage == _GROUNDED_STAGE:
-        # Asserted positively rather than skipped: research must stay on a
-        # route whose grounding has actually been observed, so silently
+    if stage in _GROUNDED_STAGES:
+        # Asserted positively rather than skipped: a retrieving stage must stay
+        # on a route whose grounding has actually been observed, so silently
         # drifting it forward again fails here rather than in production.
-        assert model == "anthropic/claude-sonnet-4:online", (
-            "research must stay on a model whose `:online` grounding has been "
+        assert model == _OBSERVED_GROUNDED_ROUTE, (
+            f"{stage} must stay on a model whose `:online` grounding has been "
             f"verified live (#136); got {model!r}. If you are moving it, run "
-            "research against a fact that post-dates training and confirm "
+            "the stage against a fact that post-dates training and confirm "
             "`annotations` comes back non-empty first."
         )
         return
@@ -80,12 +102,13 @@ def test_every_stage_runs_on_the_claude_5_family(stage: str, model: str) -> None
     assert base.endswith("-5"), f"{stage} is not on the Claude 5 family: {model!r}"
 
 
-def test_only_research_carries_the_online_suffix() -> None:
-    """`:online` is grounded retrieval. Research needs it; nothing downstream
-    does, and issue #90's not-grounded reasoning depends on that staying true."""
+def test_exactly_the_retrieving_stages_carry_the_online_suffix() -> None:
+    """`:online` is grounded retrieval. Research and channel planning need it
+    (#65); nothing else does, and issue #90's not-grounded reasoning about the
+    synthesis run depends on that staying true."""
     online = {stage for stage, model in _STAGE_MODELS.items() if ":online" in model}
 
-    assert online == {"research"}
+    assert online == set(_GROUNDED_STAGES)
 
 
 def test_the_seeded_synthesis_model_is_the_constant() -> None:


### PR DESCRIPTION
Refs #65.

The channel-plan agent ran on a **non-searching** model, was told in as many words that it had no web access, and was required to copy its `Source` objects out of the approved positioning artefact. Every channel recommendation — the decision the whole campaign's budget and every downstream per-channel artefact follows — was therefore justified by evidence gathered to answer a *different* question. Research asks who this audience is and what competitors say to it; channel planning asks where that audience **converts**.

## The model route, and the evidence for it

`DEFAULT_CHANNEL_PLAN_MODEL` moves from `anthropic/claude-opus-5` to **`anthropic/claude-sonnet-4:online`**.

- `:online` is how grounded retrieval works here — Biffo's native `web_search` is silently never offered on dev (empty Brave key), so an agent that declares it fabricates rather than errors.
- The route is **not** chosen for recency. `sonnet-5:online` carries the suffix and returns **zero** grounding annotations (#136's table, reproduced in `DEFAULT_RESEARCH_MODEL`'s docstring); `sonnet-4:online` returned 5 on the same probe, and #141 moved research back to it. That observation is the entire evidence for this choice. Moving it later means running the cheap probe first — a fact that post-dates training, then read `annotations` — not noticing a newer model.
- **This is a deliberate tier downgrade for an artefact-producing stage, and the trade is stated in the code.** Opus was there because a confident-sounding fabrication is this stage's failure mode. It is given up because the question ("where does this audience convert") is not answerable from weights at all: a better model that cannot retrieve produces a more *persuasive* version of exactly the defect #65 reports. What replaces the tier is mechanical, below, not aspirational.

## Provenance for a stage that retrieves its own sources (#113/#22)

`channel_plan` is a guarded stage: every cited URL was checked against the approved parent's citation set. #65's whole point is citing evidence the parent does **not** contain, so this had to be answered explicitly rather than left to fall out.

**The rule is neither carried over nor dropped: the set stays closed and stops being the parent alone.**

A channel-plan run can legitimately have read exactly two things — the approved positioning it was handed, and whatever its own retrieval returned. The runtime records the second *independently of the model*, on `annotations` (#82). So the allowed set becomes **parent citations ∪ this run's `annotations` URLs**, and "a URL in neither was read by nothing" is the same sentence `UncitedSourceError` always meant. Nothing here trusts the model for any of it.

The tri-state is preserved, because collapsing it is how this breaks in either direction:

| `annotations` | meaning | allowed set |
|---|---|---|
| non-empty | retrieval returned these | parent ∪ retrieved |
| `[]` | retrieval genuinely returned nothing | parent alone — exactly as before #65 |
| `None` | **no record of what this run retrieved** | check skipped, and a warning logged |

`None` is skipped rather than enforced-parent-only because enforcing it would fail a genuinely grounded run whose annotations the runtime did not record — which is how a guard ends up switched off for real. That is the same treatment the module already gives an unknown `allowed_source_urls`, and it is why every pre-existing channel-plan test still passes untouched in meaning.

**Provenance alone is necessary and not sufficient**, which is the other half of the issue: carried-over positioning sources satisfy it *perfectly* while answering the wrong question. So a second, new guard — `UngroundedRecommendationError` — requires **every recommendation** to cite at least one URL this run retrieved. Per recommendation, not per plan: a plan-level check passes as soon as one channel is researched and the rest ride along on it. A zero-URL run (`annotations == []`) therefore fails, as #65 asks and as research already does.

#154/#67 is untouched: `allowed_motions` + the taxonomy snapshot narrowing is unchanged, and the new checks run before it in the same function without altering it.

## What else changed

- **The searched query leads the payload.** An `:online` run's provider searches *from the payload* before the model is invoked (#101 measured this: identical payloads → 4-of-5 identical pages), so `search_query` is now the first key, built from this campaign's audience segments, the channels actually on the table and its motion, closed with a conversion framing (`CHANNEL_PLAN_SEARCH_FRAMING`). Leading with `positioning` would have retrieved the positioning question a second time.
- **The prompt** no longer says "you do not have web access"; it asks for conversion evidence specifically (rates, CPA/lead cost, comparable-campaign results, channel economics), prefers the page carrying the number over a listicle, and states both source rules mechanically.
- **Retrieval-breadth instrument** (`pipeline.evidence_profile`, #101) now covers this stage: `channel plan retrieval breadth: …` with `channel_plan_*` structured keys, logged on every terminal path including the failed one. One implementation with a `stage` parameter, not a near-copy — research's message and keys are unchanged byte for byte. "Is this grounded?" is now a log query rather than a day of archaeology.

## Cost and latency — materially heavier, and there is no headroom

- `CHANNEL_PLAN_MAX_TURNS` 3 → `RESEARCH_MAX_TURNS` (8). At 3 the stage could search once and then had to answer.
- `:online` bills **per result**, and every turn can now carry a retrieval. This stage becomes roughly research-shaped in cost where it was previously a single reasoning call. #65 accepts this explicitly ("I don't mind making this an expensive/time consuming query. This is key to success").
- **It buys no extra wall clock.** `AGENT_TIMEOUT_SECONDS` is already 240s = `RUNTIME_TIMEOUT_CEILING_SECONDS`, and the runtime has warned about runs finishing close to it. These turns must fit in the same budget research's do. Raising it is an **instance** change (`run_timeout_seconds` in template-owned Terraform, plus the Lambda timeout), not a plugin one — flagging rather than attempting it.

## Fail-first evidence

New: `tests/test_marketing_channel_plan_grounding.py`. Against `origin/dev`'s source (`git stash push -- src/`):

```
19 failed, 7 passed in 0.25s
FAILED …::test_the_channel_plan_stage_runs_on_a_grounded_route
FAILED …::test_the_channel_plan_route_is_one_whose_grounding_has_been_observed_live
FAILED …::test_the_prompt_no_longer_tells_the_agent_it_has_no_web_access
FAILED …::test_the_prompt_asks_for_conversion_evidence_specifically
FAILED …::test_the_turn_budget_leaves_room_to_search_and_then_answer
FAILED …::test_the_run_leads_with_a_conversion_search_query
FAILED …::test_a_url_this_run_retrieved_is_not_treated_as_fabricated
FAILED …::test_a_url_in_neither_the_parent_nor_the_retrieval_is_still_refused
FAILED …::test_the_parents_own_sources_are_still_legitimate_alongside_retrieval
FAILED …::test_unknown_retrieval_cannot_adjudicate_provenance_either_way
FAILED …::test_a_plan_resting_entirely_on_positionings_sources_is_refused
FAILED …::test_every_recommendation_needs_its_own_retrieved_evidence
FAILED …::test_a_zero_url_channel_plan_run_fails
FAILED …::test_an_ungrounded_recommendation_is_a_pipeline_error
FAILED …::test_channel_plan_retrieval_breadth_is_measured_like_researchs
FAILED …::test_channel_plan_breadth_is_logged_when_the_run_failed
FAILED …::test_channel_plan_breadth_says_unmeasured_rather_than_a_false_zero
FAILED tests/test_marketing_stage_models.py::test_every_stage_runs_on_the_claude_5_family[channel_plan-anthropic/claude-opus-5]
FAILED tests/test_marketing_stage_models.py::test_exactly_the_retrieving_stages_carry_the_online_suffix
```

With the fix:

```
26 passed in 0.14s      # the same two files
663 passed in 6.12s     # whole suite
```

Plus two route-level tests: a plan grounded in its own retrieval is proposed with the retrieved URL in `citations`; a plan that only re-cites positioning is refused with a 502 and left `pending`.

Three existing tests changed meaning and were updated deliberately, not to go green: the two that assert a fabricated citation is refused now pass `annotations=[]`, because "a URL the positioning never contained" is only fabrication once retrieval is *known* not to have returned it; and the `start_channel_plan` payload test now expects the leading `search_query`.

## What this does NOT prove

Whether the plans are *actually* better grounded is only observable on a live run — reading the citations, not counting them. `Refs #65` rather than a closing keyword for that reason. The remaining "done when" boxes (a real dev run whose citations are about conversion; recorded cost and wall clock per run) need that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)