### PR TITLE
feat(marketing): let an operator record ad spend against a campaign

### DIFF
--- a/biffo.plugin.json
+++ b/biffo.plugin.json
@@ -413,6 +413,58 @@
           "required_role": ["admin"]
         }
       }
+    },
+    {
+      "name": "marketing_spend",
+      "description": "What an operator actually spent on a campaign, typed in by the person who spent it. This plugin calls no ad platform API (`paid_pack_routes.py`), so nothing can generate a row here — which is exactly why NO rows means \"unknown\", never \"zero\", while a row with `amount` 0 is a real, measured zero. The two must never be collapsed; DDL module 049 takes the same position for `tabsii.lead_source_costs`, and `src/marketing/spend_routes.py`'s module docstring says why the figure lives in this plugin's own table rather than that one.",
+      "columns": [
+        {
+          "name": "campaign_id",
+          "type": "String(36)",
+          "nullable": false,
+          "index": true
+        },
+        {
+          "name": "amount",
+          "type": "Float",
+          "nullable": false,
+          "description": "Non-negative; the route rejects a negative as a data-entry slip, the same position module 049 takes in SQL. NOT nullable, unlike module 049's `amount`: there, NULL means \"period acknowledged, invoice not in yet\", a state this plugin has no workflow for. Here the unknown state is simply the absence of a row."
+        },
+        {
+          "name": "currency",
+          "type": "String(3)",
+          "nullable": false,
+          "description": "ISO-4217-shaped, upper-cased at the route so `usd` and `USD` are one currency rather than two. Stored per row rather than per campaign so a total can REFUSE to sum mixed currencies instead of silently adding numbers that do not add."
+        },
+        {
+          "name": "notes",
+          "type": "Text",
+          "nullable": true,
+          "description": "Free text — \"week 1, Meta\". Shown to an operator, never parsed."
+        }
+      ],
+      "permissions": {
+        "list": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "read": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "create": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "update": {
+          "allowed": true,
+          "required_role": ["admin"]
+        },
+        "delete": {
+          "allowed": true,
+          "required_role": ["admin"]
+        }
+      }
     }
   ],
   "api_routes": [
@@ -576,6 +628,27 @@
       "table": "marketing_channel",
       "operation": "delete",
       "description": "Remove a channel (admin only). A future recommendation/copy/link row that already referenced this channel's key would be orphaned, same trade-off as idea-scout's business-model categories."
+    },
+    {
+      "method": "GET",
+      "path": "/spends",
+      "table": "marketing_spend",
+      "operation": "list",
+      "description": "List recorded spend for the caller's tenant. Filtered by `campaign_id` and paged in full by `spend_routes._all_spend_rows` — a total that stopped at page one would under-count money."
+    },
+    {
+      "method": "GET",
+      "path": "/spends/{id}",
+      "table": "marketing_spend",
+      "operation": "read",
+      "description": "Read one recorded spend entry."
+    },
+    {
+      "method": "POST",
+      "path": "/spends",
+      "table": "marketing_spend",
+      "operation": "create",
+      "description": "Record one spend entry against a campaign (admin only). Written by `spend_routes.record_spend_route`, which confirms the campaign exists first — a row naming no campaign is money recorded against nowhere, and no route here would ever surface it again."
     }
   ],
   "event_subscriptions": [

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -1037,6 +1037,16 @@ def build_app() -> FastAPI:
 
     app.include_router(paid_pack_router)
 
+    # Recording what a campaign actually cost (M9, issue #8) — the paid
+    # pack's own `spend` figure has to come from somewhere, and an operator
+    # typing it in is the only source this deployment can ever have (no ad
+    # platform API, by design). Its own module for the same reason every
+    # other route module above is, and see that file's docstring for why the
+    # row lives in this plugin's own table rather than tabsii's.
+    from .spend_routes import router as spend_router
+
+    app.include_router(spend_router)
+
     # LAST. See the module docstring: a StaticFiles mount at "/" swallows
     # everything registered after it, so anything below this line is unreachable.
     static = _static_dir()

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -31,14 +31,15 @@ this module adds is the part that is genuinely paid-only:
    no historical spend or performance data to optimise against, so this is a
    declared, fixed starting-point heuristic — not a bidding model — and says
    so in its own ``basis`` field.
-4. **Spend, reported as explicitly unmeasurable.** Issue #31 closed the gap
-   for ``results_routes.py``'s leads/conversions/cost — those now go through
-   the instance-configured leads source — but this route asks a different
-   question (spend for one campaign, inside a paid brief pack) that contract
-   was never wired to answer, and still isn't. This module does not invent a
-   call to a route that does not exist; it reuses
-   ``results_routes.UnmeasuredMetric`` verbatim so "no data" reads the same
-   way here as it does on the results dashboard, rather than a bespoke ``0``.
+4. **Spend, from what an operator recorded.** This was the last unmet
+   criterion of issue #8, and until ``spend_routes.py`` existed this field
+   was a hard-coded ``UnmeasuredMetric`` — there was genuinely no way for a
+   spend figure to exist, because nothing could write one. There is now:
+   ``POST /campaigns/{id}/spend`` writes a ``marketing_spend`` row, and this
+   pack totals them (``spend_routes.recorded_spend``). **A campaign with
+   nothing recorded is still unmeasurable, not a zero** — see that module's
+   docstring for the full reasoning and for why the row lives in this
+   plugin's own table rather than ``tabsii.lead_source_costs``.
 
 ## What this module deliberately does NOT do
 
@@ -59,8 +60,7 @@ from typing import Any
 from biffo_plugin_sdk import BiffoAPIClient, create_core_client
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from . import admin_app, config, pack_routes, pipeline, principal_client
-from .results_routes import UnmeasuredMetric
+from . import admin_app, config, pack_routes, pipeline, principal_client, spend_routes
 
 require_admin = admin_app.require_admin
 
@@ -413,5 +413,8 @@ async def get_paid_pack_route(
         "budget": _budget_recommendation(len(paid_channels)),
         "links": links,
         "guidance": campaign.get("guidance") or "",
-        "spend": UnmeasuredMetric(),
+        # Totalled from this plugin's own `marketing_spend` rows. Unmeasurable
+        # when nothing has been recorded — never a fabricated zero; see
+        # `spend_routes`'s module docstring.
+        "spend": await spend_routes.recorded_spend(campaign_id, campaign_client=campaign_client),
     }

--- a/src/marketing/results_routes.py
+++ b/src/marketing/results_routes.py
@@ -182,30 +182,17 @@ class ClickBreakdown(BaseModel):
     unknown_channel_type: int
 
 
-class UnmeasuredMetric(BaseModel):
-    """A metric this endpoint cannot compute at all today.
-
-    Deliberately not a bare `null` or a `0`: `measurable` is always `False`
-    on every instance this module constructs, and `reason` says why, so a
-    caller reading the JSON — not just this file's docstring — can tell "no
-    data" from "zero" without guessing. `denominator` is the population this
-    metric would be a share of once it becomes measurable (e.g. total clicks,
-    for a click-to-lead rate) when that population is itself known here;
-    `None` when it isn't (e.g. a conversion rate's denominator is a lead
-    count this plugin cannot see either).
-
-    Still used verbatim by `paid_pack_routes.py` for its own, still-genuinely
-    -unreachable `spend` field — unrelated to the leads/conversions/cost
-    metrics below, which now go through `Metric` instead.
-    """
-
-    measurable: bool = False
-    denominator: int | None = None
-    reason: str = (
-        "No route reachable from this plugin's internal Core transport exposes this yet "
-        "(tracked in issue #31) — 'unmeasurable' means the transport does not exist, "
-        "not that the count is zero."
-    )
+#: `UnmeasuredMetric` used to live here: a metric with `measurable` fixed at
+#: `False` and a default reason of "no route reachable from this plugin's
+#: internal Core transport exposes this yet (tracked in issue #31)". Issue
+#: #31 removed its last use on this dashboard (leads/conversions/cost went to
+#: `Metric` below), leaving `paid_pack_routes.py`'s `spend` as the only
+#: caller — and issue #8 removed that one too, by building the transport its
+#: reason said did not exist. A model whose only remaining content is a claim
+#: that is no longer true is worse than no model, so it is gone rather than
+#: left as a shape a future field might reach for: a metric that can only
+#: ever be unmeasurable cannot represent the measured case, which is exactly
+#: how #114 shipped.
 
 
 class Metric(BaseModel):
@@ -219,9 +206,13 @@ class Metric(BaseModel):
       unmeasurable metric by `measurable` alone, never by `value` being falsy).
     - `measurable=False`, `value=None`, `reason` set to why.
 
