### PR TITLE
fix(channel-plan): stop ordering a search the run has no tool for, and let a failed stage be re-run

### DIFF
--- a/scripts/seed_fan_in_workflow.py
+++ b/scripts/seed_fan_in_workflow.py
@@ -204,7 +204,7 @@ def config_fingerprint(config: dict[str, Any]) -> str:
 #: anything. Nothing inside this repo can know that — only ``--check`` against
 #: a live Core, or ``marketing.pipeline.synthesis_config_drift`` reading a real
 #: run's ``definition_snapshot``, can.
-SEEDED_CONFIG_FINGERPRINT = "sha256:cb3c731624d6c34e"
+SEEDED_CONFIG_FINGERPRINT = "sha256:31883429cd45ebe4"
 
 
 def config_drift(

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -598,6 +598,41 @@ finding on your angle, say so by returning nothing; but if a source does
 support one, it must appear with its URL.
 """
 
+#: What EVERY grounded (``:online``) stage is told about its own retrieval
+#: (issue #159), stated in the past tense because that is what is true.
+#:
+#: No agent in this plugin has a search tool — every ``*_definition`` below
+#: returns ``tools: []``, deliberately (a registered-but-unconfigured
+#: ``web_search`` is silently dropped rather than failed). Retrieval, where it
+#: happens at all, is the ``:online`` suffix: the provider searches **once**,
+#: from the run's input payload, **before** the model is invoked (#101). An
+#: agent therefore cannot search on purpose at any point, on any turn.
+#:
+#: **A prompt that orders one anyway has cost this plugin two live defects.**
+#: ``_EVIDENCE_RULE`` below records the first: research was told to "search the
+#: web for current material", could not, and took the escape hatch that
+#: followed — 10 sources retrieved on every run, none cited, twice
+#: consecutively (dev, 2026-08-12). Issue #155 then wrote the same shape into
+#: ``CHANNEL_PLAN_INSTRUCTIONS`` ("**you also have live web search, and you
+#: are expected to use it**", "search before you decide"), and the second
+#: instance was worse than the first: on dev 2026-08-14 the run completed in
+#: 16.6s of a 240s budget, billed $0.1344, and called no tool at all —
+#: ``the channel-plan run produced no submit_channel_plan tool call`` (#159).
+#:
+#: So this is one shared constant rather than a sentence each prompt is
+#: trusted to remember, and
+#: ``tests/test_marketing_output_tool_call.py`` sweeps every ``:online``
+#: stage for it — and every stage, grounded or not, for the imperative mood
+#: that caused both incidents.
+RETRIEVAL_ALREADY_RAN_RULE = """\
+Your input begins with a `search_query`: the text the retrieval you were
+given was derived from. **That search has already run.** Its results are in
+the material in front of you, and there is no search tool on this run — you
+cannot issue another search, and nothing you write will trigger one. So
+"let me search first" is not a step available to you, and "I need to search
+before I can answer" is not an answer this run is able to deliver.
+"""
+
 #: What each research agent is told about the retrieval it was handed.
 #:
 #: The two angles used to be expressed ONLY in these instructions, which the
@@ -612,14 +647,52 @@ support one, it must appear with its URL.
 #: and sent as the *first* key of the payload, so the two agents genuinely
 #: search different things. This rule tells the model that, so it does not
 #: re-derive the other angle's ground from its own material.
-_RETRIEVAL_SCOPE_RULE = """\
-Your input begins with a `search_query`: the text the retrieval you were
-given was derived from. It is scoped to YOUR angle and deliberately differs
-from the other researcher's, so the pages in front of you are not the pages
-in front of them. Work your own angle from your own material — the other
-angle is covered by someone else, and restating the market's top-level facts
+_RETRIEVAL_SCOPE_RULE = f"""\
+{RETRIEVAL_ALREADY_RAN_RULE}
+That query is scoped to YOUR angle and deliberately differs from the other
+researcher's, so the pages in front of you are not the pages in front of
+them. Work your own angle from your own material — the other angle is
+covered by someone else, and restating the market's top-level facts
 duplicates their work instead of adding to it.
 """
+
+
+def return_via_tool(tool_name: str) -> str:
+    """The closing rule every agent in this pipeline ends on (issue #159).
+
+    Each stage already ended with "Return your answer by calling the `X` tool
+    exactly once. Do not answer in prose." What none of them said is what
+    happens when the model decides it has **nothing** to return — and four of
+    the six explicitly invite exactly that ("return empty lists rather than
+    inventing content", "return fewer channels (or none)", "return an empty
+    findings list", "say so in the summary").
+
+    An operator cannot tell those two outcomes apart, because both are a 502.
+    But one of them carries a sentence they can act on ("The research run
+    fetched zero URLs... try running research again") and the other carries
+    only ``produced no submit_channel_plan tool call`` — a stage that ran, and
+    billed, and left nothing behind. The difference between them is a single
+    tool call, so the prompt now says in as many words that the empty answer
+    travels the same way every other answer does.
+
+    Generated per tool rather than written out five times so a stage cannot
+    end up naming another stage's tool, which would be worse than silence.
+    """
+    return f"""\
+Return your answer by calling the `{tool_name}` tool exactly once, and answer
+only that way. Do not reply in prose — not to explain what you would need,
+not to report that what you were given was too thin, and not to ask for
+anything before you begin.
+
+**Having nothing to report is still an answer, and it is delivered the same
+way.** If the material in front of you supports nothing, call `{tool_name}`
+with empty lists and let that be the answer; the operator is shown an empty
+artefact and can act on it. A run that ends without calling `{tool_name}`
+produces no artefact at all — the operator sees a failed stage and a sentence
+about a missing tool call, and every word you wrote instead is discarded
+unread.
+"""
+
 
 AUDIENCE_RESEARCH_INSTRUCTIONS = f"""\
 You are the campaign studio's audience researcher. Your angle is who this
@@ -637,9 +710,7 @@ Prioritise:
 {_RETRIEVAL_SCOPE_RULE}
 {_EVIDENCE_RULE}
 {_UNTRUSTED_INPUT_RULE}
-Return your findings by calling the `{FINDINGS_TOOL_NAME}` tool exactly once.
-Do not answer in prose.
-"""
+{return_via_tool(FINDINGS_TOOL_NAME)}"""
 
 COMPETITIVE_RESEARCH_INSTRUCTIONS = f"""\
 You are the campaign studio's competitive researcher. Your angle is what
@@ -656,9 +727,7 @@ Prioritise:
 {_RETRIEVAL_SCOPE_RULE}
 {_EVIDENCE_RULE}
 {_UNTRUSTED_INPUT_RULE}
-Return your findings by calling the `{FINDINGS_TOOL_NAME}` tool exactly once.
-Do not answer in prose.
-"""
+{return_via_tool(FINDINGS_TOOL_NAME)}"""
 
 RESEARCH_SYNTHESIS_INSTRUCTIONS = f"""\
 You are the campaign studio's research analyst. You are given the campaign
@@ -681,9 +750,7 @@ invent findings to fill the gap; an operator reviewing this artefact needs to
 know the research came back empty, not read a summary that hides it.
 
 {_UNTRUSTED_INPUT_RULE}
-Return your answer by calling the `{RESEARCH_SYNTHESIS_TOOL_NAME}` tool
-exactly once. Do not answer in prose.
-"""
+{return_via_tool(RESEARCH_SYNTHESIS_TOOL_NAME)}"""
 
 POSITIONING_INSTRUCTIONS = f"""\
 You are the campaign studio's positioning strategist. You are given one
@@ -719,9 +786,7 @@ If the research is too thin to support any segment, pillar or CTA, return
 empty lists rather than inventing content to fill them.
 
 {_UNTRUSTED_INPUT_RULE}
-Return your answer by calling the `{POSITIONING_TOOL_NAME}` tool exactly
-once. Do not answer in prose.
-"""
+{return_via_tool(POSITIONING_TOOL_NAME)}"""
 
 CHANNEL_PLAN_INSTRUCTIONS = f"""\
 You are the campaign studio's channel strategist. You are given one
@@ -730,17 +795,18 @@ calls to action, each carrying the sources that support it — a
 `campaign_motion` (`organic`, `paid` or `both`), and one **channel
 taxonomy**: a list of `{{channel_key, label, motion, category}}` entries.
 
-**You also have live web search, and you are expected to use it.** The
-positioning you were given answers a different question from yours. It was
-researched to establish who this audience is and what competitors say to
-them; you are deciding where this audience actually converts. Its sources
-cannot answer that, and a channel plan justified entirely by them is the
-failure this stage was rebuilt to end.
+**Live conversion evidence has already been retrieved for you, and it is
+what you decide from.** The positioning you were given answers a different
+question from yours. It was researched to establish who this audience is and
+what competitors say to them; you are deciding where this audience actually
+converts. Its sources cannot answer that, and a channel plan justified
+entirely by them is the failure this stage was rebuilt to end.
 
-## Search for conversion evidence, not for description
+## The retrieval in front of you is about conversion, not description
 
-Search before you decide, and search for the numbers a media planner would
-ask for:
+{RETRIEVAL_ALREADY_RAN_RULE}
+That query was aimed at the numbers a media planner would ask for, so those
+are what to look for in the pages you were given:
 
 - Where this audience demonstrably **converts** — not where it merely has
   attention. Intent expressed beats attention observed.
@@ -751,10 +817,10 @@ ask for:
 - Channel **economics and saturation** for this segment: what it costs to be
   seen there now, and what that buys.
 
-Prefer the specific page carrying the number — a benchmark report, a results
-write-up, a case study — over a vendor home page or an agency's "top 10
-channels" listicle. A retrieved page of generic channel wisdom is still
-generic channel wisdom; it has simply been fetched.
+Among the pages you were given, prefer the specific one carrying the number —
+a benchmark report, a results write-up, a case study — over a vendor home
+page or an agency's "top 10 channels" listicle. A retrieved page of generic
+channel wisdom is still generic channel wisdom; it has simply been fetched.
 
 **The taxonomy you are given is not the whole taxonomy.** It is the set of
 channels the operator selected for this campaign, already narrowed to the
@@ -792,8 +858,8 @@ around checking the list first, and never to re-propose a channel the
 operator has already left out for a reason you cannot see.
 
 Rank the channels within each motion (1 = highest priority) and give each a
-rationale an operator can disagree with: name the conversion evidence you
-found — the figure, the comparable campaign, the observed intent — and name
+rationale an operator can disagree with: name the conversion evidence in the
+retrieval — the figure, the comparable campaign, the observed intent — and name
 which segment, pillar or CTA it serves. Rank on what the evidence says
 converts, not on what is conventionally listed first. A channel recommendation
 with no evidence behind it is the most confident-sounding fabrication in this
@@ -807,38 +873,40 @@ rationale.
 Every recommendation must carry `sources`, and a `url` may come from exactly
 two places:
 
-1. **Your own search results** — copied exactly as the result gives it,
-   character for character. Do not tidy a URL, do not shorten it, and do not
-   cite a link you saw quoted *inside* a page rather than in your results.
+1. **The retrieval you were given** — the pages returned for this run's
+   `search_query`, copied exactly as they appear, character for character. Do
+   not tidy a URL, do not shorten it, and do not cite a link you saw quoted
+   *inside* a page rather than in the retrieval itself.
 2. **The positioning you were given** — the `url` of a `Source` on a segment,
    pillar or CTA, again exactly as written.
 
-Both are checked mechanically, against the runtime's own record of what your
-search actually returned and against the positioning you were given. A `url`
-in neither is rejected and the whole plan fails with it, so a plausible-looking
-source you did not read is worse than a recommendation you leave out.
+Both are checked mechanically, against the runtime's own record of what the
+retrieval actually returned and against the positioning you were given. A
+`url` in neither is rejected and the whole plan fails with it, so a
+plausible-looking source you did not read is worse than a recommendation you
+leave out.
 
-**Every recommendation needs at least one source from your own search
-results.** This is checked per recommendation, not across the plan: a channel
-justified only by positioning's sources is justified by evidence about a
-different question, and is rejected along with the whole plan. If you searched
-and found nothing about a channel's performance for this audience, do not
-recommend that channel — say nothing rather than reach for the positioning to
-dress it up.
+**Every recommendation needs at least one source from this run's own
+retrieval.** This is checked per recommendation, not across the plan: a
+channel justified only by positioning's sources is justified by evidence
+about a different question, and is rejected along with the whole plan. If the
+retrieval in front of you says nothing about a channel's performance for this
+audience, do not recommend that channel — leave it out rather than reach for
+the positioning to dress it up.
 
 For `note`, do not paste the positioning item's note verbatim — your
 `rationale` already says why this channel follows from the evidence, so repeat
 only what a `note` genuinely adds beyond that, or leave it empty.
 
-If your search turns up nothing that supports any recommendation in a motion,
-return fewer channels (or none) for that motion rather than inventing content
-to fill it — a channel plan that recommends nothing beats one that recommends
-plausibly.
+If the retrieval supports no recommendation in a motion, return fewer channels
+(or none) for that motion rather than inventing content to fill it — a channel
+plan that recommends nothing beats one that recommends plausibly. And if it
+supports nothing at all, return an empty plan **by calling the tool**, exactly
+as the closing rule below says: an empty plan tells the operator the retrieval
+came back thin, whereas no tool call tells them only that the stage broke.
 
 {_UNTRUSTED_INPUT_RULE}
-Return your answer by calling the `{CHANNEL_PLAN_TOOL_NAME}` tool exactly
-once. Do not answer in prose.
-"""
+{return_via_tool(CHANNEL_PLAN_TOOL_NAME)}"""
 
 # Bound to short names purely so the length rules read as numbers inside
 # `COPY_INSTRUCTIONS`'s f-string. The values are `COPY_LENGTH_BUDGET`'s — the
@@ -922,9 +990,7 @@ plan you were given: a `url` that appears in neither is rejected and the
 whole copy set fails with it.
 
 {_UNTRUSTED_INPUT_RULE}
-Return your answer by calling the `{COPY_TOOL_NAME}` tool exactly once. Do
-not answer in prose.
-"""
+{return_via_tool(COPY_TOOL_NAME)}"""
 
 #: Keyed by research agent name, in ``RESEARCH_AGENT_NAMES`` order — the
 #: pipeline looks each one up rather than duplicating the pairing.

--- a/tests/test_marketing_channel_plan_grounding.py
+++ b/tests/test_marketing_channel_plan_grounding.py
@@ -203,10 +203,22 @@ def test_the_prompt_no_longer_tells_the_agent_it_has_no_web_access() -> None:
 def test_the_prompt_asks_for_conversion_evidence_specifically() -> None:
     """Not "search the web" — the whole point is *which* question the search
     answers. Generic channel wisdom retrieved live is still generic channel
-    wisdom."""
+    wisdom.
+
+    The second assertion used to read ``"search results" in lowered``, when
+    the prompt spoke of "your own search results". Issue #159 changed the
+    *mood*, not the requirement: the agent has no search tool and never had
+    one (``tools: []``; the provider searches from the payload before the
+    model is invoked, #101), so a prompt phrased as though it could go and
+    search left it with an unsatisfiable precondition — and on dev
+    2026-08-14 it answered in prose and called no tool at all. The evidence
+    the plan must rest on is unchanged; it is now named as the retrieval this
+    run was *handed*. See ``tests/test_marketing_output_tool_call.py`` for
+    the sweep that keeps the imperative from coming back.
+    """
     lowered = CHANNEL_PLAN_INSTRUCTIONS.lower()
     assert "convert" in lowered
-    assert "search results" in lowered
+    assert "retrieval" in lowered
 
 
 def test_the_turn_budget_leaves_room_to_search_and_then_answer() -> None:

--- a/tests/test_marketing_output_tool_call.py
+++ b/tests/test_marketing_output_tool_call.py
@@ -1,0 +1,340 @@
+"""A run that ends without calling its output tool produces nothing (issue #159).
+
+On tabsii dev, 2026-08-14, the channel-plan stage failed with
+``the channel-plan run produced no submit_channel_plan tool call (502)``. The
+run itself **completed**: 16.6s against a 240s budget, no clamp warning,
+``anthropic/claude-sonnet-4:online``, $0.1344 billed. It ran, it cost money,
+and it answered in prose.
+
+## Why this module exists rather than one more assertion in the grounding suite
+
+The same defect has now happened twice in this plugin, in two different
+prompts, and the second time was written by the fix for the first.
+
+``_EVIDENCE_RULE``'s own docstring records the first: research's rule "used to
+say 'search the web for current material', which is an instruction the model
+cannot follow, immediately followed by an escape hatch for when it finds
+nothing — and it took the escape hatch". Measured on dev 2026-08-12,
+retrieval returned 10 sources on every run and the model cited none of them,
+twice consecutively.
+
+Issue #155 then rebuilt ``CHANNEL_PLAN_INSTRUCTIONS`` around exactly that
+shape again — "**You also have live web search, and you are expected to use
+it**", "Search before you decide", "If you searched and found nothing about a
+channel's performance for this audience, do not recommend that channel — say
+nothing rather than reach for the positioning" — against a definition that
+declares ``tools: []`` and a provider that searches **once, from the payload,
+before the model is invoked** (#101). The agent is ordered to take a step it
+has no tool for, and then handed a licence to produce nothing when that step
+does not happen.
+
+Research took the escape hatch and returned an empty artefact. Channel
+planning went one worse and did not call the tool at all, because nothing in
+its prompt ever said that "recommend nothing" is still delivered *by calling
+the tool*.
+
+So the rules pinned here are stage-agnostic on purpose. Both of them are
+properties of the whole pipeline, not of one prompt:
+
+1. **No agent is ordered to perform a search it has no tool for.** Every
+   definition in this plugin declares ``tools: []``; retrieval, where it
+   happens at all, is the ``:online`` suffix doing it before the model runs.
+2. **Every agent is told that having nothing to say is still delivered by
+   calling its output tool.** A stage's honest "I found nothing" and its
+   catastrophic "no artefact at all" are the same 502 to an operator, and
+   only the first is recoverable by reading it.
+
+Whether the agent then *does* reliably call the tool is only observable on a
+live run — these guards claim no more than that the prompt no longer asks for
+the impossible and no longer leaves silence as a legal answer.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+import pytest
+
+from marketing import pipeline
+from marketing.definitions import (
+    AUDIENCE_RESEARCH_INSTRUCTIONS,
+    CHANNEL_PLAN_INSTRUCTIONS,
+    CHANNEL_PLAN_TOOL_NAME,
+    COMPETITIVE_RESEARCH_INSTRUCTIONS,
+    COPY_INSTRUCTIONS,
+    COPY_TOOL_NAME,
+    DEFAULT_CHANNEL_PLAN_MODEL,
+    DEFAULT_COPY_MODEL,
+    DEFAULT_POSITIONING_MODEL,
+    DEFAULT_RESEARCH_MODEL,
+    DEFAULT_SYNTHESIS_MODEL,
+    FINDINGS_TOOL_NAME,
+    POSITIONING_INSTRUCTIONS,
+    POSITIONING_TOOL_NAME,
+    RESEARCH_SYNTHESIS_INSTRUCTIONS,
+    RESEARCH_SYNTHESIS_TOOL_NAME,
+    channel_plan_definition,
+    copy_definition,
+    positioning_definition,
+    research_definition,
+    research_synthesis_definition,
+)
+
+#: Every agent this plugin runs: its instructions, the model it runs on, the
+#: output tool it must call, and the definition it is dispatched with.
+#:
+#: Assembled once here rather than per test so a sixth stage is one row, not a
+#: sixth place to remember. Every rule below sweeps ALL of it — the two
+#: defects this module exists for were each written into one prompt while
+#: the others were fine, which is exactly the shape a per-stage assertion
+#: misses.
+_STAGES: dict[str, tuple[str, str, str, dict[str, Any]]] = {
+    "research_audience": (
+        AUDIENCE_RESEARCH_INSTRUCTIONS,
+        DEFAULT_RESEARCH_MODEL,
+        FINDINGS_TOOL_NAME,
+        research_definition(model=DEFAULT_RESEARCH_MODEL, instructions="i"),
+    ),
+    "research_competitive": (
+        COMPETITIVE_RESEARCH_INSTRUCTIONS,
+        DEFAULT_RESEARCH_MODEL,
+        FINDINGS_TOOL_NAME,
+        research_definition(model=DEFAULT_RESEARCH_MODEL, instructions="i"),
+    ),
+    "synthesis": (
+        RESEARCH_SYNTHESIS_INSTRUCTIONS,
+        DEFAULT_SYNTHESIS_MODEL,
+        RESEARCH_SYNTHESIS_TOOL_NAME,
+        research_synthesis_definition(model=DEFAULT_SYNTHESIS_MODEL, instructions="i"),
+    ),
+    "positioning": (
+        POSITIONING_INSTRUCTIONS,
+        DEFAULT_POSITIONING_MODEL,
+        POSITIONING_TOOL_NAME,
+        positioning_definition(model=DEFAULT_POSITIONING_MODEL, instructions="i"),
+    ),
+    "channel_plan": (
+        CHANNEL_PLAN_INSTRUCTIONS,
+        DEFAULT_CHANNEL_PLAN_MODEL,
+        CHANNEL_PLAN_TOOL_NAME,
+        channel_plan_definition(model=DEFAULT_CHANNEL_PLAN_MODEL, instructions="i"),
+    ),
+    "copy": (
+        COPY_INSTRUCTIONS,
+        DEFAULT_COPY_MODEL,
+        COPY_TOOL_NAME,
+        copy_definition(model=DEFAULT_COPY_MODEL, instructions="i"),
+    ),
+}
+
+
+# ── 1. Nothing is ordered to search ─────────────────────────────────────────
+
+
+def test_no_agent_in_this_pipeline_has_a_search_tool_to_be_ordered_to_use() -> None:
+    """The premise every rule below rests on, asserted rather than assumed.
+
+    Retrieval in this plugin is the `:online` suffix, which the provider
+    applies to the *payload* before the model is invoked (#101) — never a
+    registry tool, because a registered-but-unconfigured `web_search` is
+    silently dropped rather than failed. So no agent here can search on
+    purpose, at any point, on any turn.
+    """
+    for stage, (_instructions, _model, _tool, definition) in _STAGES.items():
+        assert definition["tools"] == [], (
+            f"{stage} declares a registry tool; every rule in this module assumes "
+            "retrieval travels with the model id, never as a tool the agent calls"
+        )
+
+
+#: Phrasings that order the model to go and search — the shape
+#: `_EVIDENCE_RULE`'s docstring says research took the escape hatch on, and
+#: that #155 wrote back into the channel-plan prompt.
+#:
+#: Matched as regexes over the lowered prompt rather than as an exact list of
+#: sentences, because the defect is the *mood* of the instruction (an
+#: imperative, or a claim of a capability) rather than any one wording.
+_ORDERS_A_SEARCH = (
+    r"\bsearch before you\b",
+    r"\byou (also )?have live web search\b",
+    r"\bexpected to use it\b",
+    r"\bif you searched\b",
+    r"\byour own search results\b",
+    r"\bgo and search\b",
+    r"\bsearch the web\b",
+)
+
+
+@pytest.mark.parametrize("stage", sorted(_STAGES))
+def test_no_stage_is_ordered_to_run_a_search_it_has_no_tool_for(stage: str) -> None:
+    """The first half of #159, and a defect this plugin has now shipped twice.
+
+    An agent told to search, on a run with no search tool, has been given an
+    unsatisfiable precondition for its own answer. Research's version of this
+    produced empty artefacts; channel planning's produced no tool call at all.
+    Describing the retrieval in the past tense costs nothing and removes the
+    precondition entirely.
+    """
+    instructions, _model, _tool, _definition = _STAGES[stage]
+    lowered = instructions.lower()
+    offenders = [pattern for pattern in _ORDERS_A_SEARCH if re.search(pattern, lowered)]
+    assert offenders == [], (
+        f"{stage}'s instructions order a search the run cannot perform "
+        f"({offenders}). Retrieval here happens once, from the payload, before "
+        "the model is invoked (#101) — say what was retrieved FOR it, never "
+        "what it should go and retrieve."
+    )
+
+
+#: The sentence a grounded stage must carry, quoted rather than imported so
+#: this module still imports (and still fails, legibly) against a tree where
+#: the rule does not exist yet. `test_the_already_ran_sentence_is_the_one_the
+#: _prompt_ships` below is what stops the quote and the constant drifting.
+_ALREADY_RAN_SENTENCE = "That search has already run."
+
+
+@pytest.mark.parametrize("stage", sorted(_STAGES))
+def test_every_grounded_stage_is_told_its_search_has_already_run(stage: str) -> None:
+    """The positive form of the rule above: a stage on an `:online` route DOES
+    have retrieved pages in front of it, and must be told so in as many words.
+
+    Not decoration. A model that believes it still has to search, and cannot,
+    has two options — answer from weights (which is #65) or explain the
+    problem in prose (which is #159). Telling it the results are already here
+    removes both.
+    """
+    instructions, model, _tool, _definition = _STAGES[stage]
+    if not model.endswith(":online"):
+        pytest.skip(f"{stage} does not retrieve, so it has no retrieval to describe")
+    assert _ALREADY_RAN_SENTENCE in instructions, (
+        f"{stage} runs on a grounded route but is never told that its retrieval "
+        "already happened — see `RETRIEVAL_ALREADY_RAN_RULE`"
+    )
+
+
+def test_the_already_ran_sentence_is_the_one_the_prompt_ships() -> None:
+    """Drift guard for the quoted literal above: the sentence this module
+    checks for must be the sentence the shared rule actually contains, or
+    every assertion above quietly stops meaning anything."""
+    from marketing.definitions import RETRIEVAL_ALREADY_RAN_RULE
+
+    assert _ALREADY_RAN_SENTENCE in RETRIEVAL_ALREADY_RAN_RULE
+
+
+# ── 2. Silence is never a legal answer ──────────────────────────────────────
+
+
+#: Quoted for the same reason `_ALREADY_RAN_SENTENCE` is, and pinned against
+#: the real rule by the drift test below.
+_EMPTY_IS_STILL_AN_ANSWER = "Having nothing to report is still an answer"
+
+
+@pytest.mark.parametrize("stage", sorted(_STAGES))
+def test_every_stage_is_told_that_having_nothing_to_say_still_means_calling_the_tool(
+    stage: str,
+) -> None:
+    """The second half of #159, and the half that is not specific to search.
+
+    Four of these six prompts already grant an explicit licence to return
+    nothing — "return empty lists rather than inventing content", "return
+    fewer channels (or none)", "return an empty findings list". Not one of
+    them said how an empty answer is *delivered*, and the delivery is the
+    whole difference between an artefact an operator can read ("the research
+    came back empty") and a dead stage they cannot ("produced no
+    submit_channel_plan tool call").
+    """
+    instructions, _model, _tool, _definition = _STAGES[stage]
+    assert _EMPTY_IS_STILL_AN_ANSWER in instructions, (
+        f"{stage} tells the model it may have nothing to report, but never that "
+        "an empty answer is still delivered by calling the output tool — see "
+        "`return_via_tool`"
+    )
+
+
+@pytest.mark.parametrize("stage", sorted(_STAGES))
+def test_every_stage_names_its_own_output_tool_in_that_rule(stage: str) -> None:
+    """The rule is generated per tool, so a stage cannot inherit another
+    stage's tool name — the failure that would make the instruction actively
+    wrong rather than merely absent."""
+    from marketing.definitions import return_via_tool
+
+    instructions, _model, tool, _definition = _STAGES[stage]
+    assert return_via_tool(tool) in instructions
+
+
+def test_the_empty_answer_sentence_is_the_one_the_prompt_ships() -> None:
+    """Drift guard, as above."""
+    from marketing.definitions import return_via_tool
+
+    assert _EMPTY_IS_STILL_AN_ANSWER in return_via_tool("submit_anything")
+
+
+# ── 3. The live failure's own shape, pinned ─────────────────────────────────
+#
+# These two do NOT fail before the fix — the extraction path behaved correctly
+# on 2026-08-14 and still does. They are here because "the run completed and
+# returned prose" is the shape the whole module is about, and nothing else in
+# this repo reproduces it end to end: `test_marketing_channel_plan_grounding`
+# always hands `extract_channel_plan` a tool call.
+
+
+class _CompletedWithProse:
+    """A gateway whose channel-plan run completes, successfully, having said
+    something reasonable-sounding and called nothing."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    async def request_agent_run(self, **_kwargs: Any) -> str:
+        return "run-1"
+
+    async def find_chain_run(self, **_kwargs: Any) -> pipeline.AgentRunView | None:
+        return None
+
+    async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView:
+        return pipeline.AgentRunView(
+            id=run_id,
+            status="completed",
+            messages=[{"role": "assistant", "content": self._text}],
+            annotations=[{"type": "url_citation", "url": "https://benchmarks.example.com/cpa"}],
+        )
+
+
+_TAXONOMY: dict[str, Literal["organic", "paid"]] = {"google_search_paid": "paid"}
+
+
+@pytest.mark.asyncio
+async def test_a_completed_run_that_answered_in_prose_is_refused_not_accepted() -> None:
+    """The 502 an operator saw, reproduced against the plugin's own fakes.
+
+    The run is `completed` and `succeeded` — this is NOT the failed-run path
+    (`RunNotSucceededError`), which is why the agent-runs page showed a green
+    row next to a red stage. The artefact is refused on the only thing that
+    was actually missing: the tool call.
+    """
+    gateway = _CompletedWithProse(
+        "I'd need conversion benchmarks for this audience before I could "
+        "recommend channels responsibly. Here is what I would look for..."
+    )
+
+    with pytest.raises(pipeline.MalformedOutputError) as raised:
+        await pipeline.advance_channel_plan(
+            gateway,  # type: ignore[arg-type]
+            run_id="run-1",
+            taxonomy=_TAXONOMY,
+        )
+
+    assert str(raised.value) == (
+        f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_prose_failure_is_a_pipeline_error_so_it_reaches_the_operator() -> None:
+    """`MalformedOutputError` is a `PipelineError`, so `admin_app.
+    _pipeline_error_to_http` maps it to a 502 carrying the sentence rather
+    than to a bare 500 — which is what makes the stuck stage's reason
+    readable at all, and what the retry control in `PipelineStage` keys off.
+    """
+    assert issubclass(pipeline.MalformedOutputError, pipeline.PipelineError)

--- a/web-admin/src/components/Pipeline.test.tsx
+++ b/web-admin/src/components/Pipeline.test.tsx
@@ -325,6 +325,11 @@ describe('Pipeline', () => {
       // escape hatch is exactly what is still offered.
       expect(within(research).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
       expect(within(research).queryByRole('button', { name: /^start research/i })).not.toBeInTheDocument()
+      // #159: "not startable" must not mean "not restartable". The stage keeps
+      // its badge and its reason; what it gains is an explicitly-labelled
+      // re-run, which is a different control from the plain "Start" this
+      // deliberately still withholds.
+      expect(within(research).getByRole('button', { name: /run research again/i })).toBeInTheDocument()
     })
 
     it('keeps the stage rendered WHILE a poll is in flight, not just after it (#147)', async () => {
@@ -410,5 +415,170 @@ describe('Pipeline', () => {
       vi.useRealTimers()
     })
 
+  })
+
+  /** Issue #159. On tabsii dev the channel-plan stage 502'd with "the
+   * channel-plan run produced no submit_channel_plan tool call", and then sat
+   * at `Running…` for ever: the reason was shown (#85/#86, correct) but the
+   * only control left was "Check for result", which re-reads the same dead
+   * run and returns the same 502 for as long as anyone keeps pressing it.
+   *
+   * The artefact is still `pending` because that is exactly what happened —
+   * the stage never produced anything to move it on — so no amount of
+   * re-reading changes it. What resolves it is starting a NEW run, and the
+   * route already allows that (a fresh `pending` artefact sorts ahead of this
+   * one, `admin_app._latest_artefact`). Only the UI was missing the button.
+   */
+  describe('a pending stage whose run has already failed (#159)', () => {
+    /** Positioning approved and targeting set, so the channel-plan gate is
+     * open; channel plan `pending` on first read and then answering every
+     * subsequent poll with `laterResponse`. */
+    function channelPlanFetchStub(laterResponse: { status: number; body: unknown }) {
+      let reads = 0
+      return vi.fn((url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET'
+        if (url.endsWith('/artefacts/channel_plan') && method === 'GET') {
+          reads += 1
+          if (reads === 1) {
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                id: 'a-channel_plan',
+                campaign_id: CAMPAIGN,
+                kind: 'channel_plan',
+                status: 'pending',
+                body: null,
+                citations: null,
+                causation_id: null,
+                agent_run_id: 'run-1',
+              }),
+            })
+          }
+          return Promise.resolve({
+            ok: false,
+            status: laterResponse.status,
+            json: async () => laterResponse.body,
+          })
+        }
+        if (url.endsWith('/artefacts/positioning') && method === 'GET') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: 'a-positioning',
+              campaign_id: CAMPAIGN,
+              kind: 'positioning',
+              status: 'approved',
+              body: JSON.stringify({ segments: [], pillars: [], ctas: [] }),
+              citations: null,
+              causation_id: null,
+              agent_run_id: null,
+            }),
+          })
+        }
+        if (url.endsWith('/channel-plan') && method === 'POST') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: 'a-channel_plan-2',
+              campaign_id: CAMPAIGN,
+              kind: 'channel_plan',
+              status: 'pending',
+              body: null,
+              citations: null,
+              causation_id: null,
+              agent_run_id: 'run-2',
+            }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+      })
+    }
+
+    /** Renders with the channel-plan stage `pending`, then lets one poll land
+     * on `status`/`detail`.
+     *
+     * Fake timers are installed BEFORE render, for the reason the #147 test
+     * above spells out: the heartbeat is created by an effect, so installing
+     * them afterwards leaves a real-timer interval `advanceTimersByTime`
+     * cannot drive — the poll never fires and the assertions pass or fail on
+     * whichever real-time race won, which is how two of these were briefly
+     * green against no code at all. */
+    async function renderUntilChannelPlanFails(status: number, detail: string) {
+      vi.useFakeTimers()
+      stubSession()
+      const fetchMock = channelPlanFetchStub({ status, body: { detail } })
+      vi.stubGlobal('fetch', fetchMock)
+
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
+
+      // Mount's own reads settle first, so the stage is `pending` and the
+      // heartbeat is running before any tick is advanced.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      const stage = screen.getByTestId('stage-channel_plan')
+      expect(within(stage).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+      return { stage, fetchMock }
+    }
+
+    it('offers a re-run when the run itself failed, so the operator is not stuck', async () => {
+      const { stage } = await renderUntilChannelPlanFails(
+        502,
+        'the channel-plan run produced no submit_channel_plan tool call',
+      )
+
+      // The reason stays visible — this does NOT revert to #86's silent
+      // "startable again", which is what hid the reason in the first place.
+      expect(within(stage).getByText(/produced no submit_channel_plan tool call/i)).toBeInTheDocument()
+      expect(within(stage).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+      expect(within(stage).getByRole('button', { name: /run channel plan again/i })).toBeEnabled()
+    })
+
+    it('actually starts a fresh run when that re-run is pressed', async () => {
+      // Driven entirely off the manual button rather than the poll, so this
+      // needs no fake timers to fight `userEvent` over — and it proves the
+      // other half of the same route: pressing "Check for result" on a dead
+      // run is what an operator does first, and it must be what reveals the
+      // re-run rather than something only the background poll can surface.
+      stubSession()
+      const fetchMock = channelPlanFetchStub({
+        status: 502,
+        body: { detail: 'the channel-plan run produced no submit_channel_plan tool call' },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      const user = userEvent.setup()
+
+      render(<Pipeline campaignId={CAMPAIGN} hasBrief={true} hasTargets={true} channelLookup={EMPTY_LOOKUP} />)
+      const stage = await screen.findByTestId('stage-channel_plan')
+
+      await user.click(await within(stage).findByRole('button', { name: /check for result/i }))
+      await user.click(await within(stage).findByRole('button', { name: /run channel plan again/i }))
+
+      const started = fetchMock.mock.calls.filter(
+        ([u, init]) =>
+          typeof u === 'string' && u.endsWith('/channel-plan') && (init as RequestInit)?.method === 'POST',
+      )
+      expect(started).toHaveLength(1)
+      // A fresh run, so the failure that belonged to the old one goes with it.
+      expect(within(stage).queryByText(/produced no submit_channel_plan tool call/i)).not.toBeInTheDocument()
+    })
+
+    it('does not offer a re-run for a failure that is not the run\'s own', async () => {
+      // A 403 is the operator's session, not the agent's output. Re-running
+      // would bill for a second run to fix a permissions problem — and the
+      // 502 is the one status that means "an agent ran, and what it produced
+      // is not something retrying the REQUEST fixes" (`admin_app.
+      // _pipeline_error_to_http`), which is precisely the condition a re-run
+      // is the answer to.
+      const { stage } = await renderUntilChannelPlanFails(403, 'Administrator access required')
+
+      expect(within(stage).getByText(/administrator access required/i)).toBeInTheDocument()
+      expect(within(stage).getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+      expect(within(stage).queryByRole('button', { name: /run channel plan again/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/web-admin/src/components/Pipeline.tsx
+++ b/web-admin/src/components/Pipeline.tsx
@@ -9,6 +9,7 @@ import {
   startCopy,
   startPositioning,
   startResearch,
+  StageRunFailedError,
   StaleArtefactError,
   type Artefact,
   type ArtefactKind,
@@ -31,6 +32,14 @@ interface StageState {
    * from `approveArtefact` (issue #145), never for any other failure this
    * stage can report. */
   stale: boolean
+  /** True only for a `StageRunFailedError` — the advance route's 502 (issue
+   * #159), meaning this stage's agent run reached a terminal state and what
+   * it produced cannot be turned into an artefact. Distinct from `error`,
+   * which is any failure at all: a stage can legitimately show an error
+   * (a 403, a network blip during a poll) while its run is still perfectly
+   * alive, and offering to re-run in that case would bill for a second agent
+   * run to fix something no agent caused. */
+  failed: boolean
   busy: boolean
   /** Element ids the operator has unchecked for this stage's current
    * `proposed` artefact (issue #145) — reset to empty the moment a NEW
@@ -179,6 +188,7 @@ function initialState(): Record<ArtefactKind, StageState> {
     loading: true,
     error: null,
     stale: false,
+    failed: false,
     busy: false,
     deselected: new Set<string>(),
   })
@@ -229,6 +239,10 @@ export function Pipeline({
           ...prev[kind],
           artefact,
           stale: false,
+          // A successful read is the resolution to a previous failure too
+          // (issue #159): whatever the last 502 said, this artefact is what
+          // the stage is now.
+          failed: false,
           ...(idChanged ? { deselected: new Set<string>() } : {}),
           ...extra,
         },
@@ -266,13 +280,25 @@ export function Pipeline({
    * the stage rather than in place of it.
    */
   async function load(kind: ArtefactKind, { quiet = false }: { quiet?: boolean } = {}) {
-    if (!quiet) patch(kind, { loading: true, error: null, stale: false })
+    if (!quiet) patch(kind, { loading: true, error: null, stale: false, failed: false })
     try {
       const artefact = await getArtefact(campaignId, kind)
       applyArtefact(kind, artefact, quiet ? {} : { loading: false })
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e)
-      patch(kind, quiet ? { error: message } : { loading: false, error: message, stale: false })
+      // `failed` (issue #159) is set from the error's TYPE, not from the fact
+      // that one happened — `StageRunFailedError` is the advance route's 502,
+      // the one failure another read can never clear. It is written on both
+      // the quiet and the loud path because the poll is how an operator
+      // actually finds out (#144); a failure only the manual button could
+      // reveal would leave the stage stuck for the two minutes nobody clicks.
+      const failed = e instanceof StageRunFailedError
+      patch(
+        kind,
+        quiet
+          ? { error: message, failed }
+          : { loading: false, error: message, stale: false, failed },
+      )
     }
   }
 
@@ -288,7 +314,7 @@ export function Pipeline({
   }, [campaignId])
 
   async function runMutation(kind: ArtefactKind, mutate: () => Promise<Artefact | null>) {
-    patch(kind, { busy: true, error: null, stale: false })
+    patch(kind, { busy: true, error: null, stale: false, failed: false })
     try {
       const artefact = await mutate()
       applyArtefact(kind, artefact, { busy: false })
@@ -301,6 +327,7 @@ export function Pipeline({
         busy: false,
         error: e instanceof Error ? e.message : String(e),
         stale: e instanceof StaleArtefactError,
+        failed: e instanceof StageRunFailedError,
       })
     }
   }
@@ -374,6 +401,7 @@ export function Pipeline({
             loading={s.loading}
             error={s.error}
             stale={s.stale}
+            failed={s.failed}
             canStart={gate.canStart}
             blockedReason={gate.blockedReason}
             busy={s.busy}

--- a/web-admin/src/components/PipelineStage.test.tsx
+++ b/web-admin/src/components/PipelineStage.test.tsx
@@ -86,6 +86,91 @@ describe('PipelineStage', () => {
     expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument()
   })
 
+  it('offers a re-run alongside "check for result" when the pending run has failed (#159)', async () => {
+    // `pending` + `failed` is the state a 502 from the advance route leaves
+    // behind: the run is over, the artefact never moved on, and no further
+    // read can change either fact. Without this the stage has exactly one
+    // control, and it is the one that cannot help.
+    const onStart = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <PipelineStage
+        kind="channel_plan"
+        title="Channel plan"
+        artefact={artefact('pending')}
+        loading={false}
+        error="the channel-plan run produced no submit_channel_plan tool call (502)"
+        failed={true}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={onStart}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+
+    // The badge and the reason both survive — #85/#86's requirement, which a
+    // silent revert to "startable" is exactly what broke.
+    expect(screen.getByText('Running…')).toBeInTheDocument()
+    expect(screen.getByText(/produced no submit_channel_plan tool call/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /run channel plan again/i }))
+    expect(onStart).toHaveBeenCalledOnce()
+  })
+
+  it('does not offer a re-run for a pending stage that has merely errored', () => {
+    // An error is not a failed run. A 403 or a dropped connection during a
+    // poll says nothing about the agent, and re-running would bill for a
+    // second run to fix something the first one did not cause.
+    render(
+      <PipelineStage
+        kind="channel_plan"
+        title="Channel plan"
+        artefact={artefact('pending')}
+        loading={false}
+        error="you need the admin role to load the channel plan stage (403)"
+        failed={false}
+        canStart={true}
+        blockedReason={null}
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /check for result/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /run channel plan again/i })).not.toBeInTheDocument()
+  })
+
+  it('explains why a failed pending stage cannot be re-run, rather than a dead button', () => {
+    // The same courtesy the `null`/`rejected` branch has always had: an
+    // upstream approval withdrawn since this run started makes a re-run 422,
+    // and the operator needs to know which one.
+    render(
+      <PipelineStage
+        kind="channel_plan"
+        title="Channel plan"
+        artefact={artefact('pending')}
+        loading={false}
+        error="the channel-plan run produced no submit_channel_plan tool call (502)"
+        failed={true}
+        canStart={false}
+        blockedReason="Approve the positioning stage first."
+        busy={false}
+        onStart={noop}
+        onRefresh={noop}
+        onApprove={noop}
+        onReject={noop}
+      />,
+    )
+    expect(screen.getByText('Approve the positioning stage first.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /run channel plan again/i })).toBeDisabled()
+  })
+
   it('offers approve and reject once proposed, and renders the artefact body', async () => {
     const onApprove = vi.fn()
     const onReject = vi.fn()

--- a/web-admin/src/components/PipelineStage.tsx
+++ b/web-admin/src/components/PipelineStage.tsx
@@ -22,6 +22,13 @@ interface PipelineStageProps {
    * anything wrong with the choice they made. Offers "Reload" instead of
    * leaving them to retry the exact request that just failed. */
   stale?: boolean
+  /** True when this stage's agent run reached a terminal state and produced
+   * nothing usable — `StageRunFailedError`, the advance route's 502 (issue
+   * #159). The artefact is still `pending`, because nothing ever moved it on,
+   * so "Check for result" re-reads the same dead run and returns the same
+   * reason for as long as anyone keeps pressing it. This is what turns the
+   * stage from stuck into restartable. */
+  failed?: boolean
   /** Whether the upstream gate this stage needs is satisfied. */
   canStart: boolean
   /** Human reason `canStart` is false, shown instead of a start button that
@@ -76,6 +83,7 @@ export function PipelineStage({
   loading,
   error,
   stale = false,
+  failed = false,
   canStart,
   blockedReason,
   busy,
@@ -150,9 +158,37 @@ export function PipelineStage({
           )}
 
           {status === 'pending' && (
-            <button type="button" onClick={onRefresh} disabled={busy}>
-              {busy ? 'Checking…' : 'Check for result'}
-            </button>
+            <>
+              <button type="button" onClick={onRefresh} disabled={busy}>
+                {busy ? 'Checking…' : 'Check for result'}
+              </button>
+              {/* Issue #159. A `pending` artefact whose run has already
+                  failed is not waiting for anything — the run is terminal and
+                  what it returned cannot become an artefact, so every further
+                  read produces the same 502 (see `StageRunFailedError`). An
+                  operator whose channel plan failed on tabsii dev had "Check
+                  for result" and nothing else, for ever.
+
+                  This deliberately does NOT reuse the `null`/`rejected` branch
+                  above. #85/#86 established that a failed stage must keep its
+                  badge and its reason rather than silently reverting to
+                  "startable", because reverting is what hid the reason. So the
+                  reason stays, the badge stays, and what is added is a
+                  separately-labelled re-run — the same label a `rejected`
+                  stage offers, since it is the same action.
+
+                  Gated by `canStart` like every other start: an upstream
+                  approval that has since been withdrawn would make a re-run
+                  422, and the hint says which. */}
+              {failed && (
+                <>
+                  {blockedReason !== null && <p className="hint">{blockedReason}</p>}
+                  <button type="button" onClick={onStart} disabled={!canStart || busy}>
+                    {busy ? 'Starting…' : `Run ${title.toLowerCase()} again`}
+                  </button>
+                </>
+              )}
+            </>
           )}
 
           {(status === 'proposed' || status === 'approved' || status === 'rejected') && children}

--- a/web-admin/src/lib/api.test.ts
+++ b/web-admin/src/lib/api.test.ts
@@ -11,6 +11,7 @@ import {
   listChannels,
   mintLinks,
   parseArtefactBody,
+  StageRunFailedError,
   StaleArtefactError,
   startResearch,
   updateCampaign,
@@ -144,6 +145,43 @@ describe('pipeline artefacts', () => {
     stubSession()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }))
     await expect(getArtefact('c1', 'research')).resolves.toBeNull()
+  })
+
+  it('throws StageRunFailedError, not a plain Error, for the advance route\'s 502 (#159)', async () => {
+    // 502 is `admin_app._pipeline_error_to_http`'s one status for "an agent
+    // ran and what it produced cannot be turned into an artefact" — the
+    // failure another read can never clear, and therefore the only one the
+    // stage should offer to re-run.
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: async () => ({ detail: 'the channel-plan run produced no submit_channel_plan tool call' }),
+      }),
+    )
+    const failure = getArtefact('c1', 'channel_plan')
+    await expect(failure).rejects.toBeInstanceOf(StageRunFailedError)
+    // Same wording as before #159 — nothing that only renders `error` changes.
+    await expect(failure).rejects.toThrow(
+      'the channel-plan run produced no submit_channel_plan tool call (502)',
+    )
+  })
+
+  it('does NOT throw StageRunFailedError for a failure that is not the run\'s own', async () => {
+    stubSession()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ detail: 'Administrator access required' }),
+      }),
+    )
+    const failure = getArtefact('c1', 'channel_plan')
+    await expect(failure).rejects.toBeInstanceOf(Error)
+    await expect(failure).rejects.not.toBeInstanceOf(StageRunFailedError)
   })
 
   it('starts research at the admin-app route, not generated CRUD', async () => {

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -31,6 +31,30 @@ import { createRequest } from './api-core'
  * and choose again" — a stale id cannot be retried into success. */
 export class StaleArtefactError extends Error {}
 
+/** Thrown by {@link getArtefact} for the advance route's 502 (issue #159) —
+ * "an agent ran, and what it produced (or failed to produce) is not something
+ * retrying the *request* fixes; the operator re-runs the stage instead". That
+ * sentence is `admin_app._pipeline_error_to_http`'s own docstring, and 502 is
+ * the only status this route uses to say it: every `pipeline.PipelineError`
+ * maps here and nothing else does.
+ *
+ * Distinguished from every other failure a stage read can produce because it
+ * is the one that "Check for result" can never resolve. The artefact is still
+ * `pending` — nothing ever moved it on — so re-reading it re-runs the same
+ * extraction against the same dead run and returns the same 502 for as long
+ * as anyone keeps pressing. On tabsii dev, 2026-08-14, that left a campaign
+ * sitting at `Running…` with `the channel-plan run produced no
+ * submit_channel_plan tool call` and no route forward at all.
+ *
+ * A 401/403 (the operator's session) or a 5xx from Core itself is NOT this:
+ * re-running would bill for a fresh agent run to fix something no agent
+ * caused. Hence the narrow status match rather than "any failure while
+ * pending".
+ *
+ * Carries the same message the plain `Error` did, so nothing that only
+ * renders `error` changes wording — see `throwForResponse`. */
+export class StageRunFailedError extends Error {}
+
 /** How a campaign reaches people (#67). Wider than a channel's own motion:
  * a channel is organic OR paid, a campaign may run `both`. */
 export type CampaignMotion = 'organic' | 'paid' | 'both'
@@ -344,10 +368,14 @@ async function throwForResponse(response: Response, context: string): Promise<ne
   if (response.status === 403) {
     throw new Error(detail !== null ? `${detail} (403)` : `you need the admin role to ${context} (403)`)
   }
-  if (detail !== null) {
-    throw new Error(`${detail} (${response.status})`)
+  const message = detail !== null ? `${detail} (${response.status})` : `could not ${context} (${response.status})`
+  // Issue #159: the run itself failed, so the operator needs a re-run rather
+  // than another read. Same message, a different type — see
+  // {@link StageRunFailedError} for why 502 specifically.
+  if (response.status === 502) {
+    throw new StageRunFailedError(message)
   }
-  throw new Error(`could not ${context} (${response.status})`)
+  throw new Error(message)
 }
 
 /** Update a campaign's own fields directly — generated CRUD, not an admin-app


### PR DESCRIPTION
Since #155 the channel-plan stage fails on a real run. Found by driving a campaign end to end on tabsii dev, 2026-08-14 — campaign `VERIFY GROUNDING 0814` (`b28334cd-8e6a-4b67-997c-2e7eb71d981d`) is still sitting in this state.

```
Channel plan   RUNNING…
the channel-plan run produced no submit_channel_plan tool call (502)
```

**Not a timeout** — 16.6s against a 240s budget, no clamp warning. The agent run **completed**, on `anthropic/claude-sonnet-4:online`, and billed $0.1344. It ran, it cost money, and it answered in prose.

## Which hypothesis the evidence supports

The issue lists three. Two are refuted by this repo's own code, and the third is a symptom of the real cause.

| # | Hypothesis | Verdict |
| --- | --- | --- |
| 2 | Search turns crowd out the output call (`CHANNEL_PLAN_MAX_TURNS` 3 → 8) | **Refuted, structurally.** `channel_plan_definition` returns `tools: []`; retrieval is the `:online` suffix, and the provider searches once, from the payload, *before* the model is invoked (#101). There are no search turns. 16.6s is one model call, so the raised budget changed nothing about turn one. |
| 1 | `sonnet-4` is weaker at forced output-tool use | **Refuted by an in-run control.** `DEFAULT_RESEARCH_MODEL == DEFAULT_CHANNEL_PLAN_MODEL`. Research emitted `submit_research_findings` on that identical route, in the same campaign, minutes earlier. The route can call its output tool. |
| 3 | #155's citation rule makes a valid submission too hard | **Supported — and it is the same root cause as the phrasing.** The rule demands evidence "from your own search results" from a model that believes it still has to go and search, and cannot. |

### The actual defect, and this plugin has shipped it twice

`_EVIDENCE_RULE`'s own docstring records the first instance:

> This rule used to say "search the web for current material", which is an instruction the model cannot follow, immediately followed by an escape hatch for when it finds nothing — and **it took the escape hatch**. Measured on dev 2026-08-12: retrieval returned 10 sources on every run and the model cited **none** of them, twice consecutively.

#155 wrote that same shape back into `CHANNEL_PLAN_INSTRUCTIONS` — "**You also have live web search, and you are expected to use it**", "Search before you decide", "If you searched and found nothing … say nothing rather than reach for the positioning" — and made it worse. Research took the escape hatch and returned an *empty artefact*. Channel planning did not call the tool at all, because **nothing anywhere told it that "recommend nothing" is still delivered by calling the tool.**

The new sweep names five offending phrases in `channel_plan` and **zero** in every other stage:

```
AssertionError: channel_plan's instructions order a search the run cannot perform
(['\bsearch before you\b', '\byou (also )?have live web search\b',
  '\bexpected to use it\b', '\bif you searched\b', '\byour own search results\b'])
1 failed, 5 passed
```

## The route does not move

Reverting to a non-searching model would reinstate #65, and #136 measured `sonnet-5:online` returning **zero** annotations — the set of routes that actually ground is one. **Nothing here trades grounding away.** #155's per-recommendation grounding rule is kept intact; it is only re-worded from "your own search results" to "the retrieval you were given", which is what it always meant.

- **`RETRIEVAL_ALREADY_RAN_RULE`** — one shared constant, in the past tense, telling any `:online` stage that its search has already run and there is no search tool on this run. Research's `_RETRIEVAL_SCOPE_RULE` is rebuilt on it, so there is one sentence rather than one per prompt.
- **`return_via_tool(tool_name)`** — the closing rule every stage now ends on. Four of the six prompts explicitly invite an empty answer (`return empty lists`, `return fewer channels (or none)`, `return an empty findings list`) and not one said how an empty answer is *delivered*. An operator cannot tell "the research came back empty" from "the stage produced nothing" — both are a 502 — and only the first is readable and recoverable.
- **`tests/test_marketing_output_tool_call.py`** sweeps **every** stage for both rules, because both incidents were one bad prompt among five good ones, which is exactly the shape a per-stage assertion misses.

## The stuck stage, fixed regardless

After the 502 the stage sat at `Running…` with the reason shown (#85/#86 working) and `Check for result` as its only control — which re-reads the same terminal run and returns the same 502 for as long as anyone keeps pressing. The artefact is still `pending` because nothing ever moved it on.

`getArtefact` now throws `StageRunFailedError` for the advance route's **502 specifically** — `admin_app._pipeline_error_to_http`'s own *"an agent ran, and what it produced is not something retrying the request fixes; the operator re-runs the stage instead"* — and a `pending` stage in that state gains a separately-labelled **"Run … again"** beside "Check for result".

This is **not** a revert to #86: the badge and the reason both stay, which is what the silent revert destroyed. A 403, or a dropped connection mid-poll, deliberately does **not** offer it — re-running would bill for a second agent run to fix something no agent caused. The start route already permits this; a fresh `pending` artefact sorts ahead of the dead one (`admin_app._latest_artefact`). Only the button was missing.

## Tests fail first

**Python** — `26 passed, 3 skipped` after; before:

```
18 failed, 8 passed, 3 skipped
FAILED ...::test_no_stage_is_ordered_to_run_a_search_it_has_no_tool_for[channel_plan]
FAILED ...::test_every_grounded_stage_is_told_its_search_has_already_run[channel_plan|research_audience|research_competitive]
FAILED ...::test_every_stage_is_told_that_having_nothing_to_say_still_means_calling_the_tool[all six]
FAILED ...::test_every_stage_names_its_own_output_tool_in_that_rule[all six]
```

**web-admin** — with `api.ts`/`Pipeline.tsx`/`PipelineStage.tsx` stashed and only the tests applied:

```
× pipeline artefacts > throws StageRunFailedError, not a plain Error, for the advance route's 502 (#159)
× pipeline artefacts > does NOT throw StageRunFailedError for a failure that is not the run's own
× PipelineStage > offers a re-run alongside "check for result" when the pending run has failed (#159)
× PipelineStage > explains why a failed pending stage cannot be re-run, rather than a dead button
× Pipeline > surfaces a failed run's own reason instead of returning the stage to startable
× Pipeline > a pending stage whose run has already failed (#159) > offers a re-run when the run itself failed
× Pipeline > a pending stage whose run has already failed (#159) > actually starts a fresh run when that re-run is pressed
Tests  7 failed | 51 passed (58)
```

After: `722 passed, 3 skipped` (pytest) and `Test Files 25 passed · Tests 218 passed` (vitest). `ruff`, `pyright`, `eslint`, `tsc` and `vite build` all clean.

## What still needs a live run

**Whether the agent now reliably calls `submit_channel_plan` is only observable on a live run**, which is why this uses `Refs`. What is proved here is narrower and worth stating plainly:

- the prompt no longer asks for a step the run has no tool for;
- silence is no longer a legal answer at any stage — an empty plan now has a defined delivery route, and it fails with `NoCitationsError`'s readable sentence rather than a mute missing-tool-call;
- a failed stage is restartable, which is true regardless of how the model behaves.

If a live re-run still produces prose on this route, the remaining lever is a two-step (ground in one call, structure the retrieved material in a second, non-`:online` call) rather than trading the grounding away — but the prompt defect had to be cleared first, because it explains the observation on its own.

Refs #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)