### PR TITLE
fix(marketing): report the frozen synthesis config instead of trusting it

### DIFF
--- a/scripts/seed_fan_in_workflow.py
+++ b/scripts/seed_fan_in_workflow.py
@@ -33,12 +33,69 @@ definition with the same name is left alone unless ``--replace`` is passed.
 Usage:
     CORE_API_URL=https://<api-id>.execute-api.<region>.amazonaws.com \
     ADMIN_BEARER_TOKEN=<a real Cognito admin id/access token> \
-    python scripts/seed_fan_in_workflow.py [--dry-run] [--replace]
+    python scripts/seed_fan_in_workflow.py [--dry-run] [--replace] [--check]
+
+**What this script writes is a SNAPSHOT, and a snapshot goes stale (#160).**
+
+Everything in ``action_config`` below is a *copy*, taken from this checkout at
+the moment the script runs and read back by the engine months later. Two days
+after #108 moved every stage to the Claude 5 family and #131 gave every agent
+a 240s wall clock, the deployed synthesis stage was still running
+``anthropic/claude-opus-4.8`` on 120s, because nobody re-ran this. #62's
+implementer predicted exactly that, in writing, for the **model** — and the
+timeout went unnoticed anyway, because the lesson was recorded as "the model
+is stale" rather than "**the whole snapshot is stale**".
+
+**Why the config cannot simply resolve at run time**, which is the fix anyone
+would reach for first. Measured against Core (``tabsii-platform`` @ 2026-08-14),
+not assumed:
+
+- **``instructions``/``model`` can be omitted** — ``services/api/src/api/
+  routers/internal_agents.py`` resolves each from the ``plugin_chat_agents``
+  registry row for the agent when the snapshot has none. But this plugin
+  registers **no** such row (nothing in ``biffo.plugin.json`` or anywhere else
+  creates one), and the fallbacks are hostile: a missing ``instructions`` with
+  no registry row is a **422 refusal** at run-creation time, and a missing
+  ``model`` never raises at all — it is silently filled from
+  ``settings.agent_default_model``, which on Core today is
+  ``moonshotai/kimi-k3``. Omitting the model would not resolve this plugin's
+  choice at run time; it would swap Opus 5 for a different vendor's model,
+  quietly, in the reconciling stage.
+- **``max_turns``/``timeout_seconds`` cannot be omitted at all.** Nothing
+  anywhere resolves them. ``agent_runtime.loop.RunLimits.from_snapshot`` reads
+  both straight from the snapshot and substitutes its own defaults
+  (``DEFAULT_TIMEOUT_SECONDS`` = 120.0) for whatever is absent — that
+  substitution *is* the 120s clock #160 measured. The registry row has a
+  ``timeout_seconds`` column, and ``internal_agents.py`` never copies it into
+  the snapshot, so even a registered agent would not move it.
+- Registering an agent row would therefore **relocate the frozen copy** into
+  another admin-editable record seeded by another script, not remove it, and
+  would still leave the limits frozen here.
+
+So the snapshot stays, and what changes instead is that its staleness is no
+longer silent, in three places that each read a different document:
+
+1. :func:`config_fingerprint` / :data:`SEEDED_CONFIG_FINGERPRINT` — a pin over
+   the whole ``action_config`` this checkout would seed, asserted by
+   ``tests/test_marketing_seed_fan_in_workflow.py``. Changing a model, a
+   prompt, a turn budget or a wall clock turns CI **red at the point of the
+   change**, naming the re-seed command, instead of staying green for two
+   days. It reads this repo, so it proves nothing about any deployment —
+   it proves that nobody changed the seeded config without acknowledging it.
+2. ``--check`` — reads the **deployed** definition through Core's API and
+   diffs it against what this checkout would seed. This is the only check that
+   can actually answer "is dev stale?", and it needs an admin token, so it is
+   an operator/ops command rather than a CI gate.
+3. ``marketing.pipeline.synthesis_config_drift`` — reads the
+   ``definition_snapshot`` of the synthesis run that **actually ran** and
+   reports drift on every terminal research chain. No token, no operator: it
+   fires by itself, in the environment where it is wrong.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -106,6 +163,97 @@ def definition(*, synthesis_model: str = DEFAULT_SYNTHESIS_MODEL) -> dict:
     }
 
 