-    `denominator` carries the same meaning as `UnmeasuredMetric.denominator`
-    above (see that class) and is populated the same way regardless of
-    whether this instance ended up measurable or not.
+    `denominator` is the population this metric would be a share of (e.g.
+    total clicks, for a click-to-lead rate) when that population is known
+    here; `None` when it isn't (a conversion rate's denominator is a lead
+    count this plugin does not independently verify). It is populated the
+    same way regardless of whether this instance ended up measurable or not —
+    showing it only in the unmeasurable branch inverted the requirement, and
+    was #114.
     """
 
     value: float | int | None = None

--- a/src/marketing/spend_routes.py
+++ b/src/marketing/spend_routes.py
@@ -1,0 +1,289 @@
+"""Recording what a campaign actually cost (M9, issue #8) — the one criterion
+of the paid brief pack that was never built.
+
+An operator executes the paid pack by hand in Ads Manager or Google Ads (see
+``paid_pack_routes.py``: no platform API, no app registration, by design), so
+the money leaves the building somewhere this deployment cannot observe. The
+only way a spend figure can ever exist here is for the person who spent it to
+type it in. This module is that surface, and the total it reads back.
+
+## Why the spend row lives in this plugin's own table
+
+The obvious-looking alternative is to write ``tabsii.lead_source_costs``
+(DDL module 049) through Core's generic CRUD layer, so the figure lands in
+the same ledger the results dashboard's ``cost`` already reads. That does not
+work, for four independent reasons — any one of which is sufficient:
+
+1. **This plugin must not name a tabsii table.** ``results_routes.py``'s
+   module docstring settles that in as many words for the read side ("cost
+   (``tabsii.lead_source_costs``, DDL module 049) [is a] tabsii concept this
+   plugin must never import directly — a marketing plugin installed on
+   biffo-platform has no such table and never will"), which is why issue
+   #31's option B made the *reader* a configured endpoint rather than a
+   hard-coded table. A writer hard-coding the same table would undo that.
+2. **``brand_id`` is ``NOT NULL`` and this plugin has no brand.** The generic
+   CRUD create handler injects ``tenant_id`` only; ``brand_id`` is an
+   ordinary caller-supplied payload field, and there is no brand header and
+   no default brand anywhere in Core. The reading side does not answer this
+   question either — tabsii's ``campaign_results.py`` documents that it
+   deliberately **ignores** ``brand_id`` and sums across every brand, calling
+   the requirement "a genuine, structural mismatch this endpoint works
+   around, not past". There is no value to reuse, only an acknowledged gap.
+3. **The plugin's transport cannot reach that route.** Everything this
+   plugin sends to Core goes through ``principal_client`` — SigV4 plus the
+   admin's forwarded token — onto ``/api/v1/internal/plugins/marketing/*``.
+   ``POST /api/v1/data/lead_source_costs`` is guarded by
+   ``require_crud_permission`` -> ``require_auth``, which is Cognito-bearer
+   only.
+4. **No grant could fix (3).** ``fn_authorized`` resolves permissions only
+   through a *user's* role assignments; a ``system:`` service principal has
+   no user id and therefore no representable grant at all. It is not a
+   missing row somebody can add.
+
+So spend is a ``marketing_spend`` row: this plugin's own generated-CRUD
+table, reached by the transport it already has, working identically on every
+platform this plugin can be installed into. What that costs is stated in the
+issue rather than hidden here — the results dashboard's ``cost`` metric still
+comes from the instance-configured leads source and is a different number
+answering a different question (what the instance's lead sources cost),
+until an instance chooses to have its leads source read this table too.
+
+## No spend recorded is NOT a measured zero
+
+The single decision this module exists to get right. A campaign with no
+``marketing_spend`` row is **unmeasurable**, not zero:
+
+- Nothing in this deployment generates a spend row. Zero rows therefore
+  means "nobody has told us", never "no money was spent". Reporting ``0``
+  would assert "we looked, and nothing happened" — a claim this plugin
+  cannot make — and it would be wrong in a systematic direction, since every
+  cost-per-click or ROI computed from a fabricated zero reads better than
+  reality. That is precisely the failure ``results_routes.py``'s module
+  docstring opens with.
+- A row with ``amount = 0`` **is** a real measured zero, and renders as one.
+
+That split is not invented here. DDL module 049's own header requires it
+("no row at all -> unknown ... a row, amount 0 -> genuinely free ... the
+endpoints must return null for the first and 0 for the [second], and must
+never coerce one into the other"), and tabsii's ``campaign_results.
+_cost_metric`` already implements the reading half the same way.
+
+**It does not contradict issue #99**, which ruled the opposite way for
+*leads*: there, the configured source can see the entire lead population, so
+an absent campaign id really is a real zero, and the caller vouches the
+campaign exists. Spend has no such population — there is nothing to have
+looked at. #99's rule is "a zero you can verify is a zero"; this is the same
+rule, applied to a figure that cannot be verified.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+from . import admin_app, principal_client
+from .results_routes import Metric
+
+require_admin = admin_app.require_admin
+
+router = APIRouter(dependencies=[Depends(require_admin)])
+
+#: Duplicated local constant, not a cross-module reference — see
+#: `channel_plan_routes._INTERNAL_PREFIX` and `paid_pack_routes` for exactly
+#: why: `tests/test_marketing_core_paths_guard.py` resolves a module-level
+#: string constant only within the SAME file's own AST.
+_INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
+
+#: Core's generic list route caps a single page; spend is totalled across
+#: every page rather than the first (`_all_spend_rows`). Matches
+#: `results_routes._LIST_PAGE_SIZE` — under-counting money because a list
+#: stopped at page one is the same defect that module pages to avoid, with
+#: worse consequences.
+_LIST_PAGE_SIZE = 200
+
+#: The reason a campaign with no recorded spend carries. Deliberately
+#: **actionable**, and deliberately not the pre-#8 wording ("no route
+#: reachable from this plugin's internal Core transport exposes this yet
+#: (tracked in issue #31)") — that reason was true when there was no way to
+#: record spend at all, and repeating it now would tell an operator to wait
+#: for a transport that already exists.
+NO_SPEND_RECORDED_REASON = (
+    "No spend has been recorded against this campaign yet. This plugin calls no ad "
+    "platform API, so it can only report spend an operator enters here — no rows means "
+    "nobody has entered any, which is not the same as having spent nothing."
+)
+
+#: Rows exist but Core handed back an `amount` that is not a number. Kept
+#: distinct from `NO_SPEND_RECORDED_REASON` so an operator can tell "you have
+#: not told us" from "what you told us came back unusable" — the same
+#: distinction `results_routes` draws between its unreachable and malformed
+#: reasons.
+_UNUSABLE_ROW_REASON = (
+    "Spend has been recorded for this campaign, but at least one row came back with an "
+    "amount this plugin could not read, so the total would be wrong."
+)
+
+
+class SpendMetric(Metric):
+    """`results_routes.Metric`, plus the currency the value is denominated in.
+
+    A bare `240.5` is not a spend figure — 240.5 of what? — and this is the
+    one metric in the plugin that is an amount of money rather than a count.
+    `currency` is `None` exactly when `measurable` is `False`, for the same
+    reason `value` is: there is no figure to denominate.
+    """
+
+    currency: str | None = None
+
+
+class SpendEntry(BaseModel):
+    """One spend entry an operator is recording.
+
+    No date field. Core stamps `created_at` on every plugin table row, which
+    is when the operator recorded it — and this milestone has no reporting
+    that slices spend by period, so a second, hand-entered date would be a
+    field nothing reads and every operator has to fill in. A period-scoped
+    version of this belongs with whatever first needs to group by one.
+    """
+
+    #: `ge=0` rather than `gt=0`: a genuine zero is a recordable, meaningful
+    #: figure (see the module docstring), while a negative is a data-entry
+    #: slip — module 049 takes exactly this position in SQL
+    #: (`CHECK (amount IS NULL OR amount >= 0)`).
+    amount: float = Field(ge=0)
+    #: ISO-4217-shaped, defaulting to the currency `paid_pack_routes.
+    #: _budget_recommendation` states its budget in, so the recommendation
+    #: and the actual are denominated the same way unless an operator says
+    #: otherwise. Not validated against a currency list: this plugin holds no
+    #: such list and inventing a partial one would refuse real currencies.
+    currency: str = Field(default="USD", min_length=3, max_length=3, pattern=r"^[A-Za-z]{3}$")
+    notes: str | None = Field(default=None, max_length=500)
+
+    @field_validator("currency")
+    @classmethod
+    def _upper(cls, value: str) -> str:
+        """`usd` and `USD` are one currency, not two.
+
+        Left unnormalised they are two distinct strings, and `recorded_spend`
+        would refuse to total them as "more than one currency" — a
+        mixed-currency guard firing on a casing difference.
+        """
+        return value.upper()
+
+
+def get_campaign_client(
+    admin: Any = Depends(require_admin),
+) -> principal_client.PrincipalCoreClient:
+    """A dual-auth client for this plugin's own generated-CRUD tables,
+    matching `pack_routes.get_campaign_client` / `paid_pack_routes.
+    get_campaign_client` exactly."""
+    return principal_client.PrincipalCoreClient(admin.token)
+
+
+async def _all_spend_rows(
+    campaign_id: str, *, campaign_client: principal_client.PrincipalCoreClient
+) -> list[dict[str, Any]]:
+    """Every `marketing_spend` row for this campaign — not just page one.
+
+    Same explicit paging as `results_routes._list_all`, and for the same
+    reason: Core's generic list route caps a page, so a campaign with more
+    entries than one page would silently under-total.
+    """
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        batch = await campaign_client.get(
+            f"{_INTERNAL_PREFIX}/spends",
+            params={"campaign_id": campaign_id, "limit": _LIST_PAGE_SIZE, "offset": offset},
+        )
+        batch = batch or []
+        rows.extend(batch)
+        if len(batch) < _LIST_PAGE_SIZE:
+            return rows
+        offset += _LIST_PAGE_SIZE
+
+
+async def recorded_spend(
+    campaign_id: str, *, campaign_client: principal_client.PrincipalCoreClient
+) -> SpendMetric:
+    """Total recorded spend for one campaign, or the reason there isn't one.
+
+    Four outcomes, all of them honest about which they are:
+
+    - **No rows** -> unmeasurable, `NO_SPEND_RECORDED_REASON`. See the module
+      docstring: this is the decision this file exists to make, and it is
+      never a zero.
+    - **Rows in one currency** -> `measurable=True`, the sum, and that
+      currency. A single recorded `0.00` lands here, as a real measured zero.
+    - **Rows in more than one currency** -> unmeasurable, naming them.
+      `120 USD + 80 GBP` is not `200` of anything; this plugin holds no FX
+      rate and must not invent one.
+    - **A row with an unreadable `amount`** -> unmeasurable, rather than a
+      total silently missing that row, and never a 500 on the whole pack.
+    """
+    rows = await _all_spend_rows(campaign_id, campaign_client=campaign_client)
+    if not rows:
+        return SpendMetric(measurable=False, reason=NO_SPEND_RECORDED_REASON)
+
+    currencies = sorted({str(row.get("currency") or "").upper() or "?" for row in rows})
+    if len(currencies) > 1:
+        return SpendMetric(
+            measurable=False,
+            reason=(
+                "Spend has been recorded for this campaign in more than one currency "
+                f"({', '.join(currencies)}). This plugin holds no exchange rate, so it "
+                "will not add them together."
+            ),
+        )
+
+    total = 0.0
+    for row in rows:
+        amount = row.get("amount")
+        # `bool` is an `int` in Python; a `True` here is a broken row, not 1.
+        if isinstance(amount, bool) or not isinstance(amount, (int, float)):
+            return SpendMetric(measurable=False, reason=_UNUSABLE_ROW_REASON)
+        total += float(amount)
+
+    return SpendMetric(value=total, measurable=True, currency=currencies[0])
+
+
+@router.post("/campaigns/{campaign_id}/spend", status_code=status.HTTP_201_CREATED)
+async def record_spend_route(
+    campaign_id: str,
+    body: SpendEntry,
+    campaign_client: principal_client.PrincipalCoreClient = Depends(get_campaign_client),
+    admin: Any = Depends(require_admin),
+) -> dict[str, Any]:
+    """Record one spend entry against this campaign.
+
+    Additive rather than replacing: an operator records what they spent this
+    week, and the paid pack totals every entry. Correcting a mistake is not
+    yet possible from this surface — `marketing_spend` declares no update or
+    delete route (issue #8 scoped this to recording), which is stated here
+    rather than left to be discovered.
+
+    The campaign is confirmed to exist **before** anything is written. A
+    spend row whose `campaign_id` names no campaign is money recorded against
+    nowhere, and no route in this plugin would ever surface it again — it
+    would simply be invisible, which is worse than a 404.
+    """
+    campaign_id = admin_app._validated_campaign_id(campaign_id)
+
+    campaign = await admin_app._core(
+        "GET", f"{_INTERNAL_PREFIX}/campaigns/{campaign_id}", admin.token
+    )
+    if campaign.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Campaign not found.")
+    campaign.raise_for_status()
+
+    return await campaign_client.post(
+        f"{_INTERNAL_PREFIX}/spends",
+        json={
+            "campaign_id": campaign_id,
+            "amount": body.amount,
+            "currency": body.currency,
+            "notes": body.notes,
+        },
+    )

--- a/tests/test_marketing_paid_pack_routes.py
+++ b/tests/test_marketing_paid_pack_routes.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from marketing import admin_app, pack_routes, paid_pack_routes
+from marketing import admin_app, pack_routes, paid_pack_routes, spend_routes
 from marketing.definitions import PLACEMENTS
 
 _CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ab"
@@ -185,13 +185,29 @@ class _FakeCore:
 
 
 class _FakeCampaignClient:
-    def __init__(self, *, assets: list[dict[str, Any]] | None = None) -> None:
+    """The dual-auth generated-CRUD client. Serves `marketing_asset` rows and
+    — since #8's spend recording landed — `marketing_spend` rows, which the
+    pack totals into its `spend` metric (`spend_routes.recorded_spend`)."""
+
+    def __init__(
+        self,
+        *,
+        assets: list[dict[str, Any]] | None = None,
+        spends: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.assets: list[dict[str, Any]] = list(assets or [])
+        self.spends: list[dict[str, Any]] = list(spends or [])
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         if path == f"{paid_pack_routes._INTERNAL_PREFIX}/assets":
             campaign_id = (params or {}).get("campaign_id")
             return [a for a in self.assets if a.get("campaign_id") == campaign_id]
+        if path == f"{paid_pack_routes._INTERNAL_PREFIX}/spends":
+            campaign_id = (params or {}).get("campaign_id")
+            matching = [s for s in self.spends if s.get("campaign_id") == campaign_id]
+            offset = int((params or {}).get("offset") or 0)
+            limit = int((params or {}).get("limit") or len(matching))
+            return matching[offset : offset + limit]
         raise AssertionError(f"unexpected GET {path}")
 
 
@@ -467,12 +483,69 @@ def test_assembles_the_paid_pack(monkeypatch: pytest.MonkeyPatch) -> None:
     assert all(link["is_paid"] for link in body["links"])
     assert all("utm_medium=paid" in core.links[i]["destination_url"] for i in range(2))
 
-    # 6. Spend: explicitly unmeasurable, never a fabricated zero.
+    # 6. Spend: nothing recorded for this campaign, so unmeasurable — never a
+    # fabricated zero. Since #8 the reason is actionable ("record it") rather
+    # than "no transport exists (issue #31)", because a transport now does.
     assert body["spend"]["measurable"] is False
-    assert "issue #31" in body["spend"]["reason"] or "31" in body["spend"]["reason"]
+    assert body["spend"]["value"] is None
+    assert body["spend"]["reason"] == spend_routes.NO_SPEND_RECORDED_REASON
 
     # 7. Guidance carried through unchanged, same as the organic pack.
     assert body["guidance"] == "Disclose #ad. Licensed music only."
+
+
+def test_recorded_spend_renders_as_a_measured_figure_not_not_measurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The last unmet criterion of issue #8: once an operator records what
+    they spent, the pack reports it as a real number.
+
+    This is also #114's class, one surface along: the pack's `spend` was
+    typed and rendered as unmeasurable-only, so a measured figure was
+    literally unrepresentable. A measured value has to survive the whole
+    round trip — `measurable: true`, a real `value`, `reason: null`.
+    """
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(
+        spends=[
+            {"id": "s1", "campaign_id": _CAMPAIGN, "amount": 240.5, "currency": "USD"},
+            {"id": "s2", "campaign_id": _CAMPAIGN, "amount": 59.5, "currency": "USD"},
+        ]
+    )
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    body = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack").json()
+
+    assert body["spend"]["measurable"] is True
+    assert body["spend"]["value"] == pytest.approx(300.0)
+    assert body["spend"]["currency"] == "USD"
+    assert body["spend"]["reason"] is None
+
+
+def test_a_recorded_zero_spend_is_measured_not_unmeasurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The distinction #99 and DDL module 049 both insist on, in the one
+    place it is easiest to lose: an operator who really spent nothing gets a
+    measured `0`, which is NOT what an unrecorded campaign gets."""
+    core = _FakeCore(
+        copy_artefact=_copy_artefact([_PAID_CHANNEL_META]),
+        positioning_artefact=_positioning_artefact(_SEGMENTS),
+    )
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(
+        spends=[{"id": "s1", "campaign_id": _CAMPAIGN, "amount": 0.0, "currency": "USD"}]
+    )
+    client = TestClient(_app(core_client=_FakeStorageClient(), campaign_client=campaign_client))
+
+    body = client.get(f"/campaigns/{_CAMPAIGN}/paid-pack").json()
+
+    assert body["spend"]["measurable"] is True
+    assert body["spend"]["value"] == 0
 
 
 def test_does_not_leak_an_existing_organic_link_into_the_paid_pack(

--- a/tests/test_marketing_spend_routes.py
+++ b/tests/test_marketing_spend_routes.py
@@ -1,0 +1,295 @@
+"""Recording ad spend against a campaign (M9, issue #8) and reading it back
+as an honest metric.
+
+The two properties this file exists to pin, both of them the
+"no data is not zero" discipline `results_routes.py` is built around:
+
+1. **No spend recorded is NOT a measured zero.** This plugin cannot observe
+   ad spend — nothing generates a `marketing_spend` row except a person
+   typing one in — so "no rows" means "nobody has told us", which is
+   unknown. Reporting `0` there would assert "we looked, and nothing was
+   spent", a claim this plugin cannot make, and it would understate spend in
+   a systematic direction (every ROI computed from it reads better than
+   reality). See `test_no_recorded_spend_is_unmeasurable_not_a_zero`.
+2. **A recorded `0.00` IS a measured zero**, distinguishable from (1) by
+   `measurable` alone and never by `value` being falsy — the exact property
+   issues #99 and #114 exist to protect. See
+   `test_a_recorded_zero_is_a_real_measured_zero`.
+
+That split is not this file's invention: DDL module 049's own header states
+it as a requirement ("no row at all -> unknown; a row, amount 0 -> genuinely
+free... the endpoints must never coerce one into the other"), and tabsii's
+`campaign_results._cost_metric` already implements the reading half the same
+way.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from marketing import admin_app, principal_client, spend_routes
+
+_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000ab"
+_OTHER_CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000cd"
+
+
+#: `campaign=None` has to mean "Core 404s this campaign", so the "use the
+#: default" case needs a sentinel of its own — matching
+#: `test_marketing_paid_pack_routes._DEFAULT_CAMPAIGN` exactly.
+_DEFAULT_CAMPAIGN = object()
+
+
+class _FakeCore:
+    """Stands in for `admin_app._core` — only the campaign lookup the record
+    route makes before it writes anything."""
+
+    def __init__(self, *, campaign: dict[str, Any] | None | object = _DEFAULT_CAMPAIGN) -> None:
+        self.campaign = (
+            {"id": _CAMPAIGN, "name": "C"} if campaign is _DEFAULT_CAMPAIGN else campaign
+        )
+
+    async def __call__(self, method: str, path: str, token: str, **kw: Any) -> httpx.Response:
+        request = httpx.Request(method, f"https://core.invalid{path}")
+        prefix = admin_app._INTERNAL_PREFIX
+        if method == "GET" and path.startswith(f"{prefix}/campaigns/"):
+            if self.campaign is None:
+                return httpx.Response(404, json={"detail": "not found"}, request=request)
+            return httpx.Response(200, json=self.campaign, request=request)
+        raise AssertionError(f"unexpected call {method} {path}")
+
+
+class _FakeSpendClient:
+    """The dual-auth generated-CRUD client, over `marketing_spend` rows.
+
+    Pages the way Core's generic list route really does (`limit`/`offset`),
+    so `test_totals_every_page_of_recorded_spend` exercises the paging rather
+    than a fake that always returns everything.
+    """
+
+    def __init__(self, *, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows: list[dict[str, Any]] = list(rows or [])
+        self.posted: list[dict[str, Any]] = []
+        self._next_id = 0
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        assert path == f"{spend_routes._INTERNAL_PREFIX}/spends", path
+        params = params or {}
+        matching = [r for r in self.rows if r.get("campaign_id") == params.get("campaign_id")]
+        offset = int(params.get("offset") or 0)
+        limit = int(params.get("limit") or len(matching))
+        return matching[offset : offset + limit]
+
+    async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
+        assert path == f"{spend_routes._INTERNAL_PREFIX}/spends", path
+        self._next_id += 1
+        row = {"id": f"spend-{self._next_id}", **(json or {})}
+        self.posted.append(row)
+        self.rows.append(row)
+        return row
+
+
+def _as_client(fake: _FakeSpendClient) -> principal_client.PrincipalCoreClient:
+    """`recorded_spend` is typed against the real dual-auth client, and these
+    tests call it directly rather than through `dependency_overrides` — so the
+    structural stand-in needs one explicit cast rather than a loosened
+    signature on production code."""
+    return cast(principal_client.PrincipalCoreClient, fake)
+
+
+def _row(amount: float | None, *, currency: str = "USD", campaign_id: str = _CAMPAIGN) -> dict:
+    return {
+        "id": f"row-{amount}-{currency}",
+        "campaign_id": campaign_id,
+        "amount": amount,
+        "currency": currency,
+        "notes": None,
+    }
+
+
+def _admin_user() -> Any:
+    return type("U", (), {"sub": "admin", "groups": ["admin"], "token": "admin-jwt"})()
+
+
+def _app(*, spend_client: _FakeSpendClient) -> FastAPI:
+    app = FastAPI()
+    app.include_router(spend_routes.router)
+    app.dependency_overrides[spend_routes.require_admin] = _admin_user
+    app.dependency_overrides[spend_routes.get_campaign_client] = lambda: spend_client
+    return app
+
+
+# ── recording ───────────────────────────────────────────────────────────────
+
+
+def test_records_spend_against_the_campaign(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin_app, "_core", _FakeCore())
+    client_rows = _FakeSpendClient()
+    client = TestClient(_app(spend_client=client_rows))
+
+    resp = client.post(
+        f"/campaigns/{_CAMPAIGN}/spend",
+        json={"amount": 240.5, "currency": "USD", "notes": "Week 1, Meta"},
+    )
+
+    assert resp.status_code == 201
+    assert client_rows.posted == [
+        {
+            "id": "spend-1",
+            "campaign_id": _CAMPAIGN,
+            "amount": 240.5,
+            "currency": "USD",
+            "notes": "Week 1, Meta",
+        }
+    ]
+
+
+def test_404s_an_unknown_campaign_rather_than_writing_an_orphan_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spend row whose `campaign_id` names nothing is money recorded
+    against nowhere — and this plugin has no route that would ever surface
+    it again. Refused before the write, not after."""
+    monkeypatch.setattr(admin_app, "_core", _FakeCore(campaign=None))
+    client_rows = _FakeSpendClient()
+    client = TestClient(_app(spend_client=client_rows))
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/spend", json={"amount": 10.0})
+
+    assert resp.status_code == 404
+    assert client_rows.posted == []
+
+
+def test_404s_a_campaign_id_that_is_not_a_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`admin_app._validated_campaign_id`'s SSRF guard, on this route too —
+    the path segment is interpolated into a credentialed Core URL."""
+    monkeypatch.setattr(admin_app, "_core", _FakeCore())
+    client_rows = _FakeSpendClient()
+    client = TestClient(_app(spend_client=client_rows))
+
+    resp = client.post("/campaigns/..%2Fadmin/spend", json={"amount": 10.0})
+
+    assert resp.status_code == 404
+    assert client_rows.posted == []
+
+
+def test_rejects_negative_spend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative spend is a data-entry slip, not a refund model — module 049's
+    own `CHECK (amount IS NULL OR amount >= 0)` takes the same position."""
+    monkeypatch.setattr(admin_app, "_core", _FakeCore())
+    client_rows = _FakeSpendClient()
+    client = TestClient(_app(spend_client=client_rows))
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/spend", json={"amount": -1.0})
+
+    assert resp.status_code == 422
+    assert client_rows.posted == []
+
+
+def test_normalises_the_currency_code_to_upper_case(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`usd` and `USD` are the same currency. Left unnormalised they are two,
+    and `recorded_spend` would refuse to sum them as "more than one
+    currency" — a mixed-currency guard firing on a casing difference."""
+    monkeypatch.setattr(admin_app, "_core", _FakeCore())
+    client_rows = _FakeSpendClient()
+    client = TestClient(_app(spend_client=client_rows))
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/spend", json={"amount": 5.0, "currency": "usd"})
+
+    assert resp.status_code == 201
+    assert client_rows.posted[0]["currency"] == "USD"
+
+
+# ── reading it back ─────────────────────────────────────────────────────────
+
+
+async def test_no_recorded_spend_is_unmeasurable_not_a_zero() -> None:
+    """The whole point of this milestone's spend field.
+
+    Zero rows means nobody has recorded anything, which is unknown — not
+    "£0 was spent". Reporting a measured zero here would be the systematic
+    understatement `results_routes.py`'s module docstring exists to prevent.
+    """
+    metric = await spend_routes.recorded_spend(
+        _CAMPAIGN, campaign_client=_as_client(_FakeSpendClient())
+    )
+
+    assert metric.measurable is False
+    assert metric.value is None
+    assert metric.reason == spend_routes.NO_SPEND_RECORDED_REASON
+    # The reason must be actionable now that a transport exists — it is no
+    # longer "issue #31, there is no route".
+    assert "31" not in metric.reason
+
+
+async def test_a_recorded_zero_is_a_real_measured_zero() -> None:
+    """The other half of the same distinction: an operator who really did
+    spend nothing can say so, and it renders as a measured `0`."""
+    client = _FakeSpendClient(rows=[_row(0.0)])
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.measurable is True
+    assert metric.value == 0
+    assert metric.reason is None
+
+
+async def test_totals_every_page_of_recorded_spend() -> None:
+    """Under-counting money because a list stopped at page one is the same
+    defect `results_routes._list_all` exists to prevent, and worse here."""
+    rows = [_row(1.0) for _ in range(spend_routes._LIST_PAGE_SIZE + 3)]
+    client = _FakeSpendClient(rows=rows)
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.measurable is True
+    assert metric.value == pytest.approx(float(spend_routes._LIST_PAGE_SIZE + 3))
+
+
+async def test_only_totals_this_campaigns_rows() -> None:
+    client = _FakeSpendClient(rows=[_row(10.0), _row(99.0, campaign_id=_OTHER_CAMPAIGN)])
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.value == pytest.approx(10.0)
+
+
+async def test_mixed_currencies_are_unmeasurable_rather_than_a_wrong_sum() -> None:
+    """`120 USD + 80 GBP` is not `200` of anything. This plugin holds no FX
+    rate and must not invent one, so it says so instead of adding the
+    numbers — the same "a confident number that is wrong in a systematic
+    direction is worse than a missing one" rule as everywhere else here."""
+    client = _FakeSpendClient(rows=[_row(120.0, currency="USD"), _row(80.0, currency="GBP")])
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.measurable is False
+    assert metric.value is None
+    assert metric.reason is not None
+    assert "GBP" in metric.reason and "USD" in metric.reason
+
+
+async def test_the_measured_metric_carries_the_currency_it_is_denominated_in() -> None:
+    """A bare number is not a spend figure — `240.5` of what?"""
+    client = _FakeSpendClient(rows=[_row(240.5, currency="GBP")])
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.measurable is True
+    assert metric.currency == "GBP"
+
+
+async def test_a_row_with_an_unusable_amount_degrades_rather_than_raising() -> None:
+    """A row Core hands back with a non-numeric `amount` must not 500 the
+    whole paid pack — same defensive posture as `_metric_from_raw`."""
+    client = _FakeSpendClient(rows=[_row("not a number")])  # type: ignore[arg-type]
+
+    metric = await spend_routes.recorded_spend(_CAMPAIGN, campaign_client=_as_client(client))
+
+    assert metric.measurable is False
+    assert metric.value is None
+    assert metric.reason

--- a/web-admin/src/components/PaidPack.test.tsx
+++ b/web-admin/src/components/PaidPack.test.tsx
@@ -261,4 +261,157 @@ describe('PaidPack', () => {
     )
     expect(link).toHaveAttribute('download', 'spring-launch-story-9x16.png')
   })
+  // ── Spend recording (M9, issue #8) ────────────────────────────────────────
+
+  /** A minimal pack body, so the spend tests below assert one thing each
+   * rather than re-stating the whole pack. */
+  function packWith(spend: unknown) {
+    return {
+      campaign_id: CAMPAIGN,
+      ad_copy: [],
+      assets: [],
+      missing_placements: [],
+      targeting: [],
+      budget: {
+        currency: 'USD',
+        channel_count: 1,
+        per_channel_daily: 20,
+        total_daily: 20,
+        test_window_days: 7,
+        total_test_budget: 140,
+        basis: 'A fixed starting-point heuristic.',
+      },
+      links: [],
+      guidance: '',
+      spend,
+    }
+  }
+
+  it('renders a recorded spend as a measured figure, not "not measurable"', async () => {
+    // This is issue #114's class, one surface along: `PaidPack.spend` was
+    // typed as unmeasurable-only, so a measured figure could not be
+    // represented — let alone rendered.
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => packWith({
+          value: 300,
+          measurable: true,
+          denominator: null,
+          reason: null,
+          currency: 'USD',
+        }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/USD 300/)).toBeInTheDocument()
+    expect(screen.queryByText(/not measurable/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a recorded zero as a measured 0, never as "not measurable"', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => packWith({
+          value: 0,
+          measurable: true,
+          denominator: null,
+          reason: null,
+          currency: 'GBP',
+        }),
+      }),
+    )
+
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/GBP 0/)).toBeInTheDocument()
+    expect(screen.queryByText(/not measurable/i)).not.toBeInTheDocument()
+  })
+
+  it('lets an operator record spend, then reloads the pack with the new figure', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    const fetchMock = vi
+      .fn()
+      // 1. initial pack load — nothing recorded yet
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => packWith({
+          value: null,
+          measurable: false,
+          denominator: null,
+          reason: 'No spend has been recorded against this campaign yet.',
+        }),
+      })
+      // 2. the POST that records it
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: 's1' }) })
+      // 3. the reload, now measured
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => packWith({
+          value: 240.5,
+          measurable: true,
+          denominator: null,
+          reason: null,
+          currency: 'USD',
+        }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+
+    expect(await screen.findByText(/not measurable — no spend has been recorded/i)).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText(/amount spent/i), '240.50')
+    await user.click(screen.getByRole('button', { name: /record spend/i }))
+
+    expect(await screen.findByText(/USD 240.5/)).toBeInTheDocument()
+
+    const [url, init] = fetchMock.mock.calls[1]
+    expect(String(url)).toContain(`/campaigns/${CAMPAIGN}/spend`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ amount: 240.5, currency: 'USD', notes: null })
+  })
+
+  it('surfaces a failed spend recording rather than silently doing nothing', async () => {
+    stubSession()
+    const user = userEvent.setup()
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => packWith({
+          value: null,
+          measurable: false,
+          denominator: null,
+          reason: 'No spend has been recorded against this campaign yet.',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: 'Campaign not found.' }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<PaidPack campaignId={CAMPAIGN} campaignName="Spring Launch" channelLookup={makeLookup([])} />)
+    await user.click(screen.getByRole('button', { name: /load paid pack/i }))
+    await screen.findByText(/not measurable/i)
+
+    await user.type(screen.getByLabelText(/amount spent/i), '10')
+    await user.click(screen.getByRole('button', { name: /record spend/i }))
+
+    expect(await screen.findByText(/campaign not found/i)).toBeInTheDocument()
+  })
 })