+#: A value that can never be compared, because Core masks it on read
+#: (``schemas/orchestration.py``'s ``redact_secrets``, where it is called
+#: ``SECRET_SENTINEL``): a credential-bearing config field comes back as this
+#: placeholder rather than its stored value. ``agent_fan_in`` declares no such
+#: field today, so this is a guard against a future one being reported as
+#: permanent, unfixable drift rather than as "cannot tell".
+REDACTED_SENTINEL = "••••••••"
+
+
+def config_fingerprint(config: dict[str, Any]) -> str:
+    """A stable digest of the whole ``action_config`` this checkout would seed.
+
+    **The whole config, not the model.** #62 recorded its lesson as "synthesis
+    is stuck on an old model", so #131's timeout change sailed past it two days
+    later on the same mechanism. Every key here is a copy that a deploy does
+    not update — the prompt, the tool schema, the turn budget and the wall
+    clock exactly as much as the model — so the thing that gets pinned is the
+    snapshot, and a change to any part of it has to be acknowledged.
+
+    Truncated to 16 hex characters: long enough that a change cannot collide
+    with the pinned value in practice, short enough to read in a diff.
+    """
+    return (
+        "sha256:"
+        + hashlib.sha256(json.dumps(config, sort_keys=True, default=str).encode()).hexdigest()[:16]
+    )
+
+
+#: The fingerprint of the ``action_config`` this checkout seeds.
+#:
+#: **This is a tripwire, not a record of what is deployed.** It goes red in CI
+#: the moment anyone changes the synthesis model, prompt, tool schema, turn
+#: budget or wall clock — which is the moment someone can still act on it,
+#: rather than two days later while reading a table in the portal. Updating it
+#: is the acknowledgement that the deployed workflow now needs
+#: ``--replace`` run against every environment.
+#:
+#: What it deliberately does NOT claim: that anybody actually re-seeded
+#: anything. Nothing inside this repo can know that — only ``--check`` against
+#: a live Core, or ``marketing.pipeline.synthesis_config_drift`` reading a real
+#: run's ``definition_snapshot``, can.
+SEEDED_CONFIG_FINGERPRINT = "sha256:cb3c731624d6c34e"
+
+
+def config_drift(
+    deployed: dict[str, Any] | None, desired: dict[str, Any] | None = None
+) -> dict[str, tuple[Any, Any]]:
+    """``{key: (deployed, desired)}`` for every key that differs, empty if none.
+
+    Compares the **whole** ``action_config``, including keys the deployed copy
+    has and this checkout does not (reported with a desired value of ``None``)
+    — a leftover key from an older seed is drift too.
+
+    A key Core has masked as a secret is skipped rather than reported: its real
+    value cannot be read back, so calling it drift would mean permanent,
+    unfixable red. ``deployed`` of ``None`` — nothing seeded at all — is not
+    expressible as a per-key diff and is the caller's job to report.
+    """
+    desired = definition()["action_config"] if desired is None else desired
+    if deployed is None:
+        return {}
+    drift: dict[str, tuple[Any, Any]] = {}
+    for key in sorted(set(desired) | set(deployed)):
+        deployed_value = deployed.get(key)
+        if deployed_value == REDACTED_SENTINEL:
+            continue
+        desired_value = desired.get(key)
+        if deployed_value != desired_value:
+            drift[key] = (deployed_value, desired_value)
+    return drift
+
+
+def _short(value: Any) -> str:
+    """One drift value, short enough for a terminal line."""
+    text = value if isinstance(value, str) else json.dumps(value, default=str)
+    return f"{text[:70]}… ({len(text)} chars)" if len(text) > 70 else text
+
+
+def _print_drift(drift: dict[str, tuple[Any, Any]]) -> None:
+    print(f"The deployed workflow is STALE in {len(drift)} key(s):")
+    for key, (deployed_value, desired_value) in drift.items():
+        print(f"  {key}:")
+        print(f"    deployed: {_short(deployed_value)}")
+        print(f"    this checkout: {_short(desired_value)}")
+    print(
+        "\nRe-seed it:\n"
+        "    CORE_API_URL=... ADMIN_BEARER_TOKEN=... \\\n"
+        "      uv run python scripts/seed_fan_in_workflow.py --replace"
+    )
+
+
 def _request(method: str, url: str, token: str, body: dict | None = None) -> Any:
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)  # noqa: S310
@@ -123,12 +271,21 @@ def main() -> int:
         action="store_true",
         help="overwrite an existing definition of the same name",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "compare the DEPLOYED definition against this checkout and change "
+            "nothing. 0 in step · 1 stale or not seeded · 2 cannot tell"
+        ),
+    )
     args = parser.parse_args()
 
     payload = definition()
 
     if args.dry_run:
         print(json.dumps(payload, indent=2))
+        print(f"\nfingerprint: {config_fingerprint(payload['action_config'])}", file=sys.stderr)
         return 0
 
     api = os.environ.get("CORE_API_URL", "").rstrip("/")
@@ -141,12 +298,41 @@ def main() -> int:
     try:
         existing = _request("GET", url, token) or []
     except urllib.error.HTTPError as exc:
+        # "Cannot tell" on --check: an unreadable Core is not a clean bill of
+        # health, and reporting it as one is how a drift check becomes a
+        # fail-open. Unchanged (1) on a seeding run, where it is a real failure.
         print(f"Could not list workflows: {exc.code} {exc.reason}", file=sys.stderr)
-        return 1
+        return 2 if args.check else 1
 
     match = next((w for w in existing if w.get("name") == WORKFLOW_NAME), None)
+
+    if args.check:
+        if match is None:
+            print(
+                f"NOT SEEDED: no workflow named {WORKFLOW_NAME!r} exists. "
+                "A research run will never leave `pending` here.",
+                file=sys.stderr,
+            )
+            return 1
+        drift = config_drift(match.get("action_config"))
+        if drift:
+            _print_drift(drift)
+            return 1
+        print(f"In step (id {match.get('id')}) — deployed action_config matches this checkout.")
+        return 0
+
     if match and not args.replace:
-        print(f"Already seeded (id {match.get('id')}). Pass --replace to overwrite.")
+        # Never just "already seeded" again. That message was true throughout
+        # #160 and said nothing about the deployed config being two releases
+        # behind this checkout; an operator running the documented idempotent
+        # command got a reassuring line back while synthesis ran the wrong
+        # model on half the wall clock.
+        drift = config_drift(match.get("action_config"))
+        if drift:
+            print(f"Already seeded (id {match.get('id')}), but NOT in step with this checkout.\n")
+            _print_drift(drift)
+            return 1
+        print(f"Already seeded and in step (id {match.get('id')}). Nothing to do.")
         return 0
 
     try:

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -438,6 +438,16 @@ class _CoreAgentGateway:
             # coerce to `[]`: that would make an unknown run read as a proven
             # empty retrieval, which is the exact ambiguity #82 exists to remove.
             annotations=run.get("annotations"),