--- a/web-admin/src/components/PaidPack.tsx
+++ b/web-admin/src/components/PaidPack.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { getPaidPack, type PaidPack as PaidPackData } from '../lib/api'
+import { getPaidPack, recordSpend, type PaidPack as PaidPackData, type SpendMetric } from '../lib/api'
 import { composeChannelCopy } from '../lib/packCopy'
 import { useClipboard } from '../lib/useClipboard'
 import type { ChannelLookup } from '../lib/useChannelTaxonomy'
@@ -8,12 +8,110 @@ import { CopyButton } from './CopyButton'
 import { MissingPlacementsWarning, PackAssets, PackGuidance, PackLinks } from './PackParts'
 import { PublishLink } from './PublishLink'
 
+/** One recorded-spend figure, or the reason there isn't one.
+ *
+ * Deliberately the same two-branch shape as `Results.tsx`'s `MetricCell`, and
+ * for the same reason: "no data" is a structurally distinct thing from
+ * "zero", so a measured `0` renders as `0` rather than borrowing the
+ * unmeasurable wording. Getting this wrong in the other direction is issue
+ * #114 — a real figure rendered as "not measurable — undefined" because only
+ * the unmeasurable branch was representable.
+ *
+ * Not shared with `MetricCell` itself: this one is money, so it prints the
+ * currency the value is denominated in, and it carries no denominator (a
+ * spend is an amount, not a share of anything). */
+function SpendFigure({ spend }: { spend: SpendMetric }) {
+  if (spend.measurable) {
+    return (
+      <p className="measured">
+        {spend.currency} {spend.value}
+      </p>
+    )
+  }
+  return <p className="unmeasurable">Not measurable — {spend.reason}</p>
+}
+
+/** The form an operator records spend with (issue #8).
+ *
+ * Deliberately minimal — an amount, a currency and an optional note. This
+ * plugin calls no ad platform API, so the only way a spend figure can ever
+ * exist is for the person who spent it to type it in; anything more elaborate
+ * than that is a reporting feature nothing yet reads.
+ *
+ * Entries are additive (`spend_routes.record_spend_route`): the pack totals
+ * every one. There is no edit or delete here, because the server declares no
+ * route for either yet. */
+function RecordSpend({ campaignId, onRecorded }: { campaignId: string; onRecorded: () => Promise<void> }) {
+  const [amount, setAmount] = useState('')
+  const [currency, setCurrency] = useState('USD')
+  const [notes, setNotes] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    const parsed = Number(amount)
+    if (amount.trim() === '' || Number.isNaN(parsed) || parsed < 0) {
+      // Caught here rather than sent, so the operator gets the reason back
+      // immediately instead of a 422 that says the same thing more slowly.
+      setError('Enter the amount spent as a number of 0 or more.')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await recordSpend(campaignId, { amount: parsed, currency, notes: notes.trim() || null })
+      setAmount('')
+      setNotes('')
+      // Reload rather than patching the figure locally: the total is the
+      // server's to compute (it may refuse to sum mixed currencies), and a
+      // number this component worked out itself could disagree with it.
+      await onRecorded()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form className="record-spend" onSubmit={submit}>
+      <label htmlFor="spend-amount">Amount spent</label>
+      <input
+        id="spend-amount"
+        type="number"
+        min="0"
+        step="0.01"
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+      />
+      <label htmlFor="spend-currency">Currency</label>
+      <input
+        id="spend-currency"
+        type="text"
+        maxLength={3}
+        value={currency}
+        onChange={(e) => setCurrency(e.target.value)}
+      />
+      <label htmlFor="spend-notes">Note (optional)</label>
+      <input id="spend-notes" type="text" value={notes} onChange={(e) => setNotes(e.target.value)} />
+      <button type="submit" disabled={saving}>
+        {saving ? 'Recording…' : 'Record spend'}
+      </button>
+      {error !== null && <p className="error">{error}</p>}
+    </form>
+  )
+}
+
 /** The paid brief pack (M9): ad copy at real platform character limits,
  * creative, targeting drawn from the approved positioning, a declared budget
- * heuristic, tracked links, and spend — reported as explicitly unmeasurable
- * (issue #31), reusing the exact same `UnmeasuredMetric` shape the results
- * dashboard uses, so "no data" reads the same way in both places rather than
- * a bespoke zero here.
+ * heuristic, tracked links, and spend — which since issue #8 is a real figure
+ * an operator recorded, not a permanently unmeasurable field.
+ *
+ * A campaign with nothing recorded is still explicitly unmeasurable rather
+ * than a zero, using the same wording discipline the results dashboard uses,
+ * so "no data" reads the same way in both places. See `spend_routes.py`'s
+ * module docstring for why "nobody has told us" is not "nothing was spent".
  *
  * Assets, tracked links, the missing-placements warning and guidance are the
  * same pieces `DistributionPack` renders — shared via `PackParts.tsx` rather
@@ -171,7 +269,8 @@ export function PaidPack({
           <p className="hint">{pack.budget.basis}</p>
 
           <h4>Spend</h4>
-          <p className="unmeasurable">Not measurable — {pack.spend.reason}</p>
+          <SpendFigure spend={pack.spend} />
+          <RecordSpend campaignId={campaignId} onRecorded={load} />
 
           <PackAssets assets={pack.assets} campaignName={campaignName} />
 

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -987,6 +987,44 @@ details.mint-toggle[open] > .mint {
   color: var(--text);
 }
 
+/* Recording spend (issue #8). A row of small fields rather than a full form
+ * block: this sits inside the paid pack under the figure it changes, so it
+ * has to read as an affordance on that figure, not as a second section. */
+.record-spend {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  border: 0;
+  padding: 0;
+  margin: 0 0 1rem;
+  background: transparent;
+}
+
+.record-spend label {
+  font-size: 0.75rem;
+  margin: 0 0 0.15rem;
+  align-self: flex-end;
+}
+
+.record-spend input {
+  width: auto;
+  min-width: 5rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.record-spend button {
+  font-size: 0.8rem;
+  padding: 0.4rem 0.8rem;
+}
+
+/* The failure message belongs under the whole row, not beside one field. */
+.record-spend .error {
+  flex-basis: 100%;
+  margin: 0.2rem 0 0;
+}
+
 /* The standing excluded-clicks denominator. Always rendered, including at
  * zero: "nothing was excluded" is a claim worth making explicitly. */
 .excluded {

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -723,13 +723,56 @@ export interface PaidPack {
   budget: BudgetRecommendation
   links: PackLink[]
   guidance: string
-  /** This plugin has no reachable transport to spend data (issue #31) — see
-   * {@link UnmeasuredMetric}. */
-  spend: UnmeasuredMetric
+  /** What an operator has recorded spending on this campaign (issue #8), or
+   * the reason there is no figure. See {@link SpendMetric}.
+   *
+   * **Deliberately not an unmeasurable-only type.** It used to be one, back
+   * when spend genuinely could not exist — and once `recordSpend` made it
+   * possible, that type would have left a measured figure literally
+   * unrepresentable, which is issue #114 exactly: the results dashboard
+   * rendered a real leads figure as "not measurable — undefined" for that
+   * same reason. */
+  spend: SpendMetric
 }
+
+/** The paid pack's `spend`: `results_routes.Metric`'s two shapes, plus the
+ * currency a measured value is denominated in (`spend_routes.SpendMetric`).
+ * `240.5` alone is not a spend figure — 240.5 of what? — and `currency` is
+ * `null` exactly when `measurable` is `false`, for the same reason `value`
+ * is: there is no figure to denominate.
+ *
+ * A campaign with nothing recorded is `measurable: false`, NOT a zero: this
+ * plugin calls no ad platform API, so no rows means nobody has entered any,
+ * which is not the same as having spent nothing. A recorded `0` is
+ * `measurable: true, value: 0` — a real, measured zero. Render the two
+ * differently. */
+export type SpendMetric =
+  | (MeasuredMetric & { currency: string })
+  | (UnmeasurableMetric & { currency: null })
 
 export async function getPaidPack(campaignId: string): Promise<PaidPack> {
   return request<PaidPack>('GET', `/campaigns/${campaignId}/paid-pack`, undefined, ADMIN_BASE, 'load the paid pack')
+}
+
+/** Record one spend entry against a campaign (`spend_routes.record_spend_route`).
+ *
+ * Additive: each call records what was spent, and the paid pack totals every
+ * entry. `currency` defaults to the currency the pack states its budget
+ * recommendation in, so the plan and the actual are comparable unless an
+ * operator says otherwise; the server upper-cases it, so `usd` and `USD` do
+ * not become two currencies that the total then refuses to add.
+ */
+export async function recordSpend(
+  campaignId: string,
+  entry: { amount: number; currency?: string; notes?: string | null },
+): Promise<void> {
+  await request<unknown>(
+    'POST',
+    `/campaigns/${campaignId}/spend`,
+    { amount: entry.amount, currency: entry.currency ?? 'USD', notes: entry.notes ?? null },
+    ADMIN_BASE,
+    'record spend',
+  )
 }
 
 // ── Results (M8) ──────────────────────────────────────────────────────────────
@@ -741,23 +784,13 @@ export interface ClickBreakdown {
   unknown_channel_type: number
 }
 
-/** A metric this endpoint cannot compute at all today — never a bare `null`
- * or a `0`. `measurable` is always `false` on every instance the API
- * constructs; `reason` says why. `denominator` is the population this metric
- * would be a share of once it becomes measurable, when that population is
- * itself known; `null` when it isn't. Render "not measurable" distinctly from
- * zero — this plugin has no reachable transport to `demo_requests`/
- * `lead_source_costs` (issue #31), so reporting zero would claim "we looked,
- * and nothing happened," which is not a claim it can make today.
- *
- * Still the exact shape of the paid pack's `spend`, which really is
- * unmeasurable on every instance. It is NOT the shape of the results
- * dashboard's leads/conversions/cost — see {@link Metric}. */
-export interface UnmeasuredMetric {
-  measurable: false
-  denominator: number | null
-  reason: string
-}
+/* `UnmeasuredMetric` used to live here — a metric shape whose `measurable`
+ * was fixed at `false`, mirroring `results_routes.UnmeasuredMetric`. Issue
+ * #31 moved leads/conversions/cost off it and issue #8 moved the paid pack's
+ * `spend` off it, so nothing is that shape any more and the server no longer
+ * defines it. Deleted rather than kept available: a type that can only be
+ * unmeasurable makes the measured case unrepresentable, which is precisely
+ * how #114 shipped a real leads figure as "not measurable — undefined". */
 
 /** A leads/conversions/cost figure the instance-configured leads source
  * answered (issue #31). Mirrors `results_routes.py`'s `Metric` when


### PR DESCRIPTION
Refs #8 — the last unmet criterion of M9 (paid brief pack export): "spend recorded against the campaign".

The pack could recommend a budget but had no way to learn what was actually spent, so `paid_pack_routes.py:415` returned a hard-coded `UnmeasuredMetric()` and `PaidPack.tsx` rendered "Not measurable" on every campaign, permanently.

## What lands

- **`marketing_spend`** — this plugin's own generated-CRUD table (`campaign_id`, `amount`, `currency`, `notes`) with list/read/create routes in the manifest.
- **`src/marketing/spend_routes.py`** — `POST /campaigns/{id}/spend` writes one entry (after confirming the campaign exists; a row naming no campaign is money recorded against nowhere and nothing here would ever surface it again), and `recorded_spend()` totals every page of them into a metric.
- **The paid pack reports that metric**, and `PaidPack.tsx` renders a measured figure as a figure, with a small amount / currency / note form under it.

## The two decisions, and why

### A campaign with nothing recorded stays unmeasurable — NOT a measured zero

This plugin calls no ad platform API (`paid_pack_routes.py`'s own design constraint), so **nothing can generate a spend row**. Zero rows therefore means "nobody has typed one in", never "no money was spent". A fabricated zero would be wrong in a systematic direction — every cost-per-click or ROI computed from it reads better than reality — which is exactly what `results_routes.py`'s module docstring opens by forbidding.

A recorded `0` **is** a measured zero and renders as one. The split is not invented here:

- DDL module 049's own header states it as a requirement for `tabsii.lead_source_costs` ("no row at all -> unknown ... a row, amount 0 -> genuinely free ... must never coerce one into the other").
- tabsii's `campaign_results._cost_metric` already implements the reading half the same way (no row -> `measurable: false, "no spend recorded"`).

It does **not** contradict #99, which ruled the opposite way for *leads*: there the configured source can see the entire lead population, so an absent campaign id really is a verifiable zero. Spend has no population to have looked at.

### The row lives in this plugin's table, not `tabsii.lead_source_costs`

Four independent blockers, any one of them sufficient — full reasoning in `spend_routes.py`'s module docstring:

1. **This plugin must not name a tabsii table.** `results_routes.py` settles that for the read side in as many words; issue #31 option B made the *reader* a configured endpoint precisely so the table name would not be hard-coded. A writer hard-coding it would undo that, and would 404 on every non-tabsii instance.
2. **`brand_id` is `NOT NULL` and this plugin has no brand.** Core's generic CRUD create injects `tenant_id` only; `brand_id` is an ordinary caller-supplied payload field, with no brand header and no default brand anywhere. The reading side does not answer this either — `campaign_results.py:47-62` documents that it deliberately **ignores** `brand_id` and sums across every brand, calling it "a genuine, structural mismatch this endpoint works around, not past".
3. **The transport cannot reach that route.** `POST /api/v1/data/lead_source_costs` is guarded by `require_crud_permission` -> `require_auth`, Cognito-bearer only. Everything this plugin sends to Core goes through `principal_client` (SigV4 + forwarded user token) onto `/api/v1/internal/plugins/marketing/*`.
4. **No grant could fix (3).** `fn_authorized` resolves permissions only through a *user's* role assignments, and a `system:` service principal has no user id — so `system:marketing` holding `lead_source_costs.create` is not a missing row somebody can add, it has no representation in the schema at all.

**No tabsii-platform change is needed, and none is opened.** Nothing on the instance has to be configured for this to work end to end beyond the ordinary plugin reinstall that any new plugin table requires (`biffo plugin install` regenerates Terraform and the migration).

What this deliberately does **not** do is converge with the results dashboard's `cost`, which still comes from the instance-configured leads source and answers a different question (what the instance's lead sources cost). Making them one number is an instance-side change — tabsii's leads-source endpoint reading `marketing_spend` — not a plugin one, and is worth its own issue.

## Also: removes `UnmeasuredMetric`, which this change orphaned

Both the Python model and the TypeScript interface. A metric type whose `measurable` is fixed at `false` makes the measured case **unrepresentable** — which is precisely how #114 shipped a real leads figure as "not measurable — undefined". The paid pack's `spend` is now the `Metric` union plus a currency (`SpendMetric`). Leaving the type around as a shape a future field might reach for would be leaving #114's cause in place.

## Fail-first evidence

Backend, before the implementation existed:

```
tests/test_marketing_paid_pack_routes.py:21: in <module>
    from marketing import admin_app, pack_routes, paid_pack_routes, spend_routes
E   ImportError: cannot import name 'spend_routes' from 'marketing'
ERROR tests/test_marketing_spend_routes.py
ERROR tests/test_marketing_paid_pack_routes.py
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
```

Frontend, same point in time — the four new cases fail on the absent form and the unrepresentable measured value, while the five pre-existing ones stay green:

```
 ❯ src/components/PaidPack.test.tsx:412:28
    412|     await user.type(screen.getByLabelText(/amount spent/i), '10')
       |                            ^
 Test Files  1 failed (1)
      Tests  4 failed | 5 passed (9)
```

After:

```
668 passed, 4 warnings in 6.00s          # pytest
Test Files  25 passed (25) / Tests  210 passed (210)   # vitest
0 errors, 0 warnings, 0 informations     # pyright
```

plus `ruff check`, `ruff format --check`, `tsc --noEmit`, `eslint` and `vite build` clean. The pre-push `verify` gate passed every applicable check.

## Not touched

Neither #113's citation provenance nor #154's channel narrowing is anywhere near this. `_targeting_segment`'s `source_count` and `pipeline.selected_body`'s narrowing are unchanged; the only edit to `paid_pack_routes.py`'s route body is the one `spend` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)