+            # What this run ACTUALLY ran with (issue #160). Core's
+            # `AgentRunResponse.definition_snapshot` — carried across because
+            # the research-synthesis run is fired by the orchestration engine
+            # from a copy of this plugin's definition frozen into the seeded
+            # workflow, and this is the only place the plugin can see that
+            # copy. Same reasoning as `annotations` above: absent stays
+            # `None` ("not known"), never `{}` ("checked, and it was empty"),
+            # because `synthesis_config_drift` must not read an unknown
+            # snapshot as a clean bill of health.
+            definition_snapshot=run.get("definition_snapshot"),
         )
 
 

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -77,6 +77,7 @@ from .definitions import (
     RESEARCH_AGENT_NAMES,
     RESEARCH_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_AGENT_NAME,
+    RESEARCH_SYNTHESIS_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_TOOL_NAME,
     ChannelCopy,
     ChannelPlan,
@@ -96,6 +97,7 @@ from .definitions import (
     positioning_tool_schema,
     research_definition,
     research_search_query,
+    research_synthesis_definition,
 )
 
 logger = Logger(child=True)
@@ -1121,12 +1123,24 @@ class AgentRunView:
       nothing to cite.
     - non-empty — retrieval succeeded; the run has evidence, whatever the
       model's tool call did or didn't repeat of it.
+
+    ``definition_snapshot`` is Core's ``AgentRunResponse.definition_snapshot``:
+    the configuration this run **actually ran with**, as opposed to the one
+    this repo declares. For every stage this plugin starts itself the two are
+    the same thing by construction. For the one stage it does not — research
+    synthesis, fired by the orchestration engine from a config frozen into the
+    seeded workflow — they are two independent documents that drifted apart
+    for two days without anything noticing (issue #160), which is why the
+    snapshot is carried here at all. ``None`` means "not known": a view built
+    from a list row rather than the detail endpoint, or a Core too old to
+    return the field. It never means "matches".
     """
 
     id: str
     status: str
     messages: list[dict[str, Any]] = field(default_factory=list)
     annotations: list[dict[str, Any]] | None = None
+    definition_snapshot: dict[str, Any] | None = None
 
     @property
     def is_terminal(self) -> bool:
@@ -1462,6 +1476,127 @@ async def _log_evidence_profile_for(
     _log_evidence_profile(chain_id=chain_id, views=views)
 
 
+#: The exact command that re-seeds the workflow definition, quoted verbatim
+#: anywhere this repo reports drift. Anyone reading a drift report is one
+#: command away from fixing it and should never have to go and find which one.
+RESEED_COMMAND = "uv run python scripts/seed_fan_in_workflow.py --replace"
+
+#: The keys of the frozen copy this plugin can compare a *run* against.
+#:
+#: Not "the model", which is how #62 recorded the lesson and why the timeout
+#: went unnoticed for two more days: **the whole snapshot is frozen**, so the
+#: subject of the check is every key of the run definition, enumerated from
+#: ``research_synthesis_definition``'s own output rather than listed here.
+#: ``tools`` and ``output_tools`` are compared too — a stale tool schema is
+#: the same class of defect and would be even quieter.
+SYNTHESIS_DRIFT_IGNORED_KEYS = frozenset({"output_tools"})
+
+
+def _drift_summary(value: Any) -> Any:
+    """A long string reduced to something a log line can carry.
+
+    The synthesis instructions are thousands of characters; a drift report
+    that pasted two copies of them would be unreadable and would push the
+    thing that actually differs off the end of the line.
+    """
+    if isinstance(value, str) and len(value) > 80:
+        return f"{value[:60]}… ({len(value)} chars)"
+    return value
+
+
+def synthesis_config_drift(
+    snapshot: Mapping[str, Any] | None,
+    *,
+    synthesis_model: str = DEFAULT_SYNTHESIS_MODEL,
+) -> dict[str, tuple[Any, Any]]:
+    """What the research-synthesis run **actually ran with**, against what this
+    repo declares — ``{key: (deployed, declared)}``, empty when they agree.
+
+    This is the guard for issue #160, and the document it reads matters more
+    than the comparison it makes. The synthesis stage is the one stage this
+    plugin does not start: the orchestration engine fires it from a copy of
+    the run definition that ``scripts/seed_fan_in_workflow.py`` froze into the
+    workflow's ``action_config`` at seed time. A test that reads
+    ``definitions.py`` and asserts something about ``definitions.py`` proves
+    nothing about that copy — it is biffo-template#1362's class, a guard
+    reading a different document from the one that acts, and it is exactly the
+    check that would have stayed green through all of #160.
+
+    So the subject here is ``AgentRunView.definition_snapshot``: the
+    configuration Core recorded on the run it created, which is what the
+    runtime read and billed. If that disagrees with
+    ``research_synthesis_definition``, the deployed workflow is stale and the
+    only fix is :data:`RESEED_COMMAND`.
+
+    ``None`` means the snapshot is not known (an older Core, or a view built
+    from a list row) and yields ``{}`` — the caller must not read that as
+    "in step"; it is "not checked". A key missing from the snapshot is a
+    drift with a deployed value of ``None``, because absent is precisely how
+    ``timeout_seconds`` produced the 120s clock #160 measured: the runtime
+    silently substitutes its own default for a key nobody wrote.
+    """
+    if snapshot is None:
+        return {}
+    declared = research_synthesis_definition(
+        model=synthesis_model, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
+    )
+    drift: dict[str, tuple[Any, Any]] = {}
+    for key, declared_value in declared.items():
+        if key in SYNTHESIS_DRIFT_IGNORED_KEYS:
+            continue
+        deployed_value = snapshot.get(key)
+        if deployed_value != declared_value:
+            drift[key] = (_drift_summary(deployed_value), _drift_summary(declared_value))
+    return drift
+
+
+def _report_synthesis_config_drift(
+    view: AgentRunView, *, chain_id: str, synthesis_model: str
+) -> dict[str, tuple[Any, Any]]:
+    """Log — never raise — when the run the engine fired was configured from a
+    stale copy of this repo.
+
+    Deliberately not an exception. The run has already happened and has
+    already been paid for; refusing its output over a configuration mismatch
+    would turn a reporting problem into an outage, and the operator would lose
+    a campaign to a stale workflow rather than merely running one on the wrong
+    model. It is logged at ``error`` because it is a deployment defect that
+    needs a person, not a condition the pipeline can recover from.
+
+    Reported on **every terminal path**, including failure — a run that died
+    on a 120s clock its declaration says should be 240s is the case where this
+    line is worth the most, and that run is a failure, not a success.
+    """
+    try:
+        drift = synthesis_config_drift(view.definition_snapshot, synthesis_model=synthesis_model)
+    except Exception:  # pragma: no cover — defensive; a report must not raise
+        logger.warning(
+            "synthesis config drift: not checked — the run's definition snapshot could not be read",
+            exc_info=True,
+            extra={"causation_id": chain_id},
+        )
+        return {}
+    if not drift:
+        return {}
+    logger.error(
+        "The seeded fan-in workflow is STALE: the research-synthesis run ran a "
+        "configuration this repo no longer declares. The engine fires this stage "
+        "from a copy frozen into the workflow's action_config at seed time, so "
+        "nothing in a deploy updates it. Re-seed with: %s",
+        RESEED_COMMAND,
+        extra={
+            "causation_id": chain_id,
+            "agent_run_id": view.id,
+            "reseed_command": RESEED_COMMAND,
+            "synthesis_config_drift": {
+                key: {"deployed": deployed, "declared": declared}
+                for key, (deployed, declared) in drift.items()
+            },
+        },
+    )
+    return drift
+
+
 async def advance_research(
     gateway: AgentGateway,
     *,
@@ -1479,9 +1614,17 @@ async def advance_research(
     artefact would sit ``pending`` forever with nothing to explain why.
     Raises :class:`MalformedOutputError` / :class:`NoCitationsError` via
     :func:`extract_research_synthesis` on a malformed or citation-less
-    result. ``synthesis_model`` is accepted for parity with the other stage
-    starters even though this stage never *starts* a run — the engine does —
-    so callers have one place to read every model this pipeline can use.
+    result. ``synthesis_model`` used to be accepted for parity with the other
+    stage starters and then discarded (``del synthesis_model``), because this
+    stage never *starts* a run — the engine does. It is now the model this
+    stage is **supposed** to run on, and the run's own
+    ``definition_snapshot`` is checked against it
+    (:func:`synthesis_config_drift`): the engine fires synthesis from a copy
+    of that definition frozen into the seeded workflow, and for two days that
+    copy ran ``claude-opus-4.8`` on a 120s clock while this repo declared
+    ``claude-opus-5`` on 240s with nothing anywhere reporting it (#160). A
+    parameter that is accepted and discarded is how a stage ends up with no
+    guard at all.
 
     The citation guard is grounded in the **research** runs' annotations
     (:func:`_aggregate_research_annotations`), not the synthesis run's own —
@@ -1504,14 +1647,18 @@ async def advance_research(
     still in flight, because this function is polled and the line would then be
     a stream of partial snapshots rather than one measurement per chain.
     """
-    del synthesis_model  # the engine chooses the synthesis run's model, not us
-
     synthesis_run = await gateway.find_chain_run(
         chain_id=chain_id, agent_name=RESEARCH_SYNTHESIS_AGENT_NAME
     )
     if synthesis_run is not None:
         if not synthesis_run.is_terminal:
             return None  # synthesis is running; nothing to do yet
+        # The engine chose this run's configuration, from a copy of ours frozen
+        # at seed time — so `synthesis_model` is not the model that ran, it is
+        # the model that *should* have (issue #160). Compare them and say so.
+        _report_synthesis_config_drift(
+            synthesis_run, chain_id=chain_id, synthesis_model=synthesis_model
+        )
         if not synthesis_run.succeeded:
             await _log_evidence_profile_for(
                 gateway, chain_id=chain_id, research_run_ids=research_run_ids

--- a/tests/test_marketing_agent_gateway.py
+++ b/tests/test_marketing_agent_gateway.py
@@ -108,3 +108,50 @@ async def test_get_agent_run_defaults_a_missing_annotations_key_to_none() -> Non
 
     assert view is not None
     assert view.annotations is None
+
+
+# ── definition_snapshot: what the run ACTUALLY ran with (issue #160) ──────────
+#
+# Same boundary, same failure mode as `annotations` above: the drift check in
+# `pipeline.synthesis_config_drift` is inert unless the field it reads survives
+# the trip from Core's JSON onto the view. It matters more here than usual —
+# the synthesis run is fired by the orchestration engine from a *copy* of this
+# plugin's run definition frozen into the seeded workflow, so this snapshot is
+# the only thing in the whole system that can tell the plugin what that copy
+# actually says.
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_carries_the_definition_snapshot_onto_the_view() -> None:
+    """Core's `AgentRunResponse.definition_snapshot` — the configuration the
+    runtime read and billed, including the model and wall clock #160 found
+    two releases behind."""
+    run = {
+        **_BASE_RUN,
+        "definition_snapshot": {
+            "instructions": "…",
+            "model": "anthropic/claude-opus-4.8",
+            "max_turns": 3,
+        },
+    }
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.definition_snapshot == run["definition_snapshot"]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_defaults_a_missing_definition_snapshot_to_none() -> None:
+    """Absent must stay `None` — "not known", never `{}`. An empty dict would
+    make `synthesis_config_drift` report every key as drifted, and a check
+    that screams on every run is one nobody reads."""
+    run = dict(_BASE_RUN)
+    assert "definition_snapshot" not in run
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.definition_snapshot is None

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -15,12 +15,24 @@ import pytest
 
 from marketing import pipeline
 from marketing.definitions import (
+    AGENT_TIMEOUT_SECONDS,
     CHANNEL_PLAN_AGENT_NAME,
     COPY_AGENT_NAME,
+    DEFAULT_SYNTHESIS_MODEL,
     POSITIONING_AGENT_NAME,
     RESEARCH_AGENT_NAMES,
     RESEARCH_SYNTHESIS_AGENT_NAME,
+    RESEARCH_SYNTHESIS_INSTRUCTIONS,
+    research_synthesis_definition,
 )
+
+
+def _in_step_snapshot() -> dict[str, Any]:
+    """The definition snapshot a *freshly re-seeded* workflow would produce —
+    what the engine ran the synthesis agent with when nothing has drifted."""
+    return research_synthesis_definition(
+        model=DEFAULT_SYNTHESIS_MODEL, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
+    )
 
 
 @dataclass
@@ -92,12 +104,26 @@ class _FakeGateway:
         status: str = "completed",
         messages: list | None = None,
         annotations: list[dict[str, Any]] | None = None,
+        definition_snapshot: dict[str, Any] | None = None,
     ) -> str:
-        """Simulate the engine's `agent_fan_in` firing a joining agent."""
+        """Simulate the engine's `agent_fan_in` firing a joining agent.
+
+        `definition_snapshot` is what the engine ran it with — a copy of this
+        plugin's definition frozen into the seeded workflow, which is a
+        different document from `definitions.py` and drifted from it for two
+        days (#160). Defaults to the frozen copy being *in step*; the drift
+        tests pass a stale one explicitly.
+        """
         self._next_id += 1
         run_id = f"run-{self._next_id}"
         self._runs[run_id] = pipeline.AgentRunView(
-            id=run_id, status=status, messages=messages or [], annotations=annotations
+            id=run_id,
+            status=status,
+            messages=messages or [],
+            annotations=annotations,
+            definition_snapshot=(
+                _in_step_snapshot() if definition_snapshot is None else definition_snapshot
+            ),
         )
         self._chain_runs[(chain_id, agent_name)] = run_id
         return run_id
@@ -950,3 +976,175 @@ def test_require_approved_passes_on_approved() -> None:
 def test_require_approved_raises_on_anything_else(status: str) -> None:
     with pytest.raises(pipeline.ArtefactNotApprovedError):
         pipeline.require_approved(status, what="Research")
+
+
+# ── The frozen synthesis config, and the run that reveals it (issue #160) ─────
+#
+# The synthesis stage is the ONE stage this plugin does not start. The engine
+# fires it from a copy of `research_synthesis_definition` that
+# `scripts/seed_fan_in_workflow.py` froze into the workflow's `action_config`,
+# and nothing in a deploy updates that copy. On 2026-08-14 it was still running
+# `claude-opus-4.8` on 120s, two days after every other stage moved to Claude 5
+# on 240s — and nothing anywhere reported it. Someone found it by reading a
+# table in the portal while diagnosing something else.
+#
+# These tests read the run's OWN `definition_snapshot` — what Core recorded and
+# the runtime billed — rather than `definitions.py`, because a guard that reads
+# `definitions.py` and asserts something about `definitions.py` would have been
+# green throughout (biffo-template#1362's class).
+
+DRIFT_PREFIX = "The seeded fan-in workflow is STALE"
+
+
+#: What the engine really ran on tabsii dev, per #160's table.
+_STALE_SNAPSHOT = {
+    **_in_step_snapshot(),
+    "model": "anthropic/claude-opus-4.8",
+    "timeout_seconds": 120.0,
+}
+
+
+def _drift_records(caplog: pytest.LogCaptureFixture) -> list[Any]:
+    return [r for r in caplog.records if r.getMessage().startswith(DRIFT_PREFIX)]
+
+
+def test_synthesis_config_drift_names_both_the_model_and_the_clock() -> None:
+    """#62 predicted the model would stick and wrote it down; the timeout
+    stuck anyway, because the lesson was recorded about one key rather than
+    about the snapshot. Both must be named."""
+    drift = pipeline.synthesis_config_drift(_STALE_SNAPSHOT)
+
+    assert set(drift) == {"model", "timeout_seconds"}
+    assert drift["model"] == ("anthropic/claude-opus-4.8", DEFAULT_SYNTHESIS_MODEL)
+    assert drift["timeout_seconds"] == (120.0, AGENT_TIMEOUT_SECONDS)
+
+
+def test_synthesis_config_drift_is_empty_for_a_freshly_seeded_workflow() -> None:
+    """The negative control: after a re-seed this must go quiet, or the report
+    is noise and gets filtered out."""
+    assert pipeline.synthesis_config_drift(_in_step_snapshot()) == {}
+
+
+def test_synthesis_config_drift_shortens_a_prompt_rather_than_pasting_it() -> None:
+    """A drifted prompt is thousands of characters. Two copies of it in one
+    log line pushes the thing that actually differs off the end."""
+    drift = pipeline.synthesis_config_drift({**_in_step_snapshot(), "instructions": "x" * 4000})
+
+    deployed, declared = drift["instructions"]
+    assert deployed.endswith("(4000 chars)")
+    assert len(deployed) < 200 and len(declared) < 200
+
+
+def test_synthesis_config_drift_says_nothing_when_the_snapshot_is_unknown() -> None:
+    """`None` is "not checked", never "in step". A view built from a list row
+    (or an older Core) has no snapshot, and reporting that as agreement is the
+    fail-open this whole issue is about."""
+    assert pipeline.synthesis_config_drift(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_advance_research_reports_the_stale_config_that_actually_ran(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The end-to-end guard: a normal, *successful* research chain whose
+    synthesis was fired from a stale workflow now says so, at ERROR, naming
+    the command that fixes it — and still returns the synthesis, because the
+    run has already happened and refusing its output would cost an operator a
+    campaign over a configuration report."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed")
+    gateway.complete(run_ids[1], status="completed")
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_findings_call("audience"),
+        definition_snapshot=_STALE_SNAPSHOT,
+    )
+
+    with caplog.at_level("ERROR"):
+        result = await pipeline.advance_research(
+            gateway, chain_id=chain_id, research_run_ids=run_ids
+        )
+
+    assert isinstance(result, pipeline.ResearchSynthesis)  # a report, not a gate
+    records = _drift_records(caplog)
+    assert len(records) == 1
+    assert pipeline.RESEED_COMMAND in records[0].getMessage()
+    reported = records[0].synthesis_config_drift
+    assert reported["model"]["deployed"] == "anthropic/claude-opus-4.8"
+    assert reported["timeout_seconds"]["deployed"] == 120.0
+    assert records[0].causation_id == chain_id
+
+
+@pytest.mark.asyncio
+async def test_advance_research_is_quiet_when_the_engine_ran_what_this_repo_declares(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed")
+    gateway.complete(run_ids[1], status="completed")
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        messages=_findings_call("audience"),
+    )
+
+    with caplog.at_level("ERROR"):
+        await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    assert _drift_records(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_advance_research_reports_drift_on_the_run_that_died_on_the_short_clock(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The case worth the most. #130 was synthesis producing 8,546 output
+    tokens and dying at 120s; the fix (#131) raised every agent to 240s and
+    never reached this stage. A failed run is exactly when someone asks *why*,
+    so the drift line has to be on the failure path too — not only the happy
+    one."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed")
+    gateway.complete(run_ids[1], status="completed")
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        status="failed",
+        definition_snapshot=_STALE_SNAPSHOT,
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(pipeline.RunNotSucceededError):
+            await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+
+    assert len(_drift_records(caplog)) == 1
+
+
+@pytest.mark.asyncio
+async def test_advance_research_says_nothing_while_synthesis_is_still_running(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`advance_research` is polled. A drift line per poll would be a stream
+    rather than a report — it belongs on the terminal transition, once."""
+    gateway = _FakeGateway()
+    chain_id, run_ids = await pipeline.start_research(gateway, brief={})
+    gateway.complete(run_ids[0], status="completed")
+    gateway.complete(run_ids[1], status="completed")
+    gateway.fire_chain_run(
+        chain_id=chain_id,
+        agent_name=RESEARCH_SYNTHESIS_AGENT_NAME,
+        status="running",
+        definition_snapshot=_STALE_SNAPSHOT,
+    )
+
+    with caplog.at_level("ERROR"):
+        assert (
+            await pipeline.advance_research(gateway, chain_id=chain_id, research_run_ids=run_ids)
+            is None
+        )
+
+    assert _drift_records(caplog) == []

--- a/tests/test_marketing_seed_fan_in_workflow.py
+++ b/tests/test_marketing_seed_fan_in_workflow.py
@@ -8,9 +8,12 @@ same rationale as idea-scout's `test_idea_scout_seed_fan_in_workflow.py`.
 
 from __future__ import annotations
 
+import pytest
 from _scripts import load_script
 
 from marketing.definitions import (
+    AGENT_TIMEOUT_SECONDS,
+    DEFAULT_SYNTHESIS_MODEL,
     RESEARCH_AGENT_NAMES,
     RESEARCH_SYNTHESIS_AGENT_NAME,
     RESEARCH_SYNTHESIS_INSTRUCTIONS,
@@ -105,3 +108,238 @@ def test_it_posts_to_the_path_core_actually_mounts() -> None:
     """
     assert _seed._DEFINITIONS_PATH == "/api/v1/orchestration/workflows"
     assert "/admin/" not in _seed._DEFINITIONS_PATH
+
+
+# ── The snapshot goes stale, and nothing used to say so (issue #160) ──────────
+#
+# Everything above asserts what this checkout WOULD seed. None of it can see
+# what is deployed — which is the whole of #160: for two days the deployed
+# `action_config` ran `anthropic/claude-opus-4.8` on a 120s clock while every
+# test in this file was green about `claude-opus-5` and 240s, because the
+# script copies those values into the workflow at seed time and the deployed
+# copy is a different document from this one.
+#
+# That is biffo-template#1362's class — a guard reading a different document
+# from the one that acts — so the tests below are careful about which document
+# each of them can actually speak for:
+#
+# * `config_drift` is exercised here against a HAND-WRITTEN copy of the real
+#   deployed config, so it proves the comparison catches #160's exact drift.
+#   Against a live Core it is `--check` that supplies the deployed side.
+# * The fingerprint pin speaks only for this repo: it goes red when someone
+#   changes what would be seeded, which is when a person can still act.
+# * Neither can prove tabsii dev was re-seeded. Only `--check` or
+#   `marketing.pipeline.synthesis_config_drift` (which reads the definition
+#   snapshot of the run that actually ran) can, and both need a live system.
+
+
+#: The `action_config` as it was actually deployed on tabsii dev on 2026-08-14,
+#: transcribed from the run table in #160: today's prompt and turn budget, a
+#: model two releases behind, and a wall clock the runtime substituted because
+#: the seeded copy predates `timeout_seconds` existing at all.
+_DEPLOYED_ON_DEV_2026_08_14 = {
+    "expect_agents": ",".join(RESEARCH_AGENT_NAMES),
+    "agent_name": RESEARCH_SYNTHESIS_AGENT_NAME,
+    "instructions": RESEARCH_SYNTHESIS_INSTRUCTIONS,
+    "model": "anthropic/claude-opus-4.8",
+    "tools": [],
+    "max_turns": definition()["action_config"]["max_turns"],
+    "output_tools": definition()["action_config"]["output_tools"],
+}
+
+
+def test_config_drift_catches_the_exact_pair_that_was_frozen_on_dev() -> None:
+    """The regression test for #160 itself.
+
+    Both halves, not just the model: #62 predicted the model would stick and
+    said so in writing, and the timeout stuck anyway because the prediction
+    was about one key rather than about the snapshot. A check that only
+    compared models would still be green on this config.
+    """
+    drift = _seed.config_drift(_DEPLOYED_ON_DEV_2026_08_14)
+
+    assert set(drift) == {"model", "timeout_seconds"}
+    assert drift["model"] == ("anthropic/claude-opus-4.8", DEFAULT_SYNTHESIS_MODEL)
+    # Absent in the deployed copy — which is exactly how it produced 120s:
+    # `RunLimits.from_snapshot` substitutes the runtime default for a key
+    # nobody wrote, so "missing" and "wrong" are the same defect here.
+    assert drift["timeout_seconds"] == (None, AGENT_TIMEOUT_SECONDS)
+
+
+def test_config_drift_is_empty_when_the_deployed_copy_is_this_one() -> None:
+    """The negative control. A check that cannot come back clean is not a
+    check, it is an alarm."""
+    assert _seed.config_drift(definition()["action_config"]) == {}
+
+
+def test_config_drift_reports_a_key_the_deployed_copy_has_and_this_one_does_not() -> None:
+    """Drift is symmetric: a leftover key from an older seed is stale
+    configuration the engine still reads, not an absence."""
+    deployed = {**definition()["action_config"], "retired_key": "left over"}
+
+    assert _seed.config_drift(deployed)["retired_key"] == ("left over", None)
+
+
+def test_config_drift_cannot_speak_for_a_deployment_with_nothing_seeded() -> None:
+    """`None` is "there is no deployed config", which is not a per-key diff —
+    and must never be reported as agreement. `main()` handles it separately
+    and exits 1; this pins that `config_drift` itself claims nothing."""
+    assert _seed.config_drift(None) == {}
+
+
+def test_config_drift_skips_a_value_core_masked_as_a_secret() -> None:
+    """Core redacts secret config fields on read (`redact_secrets`), so their
+    stored value cannot be compared. Reporting the sentinel as drift would be
+    permanent red no re-seed could clear — an alarm nobody can silence gets
+    ignored, which is how the real one gets missed."""
+    deployed = {**definition()["action_config"], "model": _seed.REDACTED_SENTINEL}
+
+    assert _seed.config_drift(deployed) == {}
+
+
+def test_the_seeded_config_fingerprint_is_pinned_to_this_checkout() -> None:
+    """The tripwire that makes `--replace` obviously necessary.
+
+    Change the synthesis model, prompt, tool schema, turn budget or wall clock
+    and this fails **in the PR that changes it**, not two days later in a
+    portal table. Updating the constant is the acknowledgement that every
+    environment now needs a re-seed.
+    """
+    actual = _seed.config_fingerprint(definition()["action_config"])
+
+    assert _seed.SEEDED_CONFIG_FINGERPRINT == actual, (
+        "The seeded workflow config changed. No deploy refreshes the copy that "
+        "is already out there — re-seed every environment with `uv run python "
+        "scripts/seed_fan_in_workflow.py --replace`, verify with `--check`, "
+        f"then pin SEEDED_CONFIG_FINGERPRINT to {actual!r}."
+    )
+
+
+@pytest.mark.parametrize("key", sorted(definition()["action_config"]))
+def test_the_fingerprint_covers_every_key_of_the_snapshot(key: str) -> None:
+    """The generalisation #62 did not make: **the whole snapshot is frozen**,
+    so every key of it has to move the pin — the prompt and the wall clock as
+    much as the model. Enumerated from the config itself, so a key added later
+    is covered the day it is added rather than the day someone remembers."""
+    mutated = {**definition()["action_config"], key: "changed"}
+
+    assert _seed.config_fingerprint(mutated) != _seed.SEEDED_CONFIG_FINGERPRINT
+
+
+# ── `--check`: the only check that reads the DEPLOYED document ────────────────
+#
+# Everything else in this file (and in the whole repo) compares this checkout
+# with itself. `--check` is the one that asks Core what is actually out there,
+# so its exit codes are the contract: 0 in step · 1 stale or not seeded ·
+# 2 cannot tell. Exit 2 is never a pass — an unreadable Core is not a clean
+# bill of health, which is the fail-open shape this estate keeps rediscovering.
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch, argv: list[str], listed: list[dict] | Exception
+) -> int:
+    """`main()` with the network replaced and both credentials present."""
+    monkeypatch.setenv("CORE_API_URL", "https://core.example")
+    monkeypatch.setenv("ADMIN_BEARER_TOKEN", "t")
+    monkeypatch.setattr(_seed.sys, "argv", ["seed_fan_in_workflow.py", *argv])
+
+    def _fake_request(method: str, url: str, token: str, body: dict | None = None) -> object:
+        del url, token, body
+        if isinstance(listed, Exception):
+            raise listed
+        return listed if method == "GET" else {"id": "wf-1"}
+
+    monkeypatch.setattr(_seed, "_request", _fake_request)
+    return _seed.main()
+
+
+def _deployed(config: dict) -> list[dict]:
+    return [{"id": "wf-1", "name": WORKFLOW_NAME, "action_config": config}]
+
+
+def test_check_exits_zero_when_the_deployed_config_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    listed = _deployed(definition()["action_config"])
+
+    assert _run_main(monkeypatch, ["--check"], listed) == 0
+
+
+def test_check_exits_one_on_the_config_that_was_really_deployed(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    listed = _deployed(_DEPLOYED_ON_DEV_2026_08_14)
+
+    assert _run_main(monkeypatch, ["--check"], listed) == 1
+    out = capsys.readouterr().out
+    assert "STALE" in out
+    assert "model" in out and "timeout_seconds" in out
+    assert "--replace" in out  # the fix, in the output that reports the fault
+
+
+def test_check_exits_one_when_nothing_is_seeded_at_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The original failure this script exists to prevent — a research run that
+    never leaves `pending` — is also a drift result, not a silent 0."""
+    assert _run_main(monkeypatch, ["--check"], []) == 1
+
+
+def test_check_exits_two_when_core_cannot_be_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cannot tell, never a pass."""
+    boom = _seed.urllib.error.HTTPError("u", 503, "Service Unavailable", {}, None)  # type: ignore[arg-type]
+
+    assert _run_main(monkeypatch, ["--check"], boom) == 2
+
+
+def test_check_exits_two_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CORE_API_URL", raising=False)
+    monkeypatch.delenv("ADMIN_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr(_seed.sys, "argv", ["seed_fan_in_workflow.py", "--check"])
+
+    assert _seed.main() == 2
+
+
+def test_a_seeding_run_no_longer_calls_a_stale_deployment_done(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without `--replace`, this used to print "Already seeded" and exit 0 —
+    a reassuring line that was true, and useless, throughout #160. The
+    idempotent run an operator is told to make must now say what is stale."""
+    listed = _deployed(_DEPLOYED_ON_DEV_2026_08_14)
+
+    assert _run_main(monkeypatch, [], listed) == 1
+    assert "NOT in step" in capsys.readouterr().out
+
+
+def test_a_seeding_run_stays_quiet_when_the_deployment_is_in_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    listed = _deployed(definition()["action_config"])
+
+    assert _run_main(monkeypatch, [], listed) == 0
+
+
+def test_replace_puts_over_the_existing_definition_rather_than_creating_a_second(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A re-seed must REPLACE. Core matches nothing on name — `PUT
+    /workflows/{id}` replaces the whole `action_config`, while a POST would
+    create a second definition with the same name and the fan-in would then
+    fire twice per chain. The match is by name over the full, unpaginated
+    list, so this is what makes `--replace` safe to run on dev."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setenv("CORE_API_URL", "https://core.example")
+    monkeypatch.setenv("ADMIN_BEARER_TOKEN", "t")
+    monkeypatch.setattr(_seed.sys, "argv", ["seed_fan_in_workflow.py", "--replace"])
+
+    def _fake_request(method: str, url: str, token: str, body: dict | None = None) -> object:
+        del token, body
+        calls.append((method, url))
+        return _deployed(_DEPLOYED_ON_DEV_2026_08_14) if method == "GET" else {"id": "wf-1"}
+
+    monkeypatch.setattr(_seed, "_request", _fake_request)
+
+    assert _seed.main() == 0
+    assert calls[1] == ("PUT", f"https://core.example{_seed._DEFINITIONS_PATH}/wf-1")
+    assert "Replaced workflow wf-1." in capsys.readouterr().out


### PR DESCRIPTION
Refs #160.

## What was wrong

The engine fires research synthesis from a **copy** of this plugin's run definition that `scripts/seed_fan_in_workflow.py` froze into the workflow's `action_config` at seed time. Nothing in a deploy updates that copy and nothing ever read it back, so on tabsii dev it was still running `anthropic/claude-opus-4.8` on a 120s clock two days after #108 and #131 moved every other stage to Claude 5 on 240s.

#62's implementer predicted exactly this — for the **model**. The timeout stuck anyway, because the lesson was recorded as "the model is stale" rather than "**the whole snapshot is stale**". Generalising that is what this PR is for.

## Can the config resolve at run time? No — measured, not assumed

Read against Core (`tabsii-platform`, 2026-08-14):

| field | resolves at run time? | evidence |
| --- | --- | --- |
| `instructions` | only from the `plugin_chat_agents` registry | `routers/internal_agents.py` — this plugin registers **no** row, and a missing prompt with no row is a **422 refusal** at run-creation time |
| `model` | only from that same registry | with no row it never raises — it is silently filled from `settings.agent_default_model`, which is **`moonshotai/kimi-k3`**. Omitting the model would not resolve this plugin's choice; it would quietly swap Opus 5 for another vendor's model in the reconciling stage |
| `max_turns` / `timeout_seconds` | **no — nowhere at all** | `agent_runtime.loop.RunLimits.from_snapshot` reads both straight from the snapshot and substitutes `DEFAULT_TIMEOUT_SECONDS = 120.0` for whatever is absent. That substitution *is* the 120s clock #160 measured. The registry row has a `timeout_seconds` column and `internal_agents.py` never copies it into the snapshot |

So registering an agent row would **relocate** the frozen copy into another admin-editable record seeded by another script, not remove it — and would still leave the limits frozen. The snapshot stays; what changes is that its staleness is no longer silent.

## The three checks, and which document each reads

1. **`pipeline.synthesis_config_drift`** — reads the `definition_snapshot` of the synthesis run that **actually ran** (what Core recorded and the runtime billed) and compares it with `research_synthesis_definition`. Logged at ERROR on every terminal chain, including the failure path, naming the re-seed command. No token, no operator: it fires by itself, in the environment where it is wrong. This is the guard that reads the document that acts (biffo-template#1362's class) — `AgentRunView` now carries `definition_snapshot`, and `_CoreAgentGateway` populates it from Core's `AgentRunResponse` with no extra HTTP call.
2. **`seed_fan_in_workflow.py --check`** — reads the **deployed** definition through Core's API and diffs the whole `action_config`. `0` in step · `1` stale or not seeded · `2` cannot tell (an unreadable Core is never a pass). Needs an admin token, so it is an ops command rather than a CI gate. A seeding run *without* `--replace` also no longer answers "Already seeded" over a stale deployment — it prints what differs and exits 1.
3. **`SEEDED_CONFIG_FINGERPRINT`** — pins the whole `action_config`, per key, enumerated from the config itself. Changing the synthesis model, prompt, tool schema, turn budget or wall clock now goes **red in the PR that changes it**, with the re-seed command in the failure message. It speaks only for this repo and says so: it cannot prove anybody re-seeded anything.

## Path and duplicate check (asked for alongside)

`_DEFINITIONS_PATH` is still Core's real mount, `/api/v1/orchestration/workflows` (#61's fix), and a re-seed **replaces**: `list_workflows` returns every definition for the tenant unpaginated, the script matches on `name`, and `PUT /workflows/{id}` replaces the whole `action_config`. A new test drives `--replace` and asserts the second call is that `PUT`, not a `POST` — a POST would create a second definition of the same name and the fan-in would fire twice per chain.

## Tests fail first

Source stashed, tests kept — 40 failures:

```
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_config_drift_catches_the_exact_pair_that_was_frozen_on_dev
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_the_seeded_config_fingerprint_is_pinned_to_this_checkout
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_the_fingerprint_covers_every_key_of_the_snapshot[model]
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_the_fingerprint_covers_every_key_of_the_snapshot[timeout_seconds]
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_check_exits_one_on_the_config_that_was_really_deployed
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_check_exits_two_when_core_cannot_be_read
FAILED tests/test_marketing_seed_fan_in_workflow.py::test_a_seeding_run_no_longer_calls_a_stale_deployment_done
FAILED tests/test_marketing_pipeline_orchestration.py::test_synthesis_config_drift_names_both_the_model_and_the_clock
FAILED tests/test_marketing_pipeline_orchestration.py::test_advance_research_reports_the_stale_config_that_actually_ran
FAILED tests/test_marketing_pipeline_orchestration.py::test_advance_research_reports_drift_on_the_run_that_died_on_the_short_clock
FAILED tests/test_marketing_agent_gateway.py::test_get_agent_run_carries_the_definition_snapshot_onto_the_view
... (40 failed, 41 passed in 0.76s — full list in the session log)
```

With the fix restored:

```
728 passed, 4 warnings in 6.48s
```

Plus `ruff check` / `ruff format --check` / `pyright` clean, and web-admin `lint`/`typecheck`/`test`/`build` all exit 0.

## Not done here, deliberately

- **The re-seed itself** is an operational action against tabsii dev and is left to the operator:
  ```
  CORE_API_URL=https://<api-id>.execute-api.<region>.amazonaws.com \
  ADMIN_BEARER_TOKEN=<admin token> \
  uv run python scripts/seed_fan_in_workflow.py --replace
  # then read it back:
  CORE_API_URL=... ADMIN_BEARER_TOKEN=... \
  uv run python scripts/seed_fan_in_workflow.py --check
  ```
- **`src/marketing/definitions.py` is untouched** — it already declares `claude-opus-5` and 240s; the defect was entirely in the copy, and #159 holds that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)