### PR TITLE
feat(channel-plan): ground in one run, then hand the retrieved URLs to a second

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -651,17 +651,47 @@ async def _advance_artefact(
         # `or None` rather than `or []` because an empty list would read as
         # "no motion is allowed" and reject everything.
         allowed_motions = pending.get("allowed_motions") or None
-        result = await pipeline.advance_channel_plan(
+        advance = await pipeline.advance_channel_plan(
             gateway,
-            run_id=_require_run_id(),
+            # `agent_run_id` is the GROUNDING run (#65): the stage starts with
+            # the `:online` run that retrieves, and the planning run it feeds
+            # is started from a later poll of this very function. Its id lands
+            # in `channel_plan_run_id` below, and is passed back here so the
+            # transition happens exactly once.
+            evidence_run_id=_require_run_id(),
+            plan_run_id=pending.get("channel_plan_run_id"),
+            plan_input=pending.get("plan_input"),
             # Carried purely so this stage's retrieval-breadth line (#65 — the
             # instrument #101 built for research, now pointed here too) can be
-            # joined to the rest of this campaign's runs.
+            # joined to the rest of this campaign's runs, and so both runs of
+            # the stage share one chain.
             causation_id=artefact.get("causation_id"),
             taxonomy=taxonomy,
             allowed_motions=allowed_motions,
             allowed_source_urls=allowed_source_urls,
         )
+        if advance.started_plan_run_id is not None:
+            # The stage is half done: the grounding run finished and its
+            # evidence has just been handed to a freshly-started planning run.
+            # Recording that id is not bookkeeping — without it the next poll
+            # would see the same terminal grounding run and start (and bill
+            # for) a second planning run. The artefact stays `pending`; the
+            # next poll advances the planning run.
+            started = await _core(
+                "PATCH",
+                f"{_INTERNAL_PREFIX}/artefacts/{artefact['id']}",
+                token,
+                json={
+                    "body": json.dumps(
+                        pipeline.with_element_ids(
+                            {**pending, "channel_plan_run_id": advance.started_plan_run_id}
+                        )
+                    )
+                },
+            )
+            started.raise_for_status()
+            return started.json()
+        result = advance.plan
     elif kind == "copy":
         # `channel_plan_channels` is `{channel_key: motion}` for the approved
         # plan's real entries this run was started against — same pattern,

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -200,7 +200,12 @@ async def start_channel_plan_route(
     ]
     taxonomy_motions = {row["key"]: row["motion"] for row in channel_rows}
 
-    causation_id, run_id = await pipeline.start_channel_plan(
+    # The stage starts with its GROUNDING run (#65): one `:online` run whose
+    # job is to retrieve and to read. The planning run that turns what it
+    # retrieved into a channel plan is started from the advance route, once
+    # this one has finished and the runtime's record of what it retrieved can
+    # be handed over as an enumerated set — see `pipeline.advance_channel_plan`.
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
         positioning_body=positioning_body,
         taxonomy=taxonomy,
@@ -226,6 +231,20 @@ async def start_channel_plan_route(
                         "channel_taxonomy": taxonomy_motions,
                         "allowed_motions": sorted(allowed_motions),
                         "allowed_source_urls": allowed_source_urls,
+                        # What the PLANNING run will be started with, one or
+                        # more polls from now (#65). Stashed for exactly the
+                        # reason `channel_taxonomy` is: it must be what this
+                        # stage was started against, not a fresh read of a
+                        # positioning or a taxonomy that has moved since. It
+                        # rides under its own key rather than at the top level
+                        # so `with_element_ids` — which stamps ids onto
+                        # top-level `segments`/`pillars`/`ctas` lists — cannot
+                        # reach into a copy of the parent artefact.
+                        "plan_input": pipeline.channel_plan_input(
+                            positioning_body=positioning_body,
+                            taxonomy=taxonomy,
+                            campaign_motion=campaign_motion,
+                        ),
                     }
                 )
             ),

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -93,6 +93,14 @@ RESEARCH_AUDIENCE_AGENT_NAME = "marketing-research-audience"
 RESEARCH_COMPETITIVE_AGENT_NAME = "marketing-research-competitive"
 RESEARCH_SYNTHESIS_AGENT_NAME = "marketing-research-synthesis"
 POSITIONING_AGENT_NAME = "marketing-positioning"
+#: The channel stage's **grounding** run (issue #65, second increment). Its job
+#: is to retrieve and to read: it runs on the one route whose ``:online``
+#: grounding this estate has observed, and returns one note per page it was
+#: given. What makes it worth a run of its own is not the notes, which are the
+#: model's own account, but ``annotations`` — the runtime's independent record
+#: of what retrieval returned, which is what the planning run below is then
+#: handed as an enumerated set.
+CHANNEL_EVIDENCE_AGENT_NAME = "marketing-channel-evidence"
 CHANNEL_PLAN_AGENT_NAME = "marketing-channel-plan"
 COPY_AGENT_NAME = "marketing-copy"
 
@@ -109,6 +117,7 @@ RESEARCH_AGENT_NAMES: tuple[str, ...] = (
 FINDINGS_TOOL_NAME = "submit_research_findings"
 RESEARCH_SYNTHESIS_TOOL_NAME = "submit_research_synthesis"
 POSITIONING_TOOL_NAME = "submit_positioning"
+CHANNEL_EVIDENCE_TOOL_NAME = "submit_channel_evidence"
 CHANNEL_PLAN_TOOL_NAME = "submit_channel_plan"
 COPY_TOOL_NAME = "submit_copy"
 
@@ -232,6 +241,57 @@ class Positioning(BaseModel):
     segments: list[Segment] = Field(default_factory=list)
     pillars: list[MessagePillar] = Field(default_factory=list)
     ctas: list[CallToAction] = Field(default_factory=list)
+
+
+# ── The channel stage's grounding run (issue #65, second increment) ──────────
+
+
+class RetrievedPageNote(BaseModel):
+    """What the grounding run read on one page it was given.
+
+    Deliberately **not** a :class:`Source`. A ``Source`` is an attribution
+    attached to a claim in an artefact an operator approves; this is an
+    intermediate reading, and it is never persisted or shown to anyone. The
+    distinction matters because the two are trusted differently: ``url`` here
+    is the model's own account of which page it is describing, and it is
+    checked against the runtime's ``annotations`` before it is carried
+    anywhere — a note whose URL was never retrieved is dropped rather than
+    forwarded (``pipeline.retrieved_evidence``).
+    """
+
+    url: str = Field(
+        min_length=1,
+        description=(
+            "The URL of the retrieved page this note is about, copied exactly from the "
+            "material you were given."
+        ),
+    )
+    note: str = Field(
+        description=(
+            "What this page actually says about where this audience converts — the "
+            "figure, the comparable campaign, the observed intent. Quote the number "
+            "where there is one."
+        )
+    )
+
+
+class ChannelEvidenceSet(BaseModel):
+    """The grounding run's full output: one note per retrieved page.
+
+    ``evidence`` is a REQUIRED key that may legitimately be empty, for exactly
+    the reason :attr:`ResearchSynthesis.findings` is — a default would make it
+    optional in the generated tool schema, and a model that can omit the
+    question will. An empty list is an honest answer here ("nothing I was given
+    says anything about conversion"), and it is a *different* answer from the
+    runtime having recorded no retrieval at all.
+    """
+
+    evidence: list[RetrievedPageNote] = Field(
+        description=(
+            "One entry per retrieved page that says something about where this audience "
+            "converts. Do not include a page you were not given, and do not pad the list."
+        )
+    )
 
 
 # ── Campaign motion (#67) ────────────────────────────────────────────────────
@@ -788,39 +848,87 @@ empty lists rather than inventing content to fill them.
 {_UNTRUSTED_INPUT_RULE}
 {return_via_tool(POSITIONING_TOOL_NAME)}"""
 
-CHANNEL_PLAN_INSTRUCTIONS = f"""\
-You are the campaign studio's channel strategist. You are given one
-**approved** positioning artefact — audience segments, message pillars and
-calls to action, each carrying the sources that support it — a
-`campaign_motion` (`organic`, `paid` or `both`), and one **channel
-taxonomy**: a list of `{{channel_key, label, motion, category}}` entries.
-
-**Live conversion evidence has already been retrieved for you, and it is
-what you decide from.** The positioning you were given answers a different
-question from yours. It was researched to establish who this audience is and
-what competitors say to them; you are deciding where this audience actually
-converts. Its sources cannot answer that, and a channel plan justified
-entirely by them is the failure this stage was rebuilt to end.
-
-## The retrieval in front of you is about conversion, not description
+#: What the grounding run is told (issue #65, second increment).
+#:
+#: This prompt has exactly one job — read the pages the provider retrieved and
+#: say what each one contains — and it deliberately does NOT ask for a
+#: recommendation. Deciding and citing in the same turn is what the single-run
+#: stage did, and on dev 2026-08-14 it produced six recommendations whose every
+#: source came from the positioning: the model had ten deep, relevant pages in
+#: context and did not treat them as citable, because nothing enumerated them
+#: while the positioning's sources arrived as structured objects it could see.
+#:
+#: Reading is therefore split off and asked for as its own structured answer,
+#: one entry per page. That output is a convenience — it is what lets the
+#: planning run write a rationale from a page rather than from a URL string —
+#: while the **citable set** is taken from ``annotations``, which the runtime
+#: records independently of anything the model says.
+CHANNEL_EVIDENCE_INSTRUCTIONS = f"""\
+You are the campaign studio's channel researcher. Pages about where this
+campaign's audience actually converts have already been retrieved for you and
+are in the material in front of you. Reading them is your whole job — you are
+not choosing channels, and nothing you write here is shown to an operator.
 
 {RETRIEVAL_ALREADY_RAN_RULE}
 That query was aimed at the numbers a media planner would ask for, so those
 are what to look for in the pages you were given:
 
-- Where this audience demonstrably **converts** — not where it merely has
-  attention. Intent expressed beats attention observed.
 - Reported **conversion rates, cost per acquisition, cost per click or lead
   cost** for this kind of buyer, on these channels, in this market.
 - What **comparable campaigns** report — case studies, published results,
   benchmark reports for this sector and geography.
 - Channel **economics and saturation** for this segment: what it costs to be
   seen there now, and what that buys.
+- Where this audience demonstrably **converts** — not where it merely has
+  attention. Intent expressed beats attention observed.
 
-Among the pages you were given, prefer the specific one carrying the number —
-a benchmark report, a results write-up, a case study — over a vendor home
-page or an agency's "top 10 channels" listicle. A retrieved page of generic
-channel wisdom is still generic channel wisdom; it has simply been fetched.
+You are also given the approved `positioning` and the `channel_taxonomy` this
+campaign may plan against. Both are context for what is worth noticing; they
+are not what you report on. The positioning was researched to establish who
+this audience is and what competitors say to them, which is a different
+question from yours.
+
+For every page worth reporting, give:
+
+- `url` — copied EXACTLY from the material you were given, character for
+  character. Do not tidy it, do not shorten it, and do not report a link you
+  saw quoted *inside* a page rather than in the material itself.
+- `note` — what THAT page says about conversion for this audience. Quote the
+  figure where there is one, and name the channel it belongs to. One page, one
+  note: do not summarise across pages, because the next step reads these one
+  at a time against the page they came from.
+
+Skip a page that says nothing about where this audience converts. A page of
+generic channel wisdom is still generic channel wisdom; it has simply been
+fetched, and reporting it as evidence is worse than leaving it out.
+
+{_UNTRUSTED_INPUT_RULE}
+{return_via_tool(CHANNEL_EVIDENCE_TOOL_NAME)}"""
+
+CHANNEL_PLAN_INSTRUCTIONS = f"""\
+You are the campaign studio's channel strategist. You are given
+`retrieved_evidence` — the conversion evidence gathered for this campaign — one
+**approved** positioning artefact (audience segments, message pillars and calls
+to action, each carrying the sources that support it), a `campaign_motion`
+(`organic`, `paid` or `both`), and one **channel taxonomy**: a list of
+`{{channel_key, label, motion, category}}` entries.
+
+## `retrieved_evidence` is the list you decide from, and cite from
+
+It is a list of pages that were fetched for this campaign, each with its `url`,
+its `title` and `what_it_says` — what a researcher reading that page recorded
+about where this audience converts. Every entry is a real page that was
+actually retrieved; the list is complete, and nothing outside it was fetched.
+
+**The positioning you were given answers a different question from yours.** It
+was researched to establish who this audience is and what competitors say to
+them; you are deciding where this audience actually converts. Its sources
+cannot answer that, and a channel plan justified entirely by them is the
+failure this stage was rebuilt to end.
+
+Among the entries you were given, prefer the specific one carrying the number —
+a benchmark report, a results write-up, a case study — over a vendor home page
+or an agency's "top 10 channels" listicle.
 
 **The taxonomy you are given is not the whole taxonomy.** It is the set of
 channels the operator selected for this campaign, already narrowed to the
@@ -858,12 +966,12 @@ around checking the list first, and never to re-propose a channel the
 operator has already left out for a reason you cannot see.
 
 Rank the channels within each motion (1 = highest priority) and give each a
-rationale an operator can disagree with: name the conversion evidence in the
-retrieval — the figure, the comparable campaign, the observed intent — and name
-which segment, pillar or CTA it serves. Rank on what the evidence says
-converts, not on what is conventionally listed first. A channel recommendation
-with no evidence behind it is the most confident-sounding fabrication in this
-pipeline —
+rationale an operator can disagree with: name the conversion evidence from
+`retrieved_evidence` — the figure, the comparable campaign, the observed intent
+— and name which segment, pillar or CTA it serves. Rank on what the evidence
+says converts, not on what is conventionally listed first. A channel
+recommendation with no evidence behind it is the most confident-sounding
+fabrication in this pipeline —
 "run paid social" or "post on LinkedIn" reads as correct whether or not
 anyone researched it, so generic channel wisdom is not an acceptable
 rationale.
@@ -873,37 +981,39 @@ rationale.
 Every recommendation must carry `sources`, and a `url` may come from exactly
 two places:
 
-1. **The retrieval you were given** — the pages returned for this run's
-   `search_query`, copied exactly as they appear, character for character. Do
-   not tidy a URL, do not shorten it, and do not cite a link you saw quoted
-   *inside* a page rather than in the retrieval itself.
+1. **`retrieved_evidence`** — copy the `url` of an entry in that list exactly
+   as it appears, character for character. Do not tidy a URL, do not shorten
+   it, do not cite a link that appears inside `what_it_says` rather than as an
+   entry's own `url`, and do not cite a page from memory because you expect it
+   to exist. If it is not in the list, it was not retrieved.
 2. **The positioning you were given** — the `url` of a `Source` on a segment,
    pillar or CTA, again exactly as written.
 
-Both are checked mechanically, against the runtime's own record of what the
+Both are checked mechanically, against the runtime's own record of what
 retrieval actually returned and against the positioning you were given. A
 `url` in neither is rejected and the whole plan fails with it, so a
 plausible-looking source you did not read is worse than a recommendation you
 leave out.
 
-**Every recommendation needs at least one source from this run's own
-retrieval.** This is checked per recommendation, not across the plan: a
-channel justified only by positioning's sources is justified by evidence
-about a different question, and is rejected along with the whole plan. If the
-retrieval in front of you says nothing about a channel's performance for this
-audience, do not recommend that channel — leave it out rather than reach for
-the positioning to dress it up.
+**Every recommendation needs at least one source from `retrieved_evidence`.**
+This is checked per recommendation, not across the plan: a channel justified
+only by positioning's sources is justified by evidence about a different
+question, and is rejected along with the whole plan. If nothing in
+`retrieved_evidence` speaks to a channel's performance for this audience, do
+not recommend that channel — leave it out rather than reach for the
+positioning to dress it up.
 
 For `note`, do not paste the positioning item's note verbatim — your
 `rationale` already says why this channel follows from the evidence, so repeat
 only what a `note` genuinely adds beyond that, or leave it empty.
 
-If the retrieval supports no recommendation in a motion, return fewer channels
-(or none) for that motion rather than inventing content to fill it — a channel
-plan that recommends nothing beats one that recommends plausibly. And if it
-supports nothing at all, return an empty plan **by calling the tool**, exactly
-as the closing rule below says: an empty plan tells the operator the retrieval
-came back thin, whereas no tool call tells them only that the stage broke.
+If `retrieved_evidence` supports no recommendation in a motion, return fewer
+channels (or none) for that motion rather than inventing content to fill it — a
+channel plan that recommends nothing beats one that recommends plausibly. And
+if it supports nothing at all, return an empty plan **by calling the tool**,
+exactly as the closing rule below says: an empty plan tells the operator the
+evidence came back thin, whereas no tool call tells them only that the stage
+broke.
 
 {_UNTRUSTED_INPUT_RULE}
 {return_via_tool(CHANNEL_PLAN_TOOL_NAME)}"""
@@ -1246,35 +1356,40 @@ DEFAULT_RESEARCH_MODEL = "anthropic/claude-sonnet-4:online"
 #: given — so neither needs `:online`.
 DEFAULT_SYNTHESIS_MODEL = "anthropic/claude-opus-5"
 DEFAULT_POSITIONING_MODEL = "anthropic/claude-opus-5"
-#: Channel planning **does** search (issue #65), so it carries `:online` — and
-#: therefore lands on the same route research does, for the same measured
-#: reason rather than a stylistic one.
-#:
-#: **This is a deliberate tier downgrade, and the trade is worth stating.**
-#: Every artefact-producing stage runs on Opus above, because a
-#: confident-sounding fabrication is their failure mode. Channel planning is
-#: the stage where that is *least* visible — "run paid social" reads as
-#: correct whether or not anyone researched it — so the Opus tier was doing
-#: real work here. It is given up because the alternative is worse: the
-#: question this stage has to answer ("where does this audience convert") is
-#: not answerable from weights at all, and #136's table says plainly that a
-#: Claude 5 route with `:online` attached returns **zero** annotations. A
-#: better model that cannot retrieve produces a more persuasive version of
-#: exactly the defect #65 was filed about.
-#:
-#: What replaces the tier is mechanical rather than aspirational, which is the
-#: only kind of replacement worth having: provenance is now checked against
-#: the union of the approved parent's citations and the run's OWN
-#: `annotations` (so an invented URL is still refused), and every single
-#: recommendation must cite at least one URL the runtime recorded this run
-#: retrieving (`pipeline.UngroundedRecommendationError`). A plan resting on
-#: positioning's carried-over sources fails whatever tier produced it.
+#: The channel stage's **grounding** run searches (issue #65), so it carries
+#: `:online` — and therefore lands on the same route research does, for the
+#: same measured reason rather than a stylistic one. This is the pin #155 put
+#: on `DEFAULT_CHANNEL_PLAN_MODEL`, moved to the run that actually retrieves
+#: rather than removed: `:online` still only demonstrably grounds on
+#: `sonnet-4` in this estate (#136), and that has not changed.
 #:
 #: Revisit exactly as `DEFAULT_RESEARCH_MODEL` says to: run the stage against
 #: a fact that post-dates training, read `annotations`, and move it only on
 #: that evidence. Not because a model is newer — that is what #108 did, and it
 #: cost a day.
-DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-sonnet-4:online"
+DEFAULT_CHANNEL_EVIDENCE_MODEL = "anthropic/claude-sonnet-4:online"
+#: Channel **planning** does not retrieve — it is handed what the grounding run
+#: above retrieved, enumerated (`pipeline.retrieved_evidence`) — so it needs no
+#: `:online`, and adding one would be actively wrong: `:online` bills per
+#: result, and a second retrieval would inject a second *unenumerated* set into
+#: the context, which is the precise condition the two-step exists to remove.
+#:
+#: **The tier downgrade #155 took here is therefore given back.** That
+#: downgrade was forced, not chosen: every artefact-producing stage runs on
+#: Opus because a confident-sounding fabrication is its failure mode, and
+#: channel planning is the stage where that is *least* visible ("run paid
+#: social" reads as correct whether or not anyone researched it) — but a stage
+#: that had to retrieve could only run on the one route that grounds. Splitting
+#: retrieval into its own run removes the constraint, so this returns to the
+#: family every other artefact-producing stage uses.
+#:
+#: The mechanical guards that replaced the tier are all still in force and none
+#: of them trusts the model: provenance is checked against the approved
+#: parent's citations UNION the runtime's own record of what the grounding run
+#: retrieved, and every recommendation must cite at least one URL from that
+#: record (`pipeline.UngroundedRecommendationError`). A plan resting on
+#: positioning's carried-over sources fails whatever tier produced it.
+DEFAULT_CHANNEL_PLAN_MODEL = "anthropic/claude-opus-5"
 #: Copy reasons over what it is given, same as positioning and channel
 #: planning — no `:online` needed.
 DEFAULT_COPY_MODEL = "anthropic/claude-opus-5"
@@ -1287,11 +1402,12 @@ RESEARCH_MAX_TURNS = 8
 # headroom for a retried tool call.
 SYNTHESIS_MAX_TURNS = 3
 POSITIONING_MAX_TURNS = 3
-# Channel planning searches (issue #65), so it needs research's budget rather
-# than a reasoning stage's: at 3 turns it could search once and then had to
-# answer, which is not a stage that researches anything. Matched to
-# `RESEARCH_MAX_TURNS` deliberately — same retrieval shape, same provider,
-# same wall clock — so the two move together rather than drifting apart.
+# The channel stage's grounding run retrieves (issue #65), so it needs
+# research's budget rather than a reasoning stage's: at 3 turns it could take
+# one retrieval and then had to answer, which is not a stage that researches
+# anything. Matched to `RESEARCH_MAX_TURNS` deliberately — same retrieval
+# shape, same provider, same wall clock — so the two move together rather than
+# drifting apart.
 #
 # **This makes the stage materially more expensive**, and that is the accepted
 # trade: `:online` bills per result, every turn can carry a retrieval, and the
@@ -1301,8 +1417,14 @@ POSITIONING_MAX_TURNS = 3
 # generated per. What it does NOT buy is more wall clock: every agent is
 # already at `AGENT_TIMEOUT_SECONDS` = the runtime ceiling, so these turns
 # have to fit in the same 240s research's do, and raising that is an instance
-# change (see `RUNTIME_TIMEOUT_CEILING_SECONDS`), not a plugin one.
-CHANNEL_PLAN_MAX_TURNS = RESEARCH_MAX_TURNS
+# change (see `RUNTIME_TIMEOUT_CEILING_SECONDS`), not a plugin one. The two
+# runs get 240s EACH — the ceiling is per run, and this stage is advanced by
+# polling rather than held open across both.
+CHANNEL_EVIDENCE_MAX_TURNS = RESEARCH_MAX_TURNS
+# Channel planning no longer retrieves: it reasons over the evidence it is
+# handed, exactly as positioning and copy reason over the artefact they are
+# handed. One turn to answer, plus headroom for a retried tool call.
+CHANNEL_PLAN_MAX_TURNS = 3
 COPY_MAX_TURNS = 3
 
 #: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_SECONDS` — the
@@ -1421,17 +1543,32 @@ def positioning_definition(*, model: str, instructions: str) -> dict[str, Any]:
     }
 
 
-def channel_plan_definition(*, model: str, instructions: str) -> dict[str, Any]:
-    """The channel-plan agent's run definition.
+def channel_evidence_definition(*, model: str, instructions: str) -> dict[str, Any]:
+    """The channel stage's grounding run definition (issue #65).
 
-    ``tools`` is empty and that is **not** because this agent does not search —
-    since issue #65 it does. It reaches the web the same way research does,
-    through OpenRouter's ``:online`` model suffix rather than a registry tool,
-    for the reason ``research_definition`` records: a registered-but-
-    unconfigured ``web_search`` is silently dropped rather than failed, so an
-    agent that declared it would return no findings with no error anywhere —
-    which is the exact shape of failure this stage is least able to survive.
+    ``tools`` is empty and that is **not** because this agent does not
+    retrieve — it is the only agent in this stage that does. It reaches the web
+    the same way research does, through OpenRouter's ``:online`` model suffix
+    rather than a registry tool, for the reason ``research_definition``
+    records: a registered-but-unconfigured ``web_search`` is silently dropped
+    rather than failed, so an agent that declared it would return no findings
+    with no error anywhere — which is the exact shape of failure this stage is
+    least able to survive.
     """
+    return {
+        "instructions": instructions,
+        "model": model,
+        "tools": [],
+        "max_turns": CHANNEL_EVIDENCE_MAX_TURNS,
+        "timeout_seconds": AGENT_TIMEOUT_SECONDS,
+    }
+
+
+def channel_plan_definition(*, model: str, instructions: str) -> dict[str, Any]:
+    """The channel-plan agent's run definition — no tools, and since issue
+    #65's second increment no ``:online`` either: it reasons over the
+    ``retrieved_evidence`` the grounding run above produced, in the same way
+    positioning reasons over the research artefact it is given."""
     return {
         "instructions": instructions,
         "model": model,
@@ -1488,6 +1625,21 @@ def positioning_tool_schema() -> dict[str, Any]:
             "name": POSITIONING_TOOL_NAME,
             "description": "Submit the audience segments, message pillars and CTAs.",
             "parameters": Positioning.model_json_schema(),
+        },
+    }
+
+
+def channel_evidence_tool_schema() -> dict[str, Any]:
+    """The output tool the grounding run calls to return one note per
+    retrieved page."""
+    return {
+        "type": "function",
+        "function": {
+            "name": CHANNEL_EVIDENCE_TOOL_NAME,
+            "description": (
+                "Submit what each retrieved page says about where this audience converts."
+            ),
+            "parameters": ChannelEvidenceSet.model_json_schema(),
         },
     }
 
@@ -1561,7 +1713,7 @@ def copy_tool_schema() -> dict[str, Any]:
 # asserted too. Bump ``_EXPECTED_DEFINITION_FACTORY_COUNT`` deliberately
 # whenever a factory is added, removed or renamed; that is a one-line, loud,
 # reviewable diff, not silent drift.
-_EXPECTED_DEFINITION_FACTORY_COUNT = 5
+_EXPECTED_DEFINITION_FACTORY_COUNT = 6
 
 
 def discover_definition_factories() -> tuple[Callable[..., dict[str, Any]], ...]:

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -57,6 +57,9 @@ from aws_lambda_powertools import Logger
 from pydantic import BaseModel, ValidationError
 
 from .definitions import (
+    CHANNEL_EVIDENCE_AGENT_NAME,
+    CHANNEL_EVIDENCE_INSTRUCTIONS,
+    CHANNEL_EVIDENCE_TOOL_NAME,
     CHANNEL_PLAN_AGENT_NAME,
     CHANNEL_PLAN_INSTRUCTIONS,
     CHANNEL_PLAN_TOOL_NAME,
@@ -65,6 +68,7 @@ from .definitions import (
     COPY_LENGTH_BUDGET,
     COPY_LENGTH_CEILING_MULTIPLE,
     COPY_TOOL_NAME,
+    DEFAULT_CHANNEL_EVIDENCE_MODEL,
     DEFAULT_CHANNEL_PLAN_MODEL,
     DEFAULT_COPY_MODEL,
     DEFAULT_POSITIONING_MODEL,
@@ -80,6 +84,7 @@ from .definitions import (
     RESEARCH_SYNTHESIS_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_TOOL_NAME,
     ChannelCopy,
+    ChannelEvidenceSet,
     ChannelPlan,
     CopySet,
     LengthOverage,
@@ -87,6 +92,8 @@ from .definitions import (
     ResearchFindingSet,
     ResearchSynthesis,
     Source,
+    channel_evidence_definition,
+    channel_evidence_tool_schema,
     channel_plan_definition,
     channel_plan_search_query,
     channel_plan_tool_schema,
@@ -654,6 +661,100 @@ def annotation_source_urls(annotations: list[dict[str, Any]] | None) -> list[str
     return urls
 
 
+#: How much of a retrieved page's recorded text is carried into the planning
+#: run's payload, per page.
+#:
+#: Bounded for the reason ``SEARCH_QUERY_BRIEF_CHARS`` is: the planning run has
+#: to fit ten pages, the whole positioning body and the taxonomy inside one
+#: payload and still answer inside ``AGENT_TIMEOUT_SECONDS``. The excerpt is a
+#: fallback, not the main channel — the grounding run's own ``note`` is what
+#: carries the reading — so it is sized to identify the page and support a
+#: figure, not to reproduce it.
+EVIDENCE_EXCERPT_CHARS = 1200
+
+
+def extract_channel_evidence(messages: list[dict[str, Any]]) -> ChannelEvidenceSet:
+    """The grounding run's per-page notes, or :class:`MalformedOutputError`.
+
+    No citation guard of its own, deliberately, and the two reasons are worth
+    separating:
+
+    - **This is not an artefact.** Nothing here is persisted, approved or shown
+      to an operator; it is an intermediate reading handed to the planning run.
+      The guards exist to stop an unevidenced *artefact* reaching a human, and
+      the artefact this stage produces is the plan, which is guarded exactly as
+      before.
+    - **Its `url`s are not trusted anyway.** :func:`retrieved_evidence` keeps
+      only the notes whose URL the runtime independently recorded, so a page
+      the model invented here cannot reach the planning run at all — let alone
+      be citable by it.
+
+    A missing tool call IS fatal, for the reason issue #159 records: without
+    the notes the planning run would be handed URLs and titles and asked to
+    write a rationale about pages it has no reading of, which is a fabrication
+    invitation dressed as grounding. Better to fail with the #159 sentence an
+    operator can act on.
+    """
+    data = _tool_call_arguments(messages, CHANNEL_EVIDENCE_TOOL_NAME)
+    if data is None:
+        raise MalformedOutputError(
+            f"the channel-evidence run produced no {CHANNEL_EVIDENCE_TOOL_NAME} tool call"
+        )
+    try:
+        return ChannelEvidenceSet.model_validate(data)
+    except ValidationError as exc:
+        raise MalformedOutputError(str(exc)) from exc
+
+
+def retrieved_evidence(
+    annotations: list[dict[str, Any]] | None, *, notes: Mapping[str, str] | None = None
+) -> list[dict[str, str]] | None:
+    """The enumerated evidence set the planning run is handed (issue #65), or
+    ``None`` when there is no record of what was retrieved.
+
+    **This is the whole two-step, in one function: which URLs the planning run
+    may cite is decided by the runtime, not by the model.** The spine is
+    ``annotations`` — Core's record of what ``:online`` actually returned,
+    written independently of anything the model said (:class:`AgentRunView`,
+    issue #82). ``notes`` is the grounding run's own reading, keyed by
+    :func:`_url_key` and merged onto that spine, so:
+
+    - a page the runtime recorded and the model wrote nothing about is still
+      handed over — it was retrieved, so it is citable, it simply arrives with
+      an empty reading;
+    - a page the model wrote about but the runtime never recorded is **not**
+      handed over at all, so it cannot be cited, and cannot then satisfy the
+      per-recommendation grounding check by having been invented one step
+      earlier. Trusting the model's account of what it read would reintroduce
+      exactly the trust every other check in this module refuses.
+
+    ``None`` in, ``None`` out: the tri-state is preserved rather than collapsed
+    into an empty list, because "the runtime recorded nothing" and "the runtime
+    recorded that retrieval found nothing" lead to opposite decisions in
+    :func:`extract_channel_plan`.
+    """
+    if annotations is None:
+        return None
+    by_url = notes or {}
+    handed: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for entry in annotations:
+        fields = _annotation_fields(entry)
+        url = fields.get("url")
+        if not isinstance(url, str) or not url or url in seen:
+            continue
+        seen.add(url)
+        item = {"url": url, "what_it_says": by_url.get(_url_key(url), "")}
+        title = fields.get("title")
+        if isinstance(title, str) and title:
+            item["title"] = title
+        content = fields.get("content")
+        if isinstance(content, str) and content:
+            item["excerpt"] = content[:EVIDENCE_EXCERPT_CHARS]
+        handed.append(item)
+    return handed
+
+
 def _require_retrieved_evidence(
     plan: ChannelPlan, *, retrieved_source_urls: Collection[str]
 ) -> None:
@@ -714,7 +815,11 @@ def extract_channel_plan(
     issue #3): a channel recommendation is exactly as fabricable as a
     positioning claim, and arguably the most confident-sounding one in the
     whole pipeline, because channel advice reads as generic wisdom whether or
-    not anyone researched it. ``annotations`` — see
+    not anyone researched it.
+
+    ``annotations`` here is the **grounding run's**, not the planning run's —
+    see :func:`advance_channel_plan` for why that distinction is the whole
+    guard rather than a detail of plumbing. Otherwise as
     :func:`extract_research_synthesis`.
 
     ## What provenance means for a stage that retrieves (issue #65 vs #22/#113)
@@ -1282,8 +1387,8 @@ def _aggregate_research_annotations(
     return []
 
 
-def _annotation_url(entry: Any) -> str | None:
-    """The URL inside one ``annotations`` entry, whichever shape it arrived in.
+def _annotation_fields(entry: Any) -> Mapping[str, Any]:
+    """The fields of one ``annotations`` entry, whichever shape it arrived in.
 
     Core stores what the runtime recorded, and OpenRouter's ``url_citation``
     annotation has been seen both flattened (``{"type": "url_citation",
@@ -1292,13 +1397,23 @@ def _annotation_url(entry: Any) -> str | None:
     upstream OpenAI-compatible form). Reading only one of them would make the
     breadth measurement below silently report zero the day the other appears,
     which is exactly the kind of quiet blindness issue #101 was filed about.
+
+    Split out from :func:`_annotation_url` when the two-step started carrying
+    ``title`` and page text forward as well (issue #65): one place that knows
+    which shape an annotation is in, rather than one per field.
     """
     if not isinstance(entry, dict):
-        return None
-    url = entry.get("url")
-    if not isinstance(url, str) or not url:
-        nested = entry.get("url_citation")
-        url = nested.get("url") if isinstance(nested, dict) else None
+        return {}
+    if isinstance(entry.get("url"), str) and entry["url"]:
+        return entry
+    nested = entry.get("url_citation")
+    return nested if isinstance(nested, dict) else entry
+
+
+def _annotation_url(entry: Any) -> str | None:
+    """The URL inside one ``annotations`` entry — see :func:`_annotation_fields`
+    for why the entry's shape is not assumed."""
+    url = _annotation_fields(entry).get("url")
     return url if isinstance(url, str) and url else None
 
 
@@ -1362,6 +1477,45 @@ def evidence_profile(views: Collection[AgentRunView | None]) -> EvidenceProfile:
     )
 
 
+#: The run sets whose breadth this process has already reported (issue #65
+#: follow-up), and the bound past which it forgets the oldest of them.
+#:
+#: **The line is once per run; the function that emits it is called once per
+#: poll.** Reading is what advances this pipeline, so a terminal run that
+#: cannot be advanced past — a channel plan whose recommendations were refused,
+#: a research chain that failed — is re-read, and re-measured, for as long as
+#: anyone leaves the page open. Measured live on 2026-08-14: the identical
+#: breadth line at 13:26:22, :24, :26, :28 and :30. Nothing was wrong with the
+#: numbers; the count of lines simply stopped meaning the count of runs, which
+#: is the one thing an instrument like this is read for.
+#:
+#: What this does and does not promise, stated plainly because it is process
+#: state in a Lambda: within one warm container, one line per run set. A cold
+#: start, or a run set evicted by the bound below, produces a second line for a
+#: run already reported — a duplicate, never a wrong measurement. The
+#: alternative (persisting "already logged" on the artefact) would buy exactness
+#: for a Core write on a failure path, which is a worse trade for a log line.
+_BREADTH_REPORTED: set[str] = set()
+_BREADTH_REPORTED_MAX = 1024
+
+
+def _breadth_already_reported(
+    *, chain_id: str | None, stage: str, views: Collection[AgentRunView | None]
+) -> bool:
+    """True when this exact run set's breadth has already been logged here.
+
+    Keyed on the runs measured, not on the chain alone: a stage measures its
+    own runs, and two stages of one campaign legitimately report separately.
+    """
+    key = f"{stage}:{chain_id}:" + ",".join(sorted(v.id for v in views if v is not None))
+    if key in _BREADTH_REPORTED:
+        return True
+    if len(_BREADTH_REPORTED) >= _BREADTH_REPORTED_MAX:
+        _BREADTH_REPORTED.clear()
+    _BREADTH_REPORTED.add(key)
+    return False
+
+
 def _log_evidence_profile(
     *, chain_id: str | None, views: Collection[AgentRunView | None], stage: str = "research"
 ) -> None:
@@ -1391,7 +1545,15 @@ def _log_evidence_profile(
     the same day of archaeology a second time. One implementation rather than
     a near-copy, so a fix to the tri-state reasoning below cannot apply to one
     stage and not the other.
+
+    Emitted **once per run set**, not once per call: this function is reached
+    from a polled advance, and a terminal run that cannot be advanced past is
+    re-read for as long as an operator leaves the page open. See
+    :data:`_BREADTH_REPORTED` for what that de-duplication does and does not
+    promise.
     """
+    if _breadth_already_reported(chain_id=chain_id, stage=stage, views=views):
+        return
     label = stage.replace("_", " ")
     try:
         profile = evidence_profile(views)
@@ -1749,17 +1911,89 @@ async def advance_positioning(
     )
 
 
-async def start_channel_plan(
+def channel_plan_input(
+    *,
+    positioning_body: dict[str, Any],
+    taxonomy: list[dict[str, Any]],
+    campaign_motion: str,
+) -> dict[str, Any]:
+    """Everything the planning run needs beyond the evidence itself.
+
+    One definition of the shape, two users: :func:`start_channel_evidence`'s
+    caller stashes this on the pending artefact at start time, and
+    :func:`advance_channel_plan` spreads it into the planning run's payload one
+    or more polls later. Stashed rather than re-fetched for the reason
+    ``channel_taxonomy`` already is — it must be what THIS stage was started
+    against, not whatever the positioning or the taxonomy has been changed to
+    by the time the grounding run finishes.
+    """
+    return {
+        "positioning": positioning_body,
+        "channel_taxonomy": taxonomy,
+        "campaign_motion": campaign_motion,
+    }
+
+
+@dataclass(frozen=True)
+class ChannelPlanAdvance:
+    """What one poll of the two-step channel stage did (issue #65).
+
+    Three states, and the caller has to be able to tell them apart because one
+    of them requires it to persist something:
+
+    - ``plan is None``, ``started_plan_run_id is None`` — nothing to do yet.
+      The grounding run or the planning run is still in flight.
+    - ``started_plan_run_id`` set — the grounding run finished and its evidence
+      has just been handed to a freshly-started planning run. **The caller must
+      record that id**, or the next poll starts a second planning run and pays
+      for it: "the grounding run is terminal" is true on every subsequent poll,
+      and only the recorded id makes the transition happen once.
+    - ``plan`` set — the stage is finished and this is the artefact.
+    """
+
+    plan: ChannelPlan | None = None
+    started_plan_run_id: str | None = None
+
+
+async def start_channel_evidence(
     gateway: AgentGateway,
     *,
     positioning_body: dict[str, Any],
     taxonomy: list[dict[str, Any]],
     campaign_motion: str,
-    channel_plan_model: str = DEFAULT_CHANNEL_PLAN_MODEL,
+    channel_evidence_model: str = DEFAULT_CHANNEL_EVIDENCE_MODEL,
 ) -> tuple[str, str]:
-    """Request the single channel-plan agent (M4), given the *approved*
-    positioning artefact's body AND the channels this campaign may plan
-    against as input.
+    """Start the channel stage by starting its **grounding** run (M4, issues
+    #3/#65), given the *approved* positioning artefact's body AND the channels
+    this campaign may plan against as input.
+
+    ## Why the stage starts with a run that recommends nothing
+
+    Until now this stage was one ``:online`` run that retrieved and decided in
+    the same turn, and on tabsii dev, 2026-08-14, that run retrieved **ten deep
+    pages, zero site roots** — and then justified all six of its
+    recommendations with sources carried over from the approved positioning.
+    :class:`UngroundedRecommendationError` refused them, correctly.
+
+    The gap that leaves is citation behaviour, not grounding. ``:online``
+    injects retrieved pages into the context and records them on
+    ``annotations``, but nothing in the payload ever presented those URLs to
+    the model *as a set to cite from* — while the positioning's sources arrive
+    as structured ``Source`` objects it can see and copy. It cited the list it
+    could see.
+
+    So retrieval and structuring are two runs. This one grounds and reads;
+    :func:`advance_channel_plan` hands what the **runtime** recorded to a
+    second run as an enumerated list. Sequential rather than fanned out, and
+    deliberately so: research's fan-out exists to wait for N siblings and fans
+    in through the orchestration engine, which passes the children's *outputs*
+    — it has no way to pass ``annotations``, which is the one input here that
+    is worth having precisely because the model did not write it. There is also
+    only one sibling to wait for. Reading is what advances this pipeline
+    already (``admin_app._advance_artefact``), so the second run is started
+    from the poll that observes the first finishing — no second orchestration
+    pattern, no second seeded workflow, and one ``causation_id`` across both so
+    spend and the breadth line still join.
 
     ``taxonomy`` (#76 increment 2) is a list of
     ``{channel_key, label, motion, category}`` dicts — the tenant's
@@ -1783,17 +2017,17 @@ async def start_channel_plan(
     rejected. That is an efficiency, not the enforcement — see
     :func:`extract_channel_plan` for where the motion is actually enforced.
 
-    Mirrors :func:`start_positioning` otherwise, one stage further down the
-    chain: a single-run chain, not fanned out, because nothing fans in on it.
+    Mirrors :func:`start_positioning` otherwise: its own chain, started here
+    rather than discovered, because nothing fans in on it.
     """
     causation_id = str(uuid.uuid4())
     run_id = await gateway.request_agent_run(
-        agent_name=CHANNEL_PLAN_AGENT_NAME,
-        definition=channel_plan_definition(
-            model=channel_plan_model,
-            instructions=CHANNEL_PLAN_INSTRUCTIONS,
+        agent_name=CHANNEL_EVIDENCE_AGENT_NAME,
+        definition=channel_evidence_definition(
+            model=channel_evidence_model,
+            instructions=CHANNEL_EVIDENCE_INSTRUCTIONS,
         ),
-        output_tool=channel_plan_tool_schema(),
+        output_tool=channel_evidence_tool_schema(),
         # `search_query` FIRST, exactly as `start_research`'s payload is and
         # for exactly the same reason (issue #101, now #65): this is an
         # `:online` run, so the provider searches from the payload BEFORE the
@@ -1808,9 +2042,11 @@ async def start_channel_plan(
                 taxonomy=taxonomy,
                 campaign_motion=campaign_motion,
             ),
-            "positioning": positioning_body,
-            "channel_taxonomy": taxonomy,
-            "campaign_motion": campaign_motion,
+            **channel_plan_input(
+                positioning_body=positioning_body,
+                taxonomy=taxonomy,
+                campaign_motion=campaign_motion,
+            ),
         },
         causation_id=causation_id,
     )
@@ -1820,49 +2056,109 @@ async def start_channel_plan(
 async def advance_channel_plan(
     gateway: AgentGateway,
     *,
-    run_id: str,
+    evidence_run_id: str,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    plan_run_id: str | None = None,
+    plan_input: Mapping[str, Any] | None = None,
     causation_id: str | None = None,
     allowed_motions: Collection[str] | None = None,
     allowed_source_urls: Collection[str] | None = None,
-) -> ChannelPlan | None:
-    """Read the channel-plan run, advancing nothing else — mirrors
-    :func:`advance_positioning`: a single run, not a chain, so there is no
-    fan-in to discover. ``taxonomy`` is ``{channel_key: motion}`` for exactly
-    what :func:`start_channel_plan` gave this run, and ``allowed_motions``
-    the campaign motion it was started under (#67) — see
-    :func:`extract_channel_plan` for how they and ``allowed_source_urls`` are
-    used.
+    channel_plan_model: str = DEFAULT_CHANNEL_PLAN_MODEL,
+) -> ChannelPlanAdvance:
+    """Drive the two-step channel stage forward by one poll (issue #65).
 
-    Since #65 this stage retrieves, so its breadth is measured and logged on
-    every terminal path exactly as :func:`advance_research`'s is — including
-    the failed one, which is where the measurement is worth most: "the
-    retrieval was thin" and "the run died" produce the same dead artefact and
-    this line is the only thing that separates them. It is a report, never a
-    gate; it changes nothing this function returns or raises.
+    Three things can happen, and :class:`ChannelPlanAdvance` says which:
+    nothing yet, the planning run has just been started (**the caller must
+    persist its id**), or the plan is finished.
 
-    ``causation_id`` is the chain this run belongs to, carried only so the
-    breadth line can be joined to the rest of the campaign's runs. Optional
-    because it is diagnostic: a caller that has not got one still gets the
-    measurement, with the id reading as unknown rather than the measurement
-    being withheld.
+    ``evidence_run_id`` is the grounding run :func:`start_channel_evidence`
+    started; ``plan_run_id`` is the planning run this function started on an
+    earlier poll, passed back from wherever the caller stashed it.
+    ``plan_input`` is :func:`channel_plan_input`'s dict, stashed at start time
+    for the reason that function's docstring gives. ``taxonomy`` is
+    ``{channel_key: motion}`` for exactly the taxonomy the stage was started
+    against, and ``allowed_motions`` the campaign motion it was started under
+    (#67) — see :func:`extract_channel_plan` for how they and
+    ``allowed_source_urls`` are used.
+
+    ## The guard's subject is the run that RETRIEVED
+
+    ``annotations`` is read off the **grounding** run and handed to
+    :func:`extract_channel_plan`, never off the planning run. This is not a
+    convenience: the planning run is not an ``:online`` run, so its own
+    ``annotations`` can only ever be the "not a grounded run" state — which
+    skips both evidence checks. Reading it would leave
+    :class:`UngroundedRecommendationError` structurally unable to fire, without
+    a line of it being deleted. That is exactly the defect issue #90 found in
+    :func:`advance_research`, where the guard was reading the synthesis run
+    rather than the research runs that retrieved, and
+    :func:`_aggregate_research_annotations` is the same fix one stage up.
+
+    The grounding run's breadth is measured and logged on every terminal path,
+    including the failed one, which is where the measurement is worth most:
+    "the retrieval was thin" and "the run died" produce the same dead artefact
+    and this line is the only thing that separates them. It is a report, never
+    a gate. ``causation_id`` is carried only so it can be joined to the rest of
+    the campaign's runs, and is what the planning run is started on.
     """
-    view = await gateway.get_agent_run(run_id=run_id)
-    if view is None or not view.is_terminal:
-        return None
-    # Once, here, before either branch: emitted exactly one time per terminal
-    # advance, on the success and failure paths alike, and never while the run
-    # is still in flight (this function is polled, so that would be a stream of
-    # partial snapshots rather than one measurement).
-    _log_evidence_profile(chain_id=causation_id, views=[view], stage="channel_plan")
-    if not view.succeeded:
+    evidence_view = await gateway.get_agent_run(run_id=evidence_run_id)
+    if evidence_view is None or not evidence_view.is_terminal:
+        return ChannelPlanAdvance()
+    # Once, here, before any branch: the grounding run is the only run in this
+    # stage that retrieves, so it is the only one there is a breadth to measure
+    # for — and it is measured on the success and failure paths alike, never
+    # while it is still in flight.
+    _log_evidence_profile(chain_id=causation_id, views=[evidence_view], stage="channel_plan")
+    if not evidence_view.succeeded:
+        raise RunNotSucceededError("The channel-plan evidence run did not complete successfully.")
+
+    if plan_run_id is None:
+        evidence_set = extract_channel_evidence(evidence_view.messages)
+        handed = retrieved_evidence(
+            evidence_view.annotations,
+            notes={_url_key(item.url): item.note for item in evidence_set.evidence},
+        )
+        if handed is None:
+            # No record of what was retrieved. The planning run still runs —
+            # stranding a campaign because the runtime did not write a column
+            # is the failure mode this module refuses everywhere else — but it
+            # is handed nothing to cite, and `extract_channel_plan` will say
+            # out loud that it cannot adjudicate the result.
+            logger.warning(
+                "channel plan evidence hand-over is empty: the grounding run reported no "
+                "annotations, so there is no record of what it retrieved to hand on",
+                extra={"causation_id": causation_id},
+            )
+            handed = []
+        started = await gateway.request_agent_run(
+            agent_name=CHANNEL_PLAN_AGENT_NAME,
+            definition=channel_plan_definition(
+                model=channel_plan_model, instructions=CHANNEL_PLAN_INSTRUCTIONS
+            ),
+            output_tool=channel_plan_tool_schema(),
+            # `retrieved_evidence` FIRST, for the reason `search_query` leads
+            # the grounding run's payload: JSON key order is preserved, and the
+            # evidence is the thing this run decides and cites from. Leading
+            # with `positioning` is how the single-run stage came to justify
+            # every recommendation from the positioning's sources.
+            input_payload={"retrieved_evidence": handed, **(plan_input or {})},
+            causation_id=causation_id or str(uuid.uuid4()),
+        )
+        return ChannelPlanAdvance(started_plan_run_id=started)
+
+    plan_view = await gateway.get_agent_run(run_id=plan_run_id)
+    if plan_view is None or not plan_view.is_terminal:
+        return ChannelPlanAdvance()
+    if not plan_view.succeeded:
         raise RunNotSucceededError("The channel-plan run did not complete successfully.")
-    return extract_channel_plan(
-        view.messages,
-        taxonomy=taxonomy,
-        allowed_motions=allowed_motions,
-        allowed_source_urls=allowed_source_urls,
-        annotations=view.annotations,
+    return ChannelPlanAdvance(
+        plan=extract_channel_plan(
+            plan_view.messages,
+            taxonomy=taxonomy,
+            allowed_motions=allowed_motions,
+            allowed_source_urls=allowed_source_urls,
+            annotations=evidence_view.annotations,
+        )
     )
 
 

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from marketing.definitions import (
     AGENT_TIMEOUT_SECONDS,
+    CHANNEL_EVIDENCE_MAX_TURNS,
     CHANNEL_PLAN_MAX_TURNS,
     COPY_MAX_TURNS,
     POSITIONING_MAX_TURNS,
@@ -29,6 +30,7 @@ from marketing.definitions import (
     RUNTIME_DEFAULT_TIMEOUT_SECONDS,
     RUNTIME_TIMEOUT_CEILING_SECONDS,
     SYNTHESIS_MAX_TURNS,
+    channel_evidence_definition,
     channel_plan_definition,
     copy_definition,
     discover_definition_factories,
@@ -180,6 +182,7 @@ def test_every_definition_still_declares_a_turn_budget() -> None:
         research_definition: RESEARCH_MAX_TURNS,
         research_synthesis_definition: SYNTHESIS_MAX_TURNS,
         positioning_definition: POSITIONING_MAX_TURNS,
+        channel_evidence_definition: CHANNEL_EVIDENCE_MAX_TURNS,
         channel_plan_definition: CHANNEL_PLAN_MAX_TURNS,
         copy_definition: COPY_MAX_TURNS,
     }

--- a/tests/test_marketing_campaign_targeting.py
+++ b/tests/test_marketing_campaign_targeting.py
@@ -247,6 +247,44 @@ def _plan_call(channels: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
+def _evidence_call() -> list[dict[str, Any]]:
+    """The grounding run's output (#65). These runs carry no `annotations`, so
+    nothing is handed on to cite and nothing in this module's subject — the
+    campaign's motion — depends on it; the tool call still has to be there,
+    because a grounding run that answered in prose is the #159 failure."""
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "submit_channel_evidence", "arguments": {"evidence": []}}}
+            ],
+        }
+    ]
+
+
+def _plan_through_both_runs(
+    client: TestClient,
+    core: _FakeCore,
+    gateway: _FakeGateway,
+    started: dict[str, Any],
+    messages: list[dict[str, Any]],
+) -> httpx.Response:
+    """Drive both runs of the two-step channel stage and return the response
+    that carries the plan (#65).
+
+    `agent_run_id` is the grounding run; the planning run is started by the
+    first advance and its id is stashed in the pending body, which is where
+    this reads it from — deliberately, rather than assuming a run id, because
+    that stashing is the thing that stops a second planning run being started
+    on every poll.
+    """
+    gateway.complete(started["agent_run_id"], messages=_evidence_call())
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+    plan_run_id = json.loads(core.artefacts[started["id"]]["body"])["channel_plan_run_id"]
+    gateway.complete(plan_run_id, messages=messages)
+    return client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+
 def _recommendation(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "channel_key": "instagram_organic",
@@ -431,9 +469,13 @@ def test_a_proposal_outside_the_campaign_motion_fails_the_plan(
     client = _client(core, gateway, monkeypatch)
     _approve_positioning(client, gateway, core)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_plan_call(
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call(
             [
                 _recommendation(),
                 _recommendation(
@@ -442,8 +484,6 @@ def test_a_proposal_outside_the_campaign_motion_fails_the_plan(
             ]
         ),
     )
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 502
     assert "organic" in resp.json()["detail"].lower()
@@ -463,9 +503,13 @@ def test_a_proposal_within_the_campaign_motion_is_kept(
     client = _client(core, gateway, monkeypatch)
     _approve_positioning(client, gateway, core)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_plan_call(
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call(
             [
                 _recommendation(
                     channel_key=None, suggested_label="Regional franchise forum", motion="organic"
@@ -473,8 +517,6 @@ def test_a_proposal_within_the_campaign_motion_is_kept(
             ]
         ),
     )
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 200
     (channel,) = json.loads(resp.json()["body"])["channels"]
@@ -520,12 +562,14 @@ def test_a_legacy_pending_artefact_still_advances(monkeypatch: pytest.MonkeyPatc
     legacy = json.loads(core.artefacts[started["id"]]["body"])
     legacy.pop("allowed_motions", None)
     core.artefacts[started["id"]]["body"] = json.dumps(legacy)
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_plan_call([_recommendation(channel_key="google_search_paid")]),
-    )
 
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call([_recommendation(channel_key="google_search_paid")]),
+    )
 
     assert resp.status_code == 200
 

--- a/tests/test_marketing_channel_plan_grounding.py
+++ b/tests/test_marketing_channel_plan_grounding.py
@@ -32,6 +32,11 @@ Four things are pinned here, because each of them fails silently:
    benchmark, which is the gap issue #65 names in its own words: "re-using
    positioning's citations should stop being sufficient — otherwise the guard
    passes on the old evidence and nothing changes".
+
+The stage is now two runs — one that grounds, one that is handed what it found
+— and this module is unchanged by that on purpose: every rule above is a rule
+about the *plan*, and every one of them still holds. What the split adds is
+pinned separately in `tests/test_marketing_two_step_channel_plan.py`.
 """
 
 from __future__ import annotations
@@ -42,11 +47,13 @@ import pytest
 
 from marketing import pipeline
 from marketing.definitions import (
-    CHANNEL_PLAN_AGENT_NAME,
+    CHANNEL_EVIDENCE_AGENT_NAME,
+    CHANNEL_EVIDENCE_MAX_TURNS,
+    CHANNEL_EVIDENCE_TOOL_NAME,
     CHANNEL_PLAN_INSTRUCTIONS,
-    CHANNEL_PLAN_MAX_TURNS,
-    DEFAULT_CHANNEL_PLAN_MODEL,
+    DEFAULT_CHANNEL_EVIDENCE_MODEL,
     POSITIONING_MAX_TURNS,
+    channel_evidence_definition,
     channel_plan_definition,
 )
 
@@ -90,6 +97,28 @@ def _channel(channel_key: str, *urls: str, rank: int = 1) -> dict[str, Any]:
 
 def _plan_call(*channels: dict[str, Any]) -> list[dict[str, Any]]:
     return _tool_call({"channels": list(channels)})
+
+
+def _evidence_call(*urls: str) -> list[dict[str, Any]]:
+    """The grounding run's output — one note per retrieved page. Section 6
+    drives that run rather than the planning run, because breadth is a property
+    of the run that retrieved; the two-step's own behaviour is pinned in
+    `tests/test_marketing_two_step_channel_plan.py`."""
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": CHANNEL_EVIDENCE_TOOL_NAME,
+                        "arguments": {
+                            "evidence": [{"url": url, "note": "what it shows"} for url in urls]
+                        },
+                    }
+                }
+            ],
+        }
+    ]
 
 
 class _FakeGateway:
@@ -170,10 +199,11 @@ _TAXONOMY_ROWS = [
 
 def test_the_channel_plan_stage_runs_on_a_grounded_route() -> None:
     """Without `:online` the stage cannot retrieve at all, and this is a plain
-    string nothing else validates."""
-    assert DEFAULT_CHANNEL_PLAN_MODEL.endswith(":online"), (
-        "channel planning must retrieve its own conversion evidence (#65), and "
-        f"`:online` is how retrieval works here; got {DEFAULT_CHANNEL_PLAN_MODEL!r}"
+    string nothing else validates. Since the stage became two runs, the subject
+    is the run that retrieves — the pin moved, it was not dropped."""
+    assert DEFAULT_CHANNEL_EVIDENCE_MODEL.endswith(":online"), (
+        "the channel stage must retrieve its own conversion evidence (#65), and "
+        f"`:online` is how retrieval works here; got {DEFAULT_CHANNEL_EVIDENCE_MODEL!r}"
     )
 
 
@@ -184,11 +214,12 @@ def test_the_channel_plan_route_is_one_whose_grounding_has_been_observed_live() 
     emptiness on unfamiliar ones. So the route is pinned to the one this
     estate has actually watched ground, and moving it means running the cheap
     probe in `DEFAULT_RESEARCH_MODEL`'s docstring first."""
-    assert DEFAULT_CHANNEL_PLAN_MODEL == "anthropic/claude-sonnet-4:online", (
-        "channel planning must run on a route whose `:online` grounding has "
-        f"been observed live (#136/#141); got {DEFAULT_CHANNEL_PLAN_MODEL!r}. If "
-        "you are moving it, run the stage against a fact that post-dates "
-        "training and confirm `annotations` comes back non-empty first."
+    assert DEFAULT_CHANNEL_EVIDENCE_MODEL == "anthropic/claude-sonnet-4:online", (
+        "the channel stage's grounding run must run on a route whose `:online` "
+        f"grounding has been observed live (#136/#141); got "
+        f"{DEFAULT_CHANNEL_EVIDENCE_MODEL!r}. If you are moving it, run the stage "
+        "against a fact that post-dates training and confirm `annotations` comes "
+        "back non-empty first."
     )
 
 
@@ -223,15 +254,18 @@ def test_the_prompt_asks_for_conversion_evidence_specifically() -> None:
 
 def test_the_turn_budget_leaves_room_to_search_and_then_answer() -> None:
     """`POSITIONING_MAX_TURNS` is the budget of a stage that only reasons over
-    what it is given. A searching stage that keeps it can search once, at
+    what it is given. A retrieving stage that keeps it gets one retrieval, at
     most, and then must answer — which is not a stage that researches."""
-    assert CHANNEL_PLAN_MAX_TURNS > POSITIONING_MAX_TURNS
+    assert CHANNEL_EVIDENCE_MAX_TURNS > POSITIONING_MAX_TURNS
 
 
-def test_the_definition_still_declares_no_registry_tool() -> None:
+def test_neither_definition_declares_a_registry_tool() -> None:
     """Retrieval travels with the model id, never as a declared `web_search`
     tool: on dev that tool is silently unavailable, so an agent that declares
-    it fabricates rather than errors."""
+    it fabricates rather than errors. Asked of both runs of the stage, because
+    the planning run gaining a search tool would be a quieter defect than the
+    grounding run losing one."""
+    assert channel_evidence_definition(model="m", instructions="i")["tools"] == []
     assert channel_plan_definition(model="m", instructions="i")["tools"] == []
 
 
@@ -248,7 +282,7 @@ async def test_the_run_leads_with_a_conversion_search_query() -> None:
     the positioning question all over again."""
     gateway = _FakeGateway()
 
-    await pipeline.start_channel_plan(
+    await pipeline.start_channel_evidence(
         gateway,
         positioning_body=_POSITIONING_BODY,
         taxonomy=_TAXONOMY_ROWS,
@@ -264,7 +298,7 @@ async def test_the_run_leads_with_a_conversion_search_query() -> None:
     assert "convert" in query  # the channel question, not the audience question
     assert "multi-location operators" in query  # this campaign's audience, not any audience
     assert "google search ads" in query  # the channels actually on the table
-    assert gateway.requested[0]["agent_name"] == CHANNEL_PLAN_AGENT_NAME
+    assert gateway.requested[0]["agent_name"] == CHANNEL_EVIDENCE_AGENT_NAME
 
 
 # ── 4. Provenance, for a stage that retrieves (issue #113/#22 re-derived) ────
@@ -445,7 +479,7 @@ async def test_channel_plan_retrieval_breadth_is_measured_like_researchs(
     without the same instrument it is answerable only by the same day of
     archaeology."""
     gateway = _FakeGateway()
-    causation_id, run_id = await pipeline.start_channel_plan(
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
         positioning_body=_POSITIONING_BODY,
         taxonomy=_TAXONOMY_ROWS,
@@ -453,20 +487,20 @@ async def test_channel_plan_retrieval_breadth_is_measured_like_researchs(
     )
     gateway.complete(
         run_id,
-        messages=_plan_call(_channel("google_search_paid", _RETRIEVED_URL)),
+        messages=_evidence_call(_RETRIEVED_URL),
         annotations=[*_ANNOTATIONS, {"type": "url_citation", "url": "https://roots.example.com/"}],
     )
 
     with caplog.at_level("INFO"):
-        plan = await pipeline.advance_channel_plan(
+        advance = await pipeline.advance_channel_plan(
             gateway,
-            run_id=run_id,
+            evidence_run_id=run_id,
             causation_id=causation_id,
             taxonomy=_TAXONOMY,
             allowed_source_urls=[_PARENT_URL],
         )
 
-    assert plan is not None
+    assert advance.started_plan_run_id is not None
     (record,) = _breadth_records(caplog)
     assert "2 distinct URLs across 1 grounded run(s)" in record.getMessage()
     assert record.causation_id == causation_id
@@ -482,7 +516,7 @@ async def test_channel_plan_breadth_is_logged_when_the_run_failed(
     """The path an operator most needs it on, exactly as for research: "the
     retrieval was thin" and "the run died" produce the same dead artefact."""
     gateway = _FakeGateway()
-    causation_id, run_id = await pipeline.start_channel_plan(
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
         positioning_body=_POSITIONING_BODY,
         taxonomy=_TAXONOMY_ROWS,
@@ -492,7 +526,7 @@ async def test_channel_plan_breadth_is_logged_when_the_run_failed(
 
     with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
         await pipeline.advance_channel_plan(
-            gateway, run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
+            gateway, evidence_run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
         )
 
     (record,) = _breadth_records(caplog)
@@ -506,7 +540,7 @@ async def test_channel_plan_breadth_says_unmeasured_rather_than_a_false_zero(
     """`0 distinct URLs` and "we have no record" must not read the same — the
     second sends nobody hunting a retrieval outage that never happened."""
     gateway = _FakeGateway()
-    causation_id, run_id = await pipeline.start_channel_plan(
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
         positioning_body=_POSITIONING_BODY,
         taxonomy=_TAXONOMY_ROWS,
@@ -516,7 +550,7 @@ async def test_channel_plan_breadth_says_unmeasured_rather_than_a_false_zero(
 
     with caplog.at_level("INFO"), pytest.raises(pipeline.RunNotSucceededError):
         await pipeline.advance_channel_plan(
-            gateway, run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
+            gateway, evidence_run_id=run_id, causation_id=causation_id, taxonomy=_TAXONOMY
         )
 
     (record,) = _breadth_records(caplog)

--- a/tests/test_marketing_output_tool_call.py
+++ b/tests/test_marketing_output_tool_call.py
@@ -59,11 +59,14 @@ import pytest
 from marketing import pipeline
 from marketing.definitions import (
     AUDIENCE_RESEARCH_INSTRUCTIONS,
+    CHANNEL_EVIDENCE_INSTRUCTIONS,
+    CHANNEL_EVIDENCE_TOOL_NAME,
     CHANNEL_PLAN_INSTRUCTIONS,
     CHANNEL_PLAN_TOOL_NAME,
     COMPETITIVE_RESEARCH_INSTRUCTIONS,
     COPY_INSTRUCTIONS,
     COPY_TOOL_NAME,
+    DEFAULT_CHANNEL_EVIDENCE_MODEL,
     DEFAULT_CHANNEL_PLAN_MODEL,
     DEFAULT_COPY_MODEL,
     DEFAULT_POSITIONING_MODEL,
@@ -74,6 +77,7 @@ from marketing.definitions import (
     POSITIONING_TOOL_NAME,
     RESEARCH_SYNTHESIS_INSTRUCTIONS,
     RESEARCH_SYNTHESIS_TOOL_NAME,
+    channel_evidence_definition,
     channel_plan_definition,
     copy_definition,
     positioning_definition,
@@ -113,6 +117,12 @@ _STAGES: dict[str, tuple[str, str, str, dict[str, Any]]] = {
         DEFAULT_POSITIONING_MODEL,
         POSITIONING_TOOL_NAME,
         positioning_definition(model=DEFAULT_POSITIONING_MODEL, instructions="i"),
+    ),
+    "channel_evidence": (
+        CHANNEL_EVIDENCE_INSTRUCTIONS,
+        DEFAULT_CHANNEL_EVIDENCE_MODEL,
+        CHANNEL_EVIDENCE_TOOL_NAME,
+        channel_evidence_definition(model=DEFAULT_CHANNEL_EVIDENCE_MODEL, instructions="i"),
     ),
     "channel_plan": (
         CHANNEL_PLAN_INSTRUCTIONS,
@@ -279,25 +289,62 @@ def test_the_empty_answer_sentence_is_the_one_the_prompt_ships() -> None:
 # always hands `extract_channel_plan` a tool call.
 
 
+_GROUNDING_RUN = "run-evidence"
+_PLANNING_RUN = "run-plan"
+
+
 class _CompletedWithProse:
-    """A gateway whose channel-plan run completes, successfully, having said
-    something reasonable-sounding and called nothing."""
+    """A gateway whose channel-PLANNING run completes, successfully, having
+    said something reasonable-sounding and called nothing.
+
+    Its grounding run behaves perfectly — it retrieved, and it reported what it
+    read — because the failure being reproduced is the planning run answering
+    in prose, and a two-step stage that fell over one run earlier would not be
+    the same defect.
+    """
 
     def __init__(self, text: str) -> None:
         self._text = text
 
     async def request_agent_run(self, **_kwargs: Any) -> str:
-        return "run-1"
+        return _PLANNING_RUN
 
     async def find_chain_run(self, **_kwargs: Any) -> pipeline.AgentRunView | None:
         return None
 
     async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView:
+        annotations = [{"type": "url_citation", "url": "https://benchmarks.example.com/cpa"}]
+        if run_id == _GROUNDING_RUN:
+            return pipeline.AgentRunView(
+                id=run_id,
+                status="completed",
+                messages=[
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "submit_channel_evidence",
+                                    "arguments": {
+                                        "evidence": [
+                                            {
+                                                "url": "https://benchmarks.example.com/cpa",
+                                                "note": "Reported CPA for this buyer.",
+                                            }
+                                        ]
+                                    },
+                                }
+                            }
+                        ],
+                    }
+                ],
+                annotations=annotations,
+            )
         return pipeline.AgentRunView(
             id=run_id,
             status="completed",
             messages=[{"role": "assistant", "content": self._text}],
-            annotations=[{"type": "url_citation", "url": "https://benchmarks.example.com/cpa"}],
+            annotations=None,
         )
 
 
@@ -321,7 +368,8 @@ async def test_a_completed_run_that_answered_in_prose_is_refused_not_accepted() 
     with pytest.raises(pipeline.MalformedOutputError) as raised:
         await pipeline.advance_channel_plan(
             gateway,  # type: ignore[arg-type]
-            run_id="run-1",
+            evidence_run_id=_GROUNDING_RUN,
+            plan_run_id=_PLANNING_RUN,
             taxonomy=_TAXONOMY,
         )
 

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -16,6 +16,7 @@ import pytest
 from marketing import pipeline
 from marketing.definitions import (
     AGENT_TIMEOUT_SECONDS,
+    CHANNEL_EVIDENCE_AGENT_NAME,
     CHANNEL_PLAN_AGENT_NAME,
     COPY_AGENT_NAME,
     DEFAULT_SYNTHESIS_MODEL,
@@ -717,133 +718,216 @@ async def test_advance_positioning_propagates_the_runs_annotations_into_the_erro
     )
 
 
-# ── start_channel_plan / advance_channel_plan (M4) ───────────────────────────
+# ── start_channel_evidence / advance_channel_plan (M4, two-step since #65) ───
+#
+# The stage is two runs: a grounded one that retrieves and reads, and a
+# planning one that is handed what the RUNTIME recorded and turns it into the
+# artefact. What each run is handed, and why the guard reads the first run's
+# annotations rather than the second's, is pinned in
+# `tests/test_marketing_two_step_channel_plan.py`; this section covers the
+# orchestration shape — which run is requested, on which chain, and what each
+# poll returns.
+
+
+def _evidence_call(*urls: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "submit_channel_evidence",
+                        "arguments": {"evidence": [{"url": url, "note": "n"} for url in urls]},
+                    }
+                }
+            ],
+        }
+    ]
+
+
+def _plan_call(channels: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "submit_channel_plan", "arguments": {"channels": channels}}}
+            ],
+        }
+    ]
 
 
 @pytest.mark.asyncio
-async def test_start_channel_plan_requests_one_run_carrying_the_positioning_body() -> None:
+async def test_start_channel_evidence_requests_one_grounded_run_carrying_the_positioning_body() -> (
+    None
+):
     gateway = _FakeGateway()
     positioning_body = {"segments": [], "pillars": [], "ctas": []}
     taxonomy = [{"channel_key": "instagram_organic", "label": "Instagram", "motion": "organic"}]
 
-    causation_id, run_id = await pipeline.start_channel_plan(
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway, positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
     )
 
     assert len(gateway.requested) == 1
     requested = gateway.requested[0]
-    assert requested.agent_name == CHANNEL_PLAN_AGENT_NAME
+    # The GROUNDING agent, not the planning one: the stage starts by
+    # retrieving, and the planning run is started from a later poll (#65).
+    assert requested.agent_name == CHANNEL_EVIDENCE_AGENT_NAME
     assert requested.causation_id == causation_id
     assert requested.input_payload == {
-        # #65: the stage retrieves now, and an `:online` run's provider
-        # searches from the payload before the model is invoked — so the
-        # searched query leads, exactly as research's does (#101). Its
-        # CONTENT is asserted in `test_marketing_channel_plan_grounding.py`;
-        # what matters here is that the payload's other keys are unchanged
-        # and this one is present.
+        # #65: an `:online` run's provider searches from the payload before the
+        # model is invoked — so the searched query leads, exactly as research's
+        # does (#101). Its CONTENT is asserted in
+        # `test_marketing_channel_plan_grounding.py`; what matters here is that
+        # the payload's other keys are unchanged and this one is present.
         "search_query": pipeline.channel_plan_search_query(
             positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
         ),
-        "positioning": positioning_body,
-        "channel_taxonomy": taxonomy,
-        # #67: told the campaign's motion as well as shown a taxonomy already
-        # narrowed to it — see `start_channel_plan` for why the telling is an
-        # efficiency and the narrowing is the enforcement.
-        "campaign_motion": "both",
+        # Exactly what the planning run will be started with, so the two runs
+        # cannot be shown different things.
+        **pipeline.channel_plan_input(
+            positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
+        ),
     }
     assert next(iter(requested.input_payload)) == "search_query"
     assert run_id  # a real id was returned
 
 
 @pytest.mark.asyncio
-async def test_advance_channel_plan_returns_none_while_running() -> None:
+async def test_advance_channel_plan_returns_nothing_while_the_grounding_run_is_running() -> None:
     gateway = _FakeGateway()
-    _causation_id, run_id = await pipeline.start_channel_plan(
+    _causation_id, run_id = await pipeline.start_channel_evidence(
         gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
 
-    result = await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
+    advance = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
 
-    assert result is None
+    assert advance.plan is None
+    assert advance.started_plan_run_id is None
+    assert len(gateway.requested) == 1  # nothing else has been paid for yet
 
 
 @pytest.mark.asyncio
-async def test_advance_channel_plan_returns_the_plan_once_succeeded() -> None:
+async def test_advance_channel_plan_starts_the_planning_run_on_the_same_chain() -> None:
     gateway = _FakeGateway()
-    _causation_id, run_id = await pipeline.start_channel_plan(
+    causation_id, run_id = await pipeline.start_channel_evidence(
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+    )
+    gateway.complete(run_id, messages=_evidence_call("https://example.com/y"))
+
+    advance = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=run_id,
+        taxonomy={},
+        causation_id=causation_id,
+        plan_input=pipeline.channel_plan_input(
+            positioning_body={}, taxonomy=[], campaign_motion="both"
+        ),
+    )
+
+    assert advance.plan is None
+    assert advance.started_plan_run_id is not None
+    planning = gateway.requested[1]
+    assert planning.agent_name == CHANNEL_PLAN_AGENT_NAME
+    # One chain across both runs — which is what makes per-campaign spend
+    # assemble, and what joins the breadth line to the rest of the campaign.
+    assert planning.causation_id == causation_id
+
+
+@pytest.mark.asyncio
+async def test_advance_channel_plan_returns_the_plan_once_the_planning_run_succeeds() -> None:
+    gateway = _FakeGateway()
+    causation_id, run_id = await pipeline.start_channel_evidence(
         gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(
         run_id,
-        messages=[
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "function": {
-                            "name": "submit_channel_plan",
-                            "arguments": {
-                                "channels": [
-                                    {
-                                        "channel_key": "instagram_organic",
-                                        "rank": 1,
-                                        "rationale": "r",
-                                        "sources": [{"url": "https://example.com/y", "note": "n"}],
-                                    }
-                                ]
-                            },
-                        }
-                    }
-                ],
-            }
-        ],
+        messages=_evidence_call("https://example.com/y"),
+        annotations=[{"type": "url_citation", "url": "https://example.com/y"}],
+    )
+    started = await pipeline.advance_channel_plan(
+        gateway, evidence_run_id=run_id, taxonomy={}, causation_id=causation_id
+    )
+    gateway.complete(
+        started.started_plan_run_id or "",
+        messages=_plan_call(
+            [
+                {
+                    "channel_key": "instagram_organic",
+                    "rank": 1,
+                    "rationale": "r",
+                    "sources": [{"url": "https://example.com/y", "note": "n"}],
+                }
+            ]
+        ),
     )
 
-    result = await pipeline.advance_channel_plan(
-        gateway, run_id=run_id, taxonomy={"instagram_organic": "organic"}
+    advance = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=run_id,
+        plan_run_id=started.started_plan_run_id,
+        taxonomy={"instagram_organic": "organic"},
+        causation_id=causation_id,
     )
 
-    assert isinstance(result, pipeline.ChannelPlan)
-    assert result.channels[0].channel_key == "instagram_organic"
-    assert result.channels[0].motion == "organic"  # derived from taxonomy, not the agent
+    assert isinstance(advance.plan, pipeline.ChannelPlan)
+    assert advance.plan.channels[0].channel_key == "instagram_organic"
+    assert advance.plan.channels[0].motion == "organic"  # derived from taxonomy, not the agent
 
 
 @pytest.mark.asyncio
-async def test_advance_channel_plan_raises_when_the_run_failed() -> None:
+async def test_advance_channel_plan_raises_when_the_grounding_run_failed() -> None:
     gateway = _FakeGateway()
-    _causation_id, run_id = await pipeline.start_channel_plan(
+    _causation_id, run_id = await pipeline.start_channel_evidence(
         gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, status="failed")
 
     with pytest.raises(pipeline.RunNotSucceededError):
-        await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
+        await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
+
+
+@pytest.mark.asyncio
+async def test_advance_channel_plan_raises_when_the_planning_run_failed() -> None:
+    gateway = _FakeGateway()
+    _causation_id, run_id = await pipeline.start_channel_evidence(
+        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+    )
+    gateway.complete(run_id, messages=_evidence_call("https://example.com/y"))
+    started = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
+    gateway.complete(started.started_plan_run_id or "", status="failed")
+
+    with pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_channel_plan(
+            gateway,
+            evidence_run_id=run_id,
+            plan_run_id=started.started_plan_run_id,
+            taxonomy={},
+        )
 
 
 @pytest.mark.asyncio
 async def test_advance_channel_plan_propagates_null_annotations_into_the_error() -> None:
     """Issue #82, channel-plan half: `annotations=None` (a pre-upgrade run, or
     a non-`:online` model) must NOT be reported as a confirmed zero-URL
-    retrieval — proven through `advance_channel_plan`."""
+    retrieval — proven through `advance_channel_plan`. Since the stage became
+    two runs the annotations that matter are the GROUNDING run's, so that is
+    the run this leaves without them."""
     gateway = _FakeGateway()
-    _causation_id, run_id = await pipeline.start_channel_plan(
+    _causation_id, run_id = await pipeline.start_channel_evidence(
         gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
     )
-    gateway.complete(
-        run_id,
-        messages=[
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {"function": {"name": "submit_channel_plan", "arguments": {"channels": []}}}
-                ],
-            }
-        ],
-        annotations=None,
-    )
+    gateway.complete(run_id, messages=_evidence_call(), annotations=None)
+    started = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
+    gateway.complete(started.started_plan_run_id or "", messages=_plan_call([]))
 
     with pytest.raises(pipeline.NoCitationsError) as excinfo:
-        await pipeline.advance_channel_plan(gateway, run_id=run_id, taxonomy={})
+        await pipeline.advance_channel_plan(
+            gateway,
+            evidence_run_id=run_id,
+            plan_run_id=started.started_plan_run_id,
+            taxonomy={},
+        )
 
     assert "not known" in str(excinfo.value)
 

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -282,6 +282,53 @@ def _empty_channel_plan_call() -> list[dict[str, Any]]:
     ]
 
 
+def _channel_evidence_call(*urls: str) -> list[dict[str, Any]]:
+    """The grounding run's output (#65) — one note per page it read."""
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "function": {
+                        "name": "submit_channel_evidence",
+                        "arguments": {"evidence": [{"url": url, "note": "n"} for url in urls]},
+                    }
+                }
+            ],
+        }
+    ]
+
+
+def _drive_channel_plan(
+    client: Any,
+    core: Any,
+    gateway: Any,
+    started: dict[str, Any],
+    messages: list[dict[str, Any]],
+    *,
+    annotations: list[dict[str, Any]] | None = None,
+) -> Any:
+    """Drive both runs of the two-step channel stage (#65) and return the
+    response that carries the plan.
+
+    ``annotations`` belongs to the GROUNDING run — it is the runtime's record
+    of what retrieval returned, and since the split it is that run, not the
+    planning run, that retrieves. Which is the whole point: the planning run
+    below is never an ``:online`` run, so the guard cannot read its own.
+    """
+    gateway.complete(
+        started["agent_run_id"],
+        messages=_channel_evidence_call(
+            *[a["url"] for a in (annotations or []) if isinstance(a.get("url"), str)]
+        ),
+        annotations=annotations,
+    )
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")  # starts the planning run
+    plan_run_id = json.loads(core.artefacts[started["id"]]["body"])["channel_plan_run_id"]
+    gateway.complete(plan_run_id, messages=messages)
+    return client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+
 # ── start research ────────────────────────────────────────────────────────────
 
 
@@ -606,7 +653,7 @@ def test_start_channel_plan_runs_once_positioning_is_approved(ctx) -> None:
     assert body["kind"] == "channel_plan"
     assert body["status"] == "pending"
     channel_plan_requests = [
-        r for r in gateway.requested if r["agent_name"] == "marketing-channel-plan"
+        r for r in gateway.requested if r["agent_name"] == "marketing-channel-evidence"
     ]
     assert len(channel_plan_requests) == 1
     assert channel_plan_requests[0]["input_payload"]["positioning"]["segments"][0]["name"] == (
@@ -623,10 +670,7 @@ def test_get_channel_plan_artefact_proposes_organic_and_paid_once_it_succeeds(ct
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
 
-    run_id = started["agent_run_id"]
-    gateway.complete(run_id, messages=_channel_plan_call())
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+    resp = _drive_channel_plan(client, core, gateway, started, _channel_plan_call())
 
     assert resp.status_code == 200
     body = resp.json()
@@ -643,10 +687,7 @@ def test_get_channel_plan_artefact_502s_a_zero_citation_run_and_leaves_it_pendin
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
 
-    run_id = started["agent_run_id"]
-    gateway.complete(run_id, messages=_empty_channel_plan_call())
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+    resp = _drive_channel_plan(client, core, gateway, started, _empty_channel_plan_call())
 
     assert resp.status_code == 502
     assert core.artefacts[started["id"]]["status"] == "pending", "must not have been proposed"
@@ -683,13 +724,14 @@ def test_get_channel_plan_artefact_502s_a_fabricated_citation_and_leaves_it_pend
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
 
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_channel_plan_call(url="https://marketing-statistics.example/benchmarks"),
+    resp = _drive_channel_plan(
+        client,
+        core,
+        gateway,
+        started,
+        _channel_plan_call(url="https://marketing-statistics.example/benchmarks"),
         annotations=[],
     )
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 502
     assert "marketing-statistics.example" in resp.json()["detail"]
@@ -707,13 +749,14 @@ def test_channel_plan_grounded_in_its_own_retrieval_is_proposed_and_cites_it(ctx
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
     retrieved = "https://benchmarks.example/paid-search-cpa-by-sector"
 
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_channel_plan_call(url=retrieved),
+    resp = _drive_channel_plan(
+        client,
+        core,
+        gateway,
+        started,
+        _channel_plan_call(url=retrieved),
         annotations=[{"type": "url_citation", "url": retrieved, "title": "CPA by sector"}],
     )
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 200
     assert core.artefacts[started["id"]]["status"] == "proposed"
@@ -729,13 +772,14 @@ def test_channel_plan_that_only_re_cites_positioning_is_refused_by_the_route(ctx
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
 
-    gateway.complete(
-        started["agent_run_id"],
-        messages=_channel_plan_call(),  # the approved positioning's own URL
+    resp = _drive_channel_plan(
+        client,
+        core,
+        gateway,
+        started,
+        _channel_plan_call(),  # the approved positioning's own URL
         annotations=[{"type": "url_citation", "url": "https://benchmarks.example/cpa"}],
     )
-
-    resp = client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
 
     assert resp.status_code == 502
     assert "instagram_organic" in resp.json()["detail"]
@@ -749,8 +793,7 @@ def test_channel_plan_artefact_can_be_approved(ctx) -> None:
     client, core, gateway = ctx
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
-    gateway.complete(started["agent_run_id"], messages=_channel_plan_call())
-    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")  # proposes it
+    _drive_channel_plan(client, core, gateway, started, _channel_plan_call())  # proposes it
 
     resp = client.post(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan/approve")
 
@@ -801,8 +844,7 @@ def _propose_and_approve_channel_plan(client, core, gateway) -> dict[str, Any]:
     — the state `start_copy_route` requires from both upstream stages."""
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
-    gateway.complete(started["agent_run_id"], messages=_channel_plan_call())
-    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")  # advances pending -> proposed
+    _drive_channel_plan(client, core, gateway, started, _channel_plan_call())
     return client.post(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan/approve").json()
 
 
@@ -835,8 +877,7 @@ def test_start_copy_refuses_when_channel_plan_is_not_approved(ctx) -> None:
     client, core, gateway = ctx
     _propose_and_approve_positioning(client, core, gateway)
     started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
-    gateway.complete(started["agent_run_id"], messages=_channel_plan_call())
-    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")  # proposed, not approved
+    _drive_channel_plan(client, core, gateway, started, _channel_plan_call())  # proposed only
 
     resp = client.post(f"/campaigns/{_CAMPAIGN}/copy")
 

--- a/tests/test_marketing_stage_models.py
+++ b/tests/test_marketing_stage_models.py
@@ -19,11 +19,14 @@ The two invariants worth pinning are the ones whose breakage is silent:
   retrieval that stage does not use and would make issue #90's "this run was
   never grounded" reasoning wrong about it.
 
-  Since issue #65 that set is ``research`` **and** ``channel_plan``. Channel
+  Since issue #65 that set is ``research`` **and** the channel stage. Channel
   planning asks "where does this audience convert", which research's evidence
   — gathered to answer "who is this audience and what do competitors say" —
-  cannot answer; it now retrieves its own. See
-  ``tests/test_marketing_channel_plan_grounding.py`` for the guards that make
+  cannot answer; it retrieves its own. Since that issue's second increment the
+  channel stage is two runs, and only the first of them retrieves: the
+  ``channel_evidence`` run grounds, and ``channel_plan`` is handed what it
+  found. See ``tests/test_marketing_channel_plan_grounding.py`` and
+  ``tests/test_marketing_two_step_channel_plan.py`` for the guards that make
   that retrieval mean something rather than merely happen.
 """
 
@@ -32,6 +35,7 @@ from __future__ import annotations
 import pytest
 
 from marketing.definitions import (
+    DEFAULT_CHANNEL_EVIDENCE_MODEL,
     DEFAULT_CHANNEL_PLAN_MODEL,
     DEFAULT_COPY_MODEL,
     DEFAULT_POSITIONING_MODEL,
@@ -44,6 +48,7 @@ _STAGE_MODELS = {
     "research": DEFAULT_RESEARCH_MODEL,
     "synthesis": DEFAULT_SYNTHESIS_MODEL,
     "positioning": DEFAULT_POSITIONING_MODEL,
+    "channel_evidence": DEFAULT_CHANNEL_EVIDENCE_MODEL,
     "channel_plan": DEFAULT_CHANNEL_PLAN_MODEL,
     "copy": DEFAULT_COPY_MODEL,
 }
@@ -54,16 +59,18 @@ _STAGE_MODELS = {
 #: than special-cased inline so the exception is one reviewable fact, not a
 #: condition buried in an assertion.
 #:
-#: `channel_plan` joined `research` in issue #65: it retrieves its own
-#: conversion evidence now, so it needs `:online`, and `:online` only
-#: demonstrably grounds on `sonnet-4` in this estate. That is a tier
-#: *downgrade* for an artefact-producing stage, taken deliberately — grounding
-#: that has been observed beats a tier whose grounding has been observed to be
-#: absent, and the fabrication risk the Opus tier was standing in for is now
-#: carried by mechanical guards (`UngroundedRecommendationError`, and
-#: provenance widened to the run's own `annotations`) rather than by trusting
-#: a better model.
-_GROUNDED_STAGES = frozenset({"research", "channel_plan"})
+#: `channel_plan` joined `research` here in issue #65, because the stage was
+#: one run that retrieved and decided together — a tier *downgrade* for an
+#: artefact-producing stage, taken because grounding that has been observed
+#: beats a tier whose grounding has been observed to be absent.
+#:
+#: The stage is now two runs (#65's second increment), and this set names the
+#: one that actually retrieves: `channel_evidence`. The pin has not been
+#: relaxed, it has been pointed at the run it is about — and `channel_plan`,
+#: which is handed the evidence and does not retrieve, goes back to the Claude
+#: 5 family every other artefact-producing stage uses. Both halves are
+#: asserted below, so neither can drift quietly.
+_GROUNDED_STAGES = frozenset({"research", "channel_evidence"})
 
 #: The one route in this estate whose `:online` grounding has actually been
 #: watched to work. #136's table, in one constant.
@@ -103,9 +110,13 @@ def test_every_stage_runs_on_the_claude_5_family(stage: str, model: str) -> None
 
 
 def test_exactly_the_retrieving_stages_carry_the_online_suffix() -> None:
-    """`:online` is grounded retrieval. Research and channel planning need it
-    (#65); nothing else does, and issue #90's not-grounded reasoning about the
-    synthesis run depends on that staying true."""
+    """`:online` is grounded retrieval. Research and the channel stage's
+    grounding run need it (#65); nothing else does — and both halves matter.
+    Losing it on `channel_evidence` leaves the stage with nothing to hand on;
+    *gaining* it on `channel_plan` would bill a second per-result retrieval to
+    inject a second unenumerated set into the context, which is the exact
+    condition the two-step exists to remove. Issue #90's not-grounded
+    reasoning about the synthesis run depends on this staying true too."""
     online = {stage for stage, model in _STAGE_MODELS.items() if ":online" in model}
 
     assert online == set(_GROUNDED_STAGES)

--- a/tests/test_marketing_two_step_channel_plan.py
+++ b/tests/test_marketing_two_step_channel_plan.py
@@ -1,0 +1,544 @@
+"""Ground in one run, structure in a second one that is HANDED the evidence
+(issue #65, after #155/#162).
+
+## What the live run on 2026-08-14 established, and what it left
+
+Retrieval on this stage works, and works well: `channel plan retrieval breadth:
+10 distinct URLs across 1 grounded run(s) (0 shared by more than one, 10 deep
+pages, 0 site roots)` — every page deep, not a single site root. The agent
+called its output tool (#162's fix) and recommended six channels. And
+`UngroundedRecommendationError` (#155) correctly refused all six: every source
+on every recommendation had been carried over from the approved positioning.
+
+So the gap is **citation behaviour, not grounding**. The model had its own
+evidence in context and did not treat it as citable. `:online` injects the
+retrieved pages into the context and records them on `annotations`, but nothing
+in the payload ever presented those URLs to the model *as an enumerated set it
+should cite from* — while the positioning's sources are enumerated, in the
+payload, as structured `Source` objects. It cited the list it could see.
+
+This module pins the two-step that closes that gap:
+
+1. **`marketing-channel-evidence`** — the `:online` run. Its job is to retrieve
+   and to read: it returns one note per page it was given. Its `annotations`
+   are what the runtime recorded, independent of the model.
+2. **`marketing-channel-plan`** — handed `retrieved_evidence` as the FIRST key
+   of its payload: one entry per URL the *runtime* recorded, each carrying what
+   step one said that page shows. It does not search, and cannot: it is not on
+   an `:online` route at all.
+
+Four properties are pinned here because each of them fails silently:
+
+* **The URL set handed to step two comes from `annotations`, never from the
+  model's own account of what it read.** Using step one's tool call as the
+  authority would reintroduce exactly the trust this pipeline refuses
+  everywhere else (`AgentRunView.annotations`' own docstring, #82) — and would
+  let a model invent a URL in step one and then "cite what it retrieved" in
+  step two.
+* **The guard's subject is step ONE's annotations.** Step two never grounds, so
+  its own `annotations` can only ever be the "not a grounded run" state.
+  Reading it would make `UngroundedRecommendationError` structurally blind —
+  the identical defect issue #90 found in `advance_research`, where the guard
+  was reading the synthesis run rather than the runs that retrieved.
+* **The guard is not softened.** Every assertion #155 shipped still holds; they
+  are simply now asked of a plan produced by a model that was shown the
+  evidence as a list.
+* **Step two is started exactly once.** The stage is polled, so anything
+  triggered by "the grounding run is terminal" happens on every poll unless the
+  transition is recorded.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+
+from marketing import pipeline
+from marketing.definitions import (
+    CHANNEL_EVIDENCE_AGENT_NAME,
+    CHANNEL_EVIDENCE_TOOL_NAME,
+    CHANNEL_PLAN_AGENT_NAME,
+    CHANNEL_PLAN_TOOL_NAME,
+    DEFAULT_CHANNEL_EVIDENCE_MODEL,
+    DEFAULT_CHANNEL_PLAN_MODEL,
+)
+
+_PARENT_URL = "https://positioning.example.com/segment-evidence"
+_RETRIEVED_URL = "https://benchmarks.example.com/paid-search-cpa-2026"
+_SECOND_RETRIEVED_URL = "https://casestudies.example.com/multi-site-operators"
+_UNRETRIEVED_URL = "https://invented.example.com/statistics"
+
+_ANNOTATIONS = [
+    {"type": "url_citation", "url": _RETRIEVED_URL, "title": "CPA benchmarks 2026"},
+    {"type": "url_citation", "url": _SECOND_RETRIEVED_URL, "title": "Operator case studies"},
+]
+
+_TAXONOMY: dict[str, Literal["organic", "paid"]] = {
+    "google_search_paid": "paid",
+    "linkedin_organic": "organic",
+}
+
+_TAXONOMY_ROWS = [
+    {
+        "channel_key": "google_search_paid",
+        "label": "Google Search ads",
+        "motion": "paid",
+        "category": "search",
+    }
+]
+
+_POSITIONING_BODY = {
+    "segments": [
+        {
+            "name": "Multi-location operators",
+            "description": "Run 3+ sites and cannot see them in one place.",
+            "sources": [{"url": _PARENT_URL, "note": "n"}],
+        }
+    ],
+    "pillars": [],
+    "ctas": [],
+}
+
+
+class _FakeGateway:
+    """Records every requested run and lets a test complete each one
+    independently — the two-step needs two runs in different states at once,
+    which the single-run fakes elsewhere cannot express."""
+
+    def __init__(self) -> None:
+        self.requested: list[dict[str, Any]] = []
+        self._runs: dict[str, pipeline.AgentRunView] = {}
+
+    async def request_agent_run(
+        self,
+        *,
+        agent_name: str,
+        definition: dict[str, Any],
+        output_tool: dict[str, Any],
+        input_payload: dict[str, Any],
+        causation_id: str,
+    ) -> str:
+        run_id = f"run-{len(self.requested) + 1}"
+        self.requested.append(
+            {
+                "agent_name": agent_name,
+                "definition": definition,
+                "output_tool": output_tool,
+                "input_payload": input_payload,
+                "causation_id": causation_id,
+            }
+        )
+        self._runs[run_id] = pipeline.AgentRunView(id=run_id, status="pending")
+        return run_id
+
+    async def find_chain_run(self, *, chain_id: str, agent_name: str):  # pragma: no cover
+        del chain_id, agent_name
+        return None
+
+    async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView | None:
+        return self._runs.get(run_id)
+
+    def complete(
+        self,
+        run_id: str,
+        *,
+        status: str = "completed",
+        messages: list[dict[str, Any]] | None = None,
+        annotations: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._runs[run_id] = pipeline.AgentRunView(
+            id=run_id, status=status, messages=messages or [], annotations=annotations
+        )
+
+
+def _tool_call(name: str, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"role": "assistant", "tool_calls": [{"function": {"name": name, "arguments": arguments}}]}
+    ]
+
+
+def _evidence_call(*urls: str) -> list[dict[str, Any]]:
+    return _tool_call(
+        CHANNEL_EVIDENCE_TOOL_NAME,
+        {"evidence": [{"url": url, "note": f"what {url} shows about conversion"} for url in urls]},
+    )
+
+
+def _channel(channel_key: str, *urls: str, rank: int = 1) -> dict[str, Any]:
+    return {
+        "channel_key": channel_key,
+        "rank": rank,
+        "rationale": "Where this segment demonstrably converts.",
+        "sources": [{"url": url, "note": "n"} for url in urls],
+    }
+
+
+def _plan_call(*channels: dict[str, Any]) -> list[dict[str, Any]]:
+    return _tool_call(CHANNEL_PLAN_TOOL_NAME, {"channels": list(channels)})
+
+
+def _plan_input() -> dict[str, Any]:
+    return pipeline.channel_plan_input(
+        positioning_body=_POSITIONING_BODY, taxonomy=_TAXONOMY_ROWS, campaign_motion="paid"
+    )
+
+
+async def _start_and_ground(
+    gateway: _FakeGateway,
+    *,
+    annotations: list[dict[str, Any]] | None,
+    evidence_urls: tuple[str, ...] = (_RETRIEVED_URL, _SECOND_RETRIEVED_URL),
+    status: str = "completed",
+) -> tuple[str, str]:
+    """Start the stage and complete its grounding run."""
+    causation_id, evidence_run_id = await pipeline.start_channel_evidence(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+    gateway.complete(
+        evidence_run_id,
+        status=status,
+        messages=_evidence_call(*evidence_urls),
+        annotations=annotations,
+    )
+    return causation_id, evidence_run_id
+
+
+# ── 1. Two runs, and only the first one grounds ──────────────────────────────
+
+
+def test_the_grounding_run_is_the_one_on_the_observed_online_route() -> None:
+    """#136 leaves exactly one route in this estate whose `:online` grounding
+    has been watched to work. The two-step does not move it — it points it at
+    the run that actually retrieves."""
+    assert DEFAULT_CHANNEL_EVIDENCE_MODEL == "anthropic/claude-sonnet-4:online"
+
+
+def test_the_planning_run_does_not_retrieve_at_all() -> None:
+    """Handed the evidence, step two has nothing to search for. `:online` bills
+    per result, so a second retrieval would pay twice for the same question —
+    and would inject a SECOND unenumerated set into the context, which is the
+    exact condition this two-step exists to remove."""
+    assert ":online" not in DEFAULT_CHANNEL_PLAN_MODEL
+
+
+@pytest.mark.asyncio
+async def test_starting_the_stage_starts_the_grounding_run_not_the_plan() -> None:
+    gateway = _FakeGateway()
+    causation_id, _ = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+
+    (requested,) = gateway.requested
+    assert requested["agent_name"] == CHANNEL_EVIDENCE_AGENT_NAME
+    assert requested["causation_id"] == causation_id
+    assert next(iter(requested["input_payload"])) == "search_query"
+
+
+@pytest.mark.asyncio
+async def test_advancing_a_finished_grounding_run_starts_the_plan_run() -> None:
+    """On the same causation chain — research already fans out and joins on
+    `causation_id`, and per-campaign spend is assembled from it."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+
+    advance = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+
+    assert advance.plan is None
+    assert advance.started_plan_run_id == "run-2"
+    plan_request = gateway.requested[1]
+    assert plan_request["agent_name"] == CHANNEL_PLAN_AGENT_NAME
+    assert plan_request["causation_id"] == causation_id
+    assert ":online" not in plan_request["definition"]["model"]
+
+
+@pytest.mark.asyncio
+async def test_the_plan_run_is_started_once_however_often_the_stage_is_polled() -> None:
+    """Reading is what advances this pipeline, so "the grounding run is
+    terminal" is true on every poll. Passing the started run's id back is what
+    makes the transition happen once — the same reason the live breadth line
+    was logged five times in eight seconds."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+
+    first = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+    again = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        plan_run_id=first.started_plan_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+
+    assert again.started_plan_run_id is None
+    assert again.plan is None  # the plan run has not finished yet
+    assert len(gateway.requested) == 2
+
+
+# ── 2. What step two is handed, and where it comes from ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_step_two_is_handed_the_retrieved_urls_as_an_enumerated_set() -> None:
+    """The whole point of the two-step. The positioning's sources reach the
+    model as structured objects it can see and cite; until now its own
+    retrieval reached it only as injected context, and it cited the list it
+    could see. `retrieved_evidence` is that list, and it leads the payload for
+    the same reason `search_query` leads the grounding run's."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+
+    await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+
+    payload = gateway.requested[1]["input_payload"]
+    assert next(iter(payload)) == "retrieved_evidence"
+    assert [entry["url"] for entry in payload["retrieved_evidence"]] == [
+        _RETRIEVED_URL,
+        _SECOND_RETRIEVED_URL,
+    ]
+    # ...carrying what the runtime recorded about the page AND what step one
+    # read in it, so a rationale can be written from the page rather than from
+    # the URL string.
+    first = payload["retrieved_evidence"][0]
+    assert first["title"] == "CPA benchmarks 2026"
+    assert _RETRIEVED_URL in first["what_it_says"]
+    # ...and the positioning still travels, because a plan may legitimately
+    # lean on it — it simply may not lean on it alone.
+    assert payload["positioning"] == _POSITIONING_BODY
+    assert payload["campaign_motion"] == "paid"
+    assert "search_query" not in payload  # nothing to search: it does not retrieve
+
+
+@pytest.mark.asyncio
+async def test_a_url_only_the_model_claims_to_have_read_is_not_handed_on() -> None:
+    """The trust boundary, and the reason the URL set is taken from
+    `annotations` rather than from step one's tool call. If the model's own
+    account were the authority, a URL invented in step one would come back in
+    step two as "evidence this run retrieved" and satisfy the very guard that
+    exists to catch it."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(
+        gateway,
+        annotations=_ANNOTATIONS,
+        evidence_urls=(_RETRIEVED_URL, _UNRETRIEVED_URL),
+    )
+
+    await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+
+    handed = gateway.requested[1]["input_payload"]["retrieved_evidence"]
+    urls = [entry["url"] for entry in handed]
+    assert _UNRETRIEVED_URL not in urls
+    assert urls == [_RETRIEVED_URL, _SECOND_RETRIEVED_URL]
+    # The page the runtime recorded but step one wrote no note for is still
+    # handed over — it was retrieved, so it is citable; it simply arrives
+    # without a reading.
+    assert handed[1]["what_it_says"] == ""
+
+
+@pytest.mark.asyncio
+async def test_a_grounding_run_that_retrieved_nothing_hands_over_nothing() -> None:
+    """`annotations == []` is the one state that genuinely means retrieval
+    returned nothing, and it must not be dressed up as an empty-because-unknown
+    set. Step two is handed an empty list, and every recommendation it then
+    makes is ungrounded by construction."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=[])
+
+    await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+
+    assert gateway.requested[1]["input_payload"]["retrieved_evidence"] == []
+
+
+# ── 3. The guard reads the run that retrieved (issue #90's lesson) ──────────
+
+
+@pytest.mark.asyncio
+async def test_the_plan_is_judged_against_the_grounding_runs_retrieval() -> None:
+    """Step two is not an `:online` run, so its own `annotations` can only ever
+    be "not a grounded run" — the state that skips both evidence checks. The
+    subject has to be the run that actually retrieved, exactly as
+    `_aggregate_research_annotations` does for synthesis (#90). Getting this
+    wrong would switch off `UngroundedRecommendationError` without deleting a
+    line of it."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+    first = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+    # The failure the live run produced: a plan resting entirely on the
+    # positioning's carried-over sources, from a run whose own annotations are
+    # `None` because it never grounded.
+    gateway.complete(
+        first.started_plan_run_id or "",
+        messages=_plan_call(_channel("google_search_paid", _PARENT_URL)),
+        annotations=None,
+    )
+
+    with pytest.raises(pipeline.UngroundedRecommendationError) as excinfo:
+        await pipeline.advance_channel_plan(
+            gateway,
+            evidence_run_id=evidence_run_id,
+            plan_run_id=first.started_plan_run_id,
+            taxonomy=_TAXONOMY,
+            plan_input=_plan_input(),
+            causation_id=causation_id,
+            allowed_source_urls=[_PARENT_URL],
+        )
+
+    assert "google_search_paid" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_a_plan_citing_what_the_grounding_run_retrieved_is_accepted() -> None:
+    """The path that has never yet completed on a live campaign, and the one
+    the whole change is for."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+    first = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+    )
+    gateway.complete(
+        first.started_plan_run_id or "",
+        messages=_plan_call(_channel("google_search_paid", _PARENT_URL, _RETRIEVED_URL)),
+        annotations=None,
+    )
+
+    advance = await pipeline.advance_channel_plan(
+        gateway,
+        evidence_run_id=evidence_run_id,
+        plan_run_id=first.started_plan_run_id,
+        taxonomy=_TAXONOMY,
+        plan_input=_plan_input(),
+        causation_id=causation_id,
+        allowed_source_urls=[_PARENT_URL],
+    )
+
+    assert advance.plan is not None
+    assert advance.plan.channels[0].channel_key == "google_search_paid"
+    assert advance.started_plan_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_grounding_run_fails_the_stage_without_starting_a_plan() -> None:
+    """Paying for a planning run over evidence that never arrived is the one
+    thing worse than failing here."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(
+        gateway, annotations=_ANNOTATIONS, status="failed"
+    )
+
+    with pytest.raises(pipeline.RunNotSucceededError):
+        await pipeline.advance_channel_plan(
+            gateway,
+            evidence_run_id=evidence_run_id,
+            taxonomy=_TAXONOMY,
+            plan_input=_plan_input(),
+            causation_id=causation_id,
+        )
+
+    assert len(gateway.requested) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_grounding_run_that_never_called_its_tool_is_a_malformed_run() -> None:
+    """Step one's notes are what make step two able to write a rationale from
+    the page rather than from the URL. A run that returned prose instead is the
+    #159 shape, and it is reported as such rather than silently handing over
+    URLs with no readings."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await pipeline.start_channel_evidence(
+        gateway,
+        positioning_body=_POSITIONING_BODY,
+        taxonomy=_TAXONOMY_ROWS,
+        campaign_motion="paid",
+    )
+    gateway.complete(evidence_run_id, messages=[], annotations=_ANNOTATIONS)
+
+    with pytest.raises(pipeline.MalformedOutputError) as excinfo:
+        await pipeline.advance_channel_plan(
+            gateway,
+            evidence_run_id=evidence_run_id,
+            taxonomy=_TAXONOMY,
+            plan_input=_plan_input(),
+            causation_id=causation_id,
+        )
+
+    assert CHANNEL_EVIDENCE_TOOL_NAME in str(excinfo.value)
+
+
+# ── 4. The breadth line is measured once per run, not once per poll ─────────
+
+
+def _breadth_records(caplog: pytest.LogCaptureFixture) -> list[Any]:
+    return [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("channel plan retrieval breadth")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_breadth_line_is_emitted_once_per_run_not_once_per_poll(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Measured on the live run: the same measurement at 13:26:22, :24, :26,
+    :28 and :30 — once per poll of the advance route, not once per run.
+    Harmless to the campaign, and actively misleading to anyone counting runs
+    from the logs, which is the one thing this instrument exists to be read
+    for."""
+    gateway = _FakeGateway()
+    causation_id, evidence_run_id = await _start_and_ground(gateway, annotations=_ANNOTATIONS)
+
+    with caplog.at_level("INFO"):
+        for _ in range(3):
+            await pipeline.advance_channel_plan(
+                gateway,
+                evidence_run_id=evidence_run_id,
+                taxonomy=_TAXONOMY,
+                plan_input=_plan_input(),
+                causation_id=causation_id,
+            )
+
+    (record,) = _breadth_records(caplog)
+    assert "2 distinct URLs across 1 grounded run(s)" in record.getMessage()
+    assert record.causation_id == causation_id


### PR DESCRIPTION
On tabsii dev, 2026-08-14, after #162: retrieval on this stage is excellent —
`channel plan retrieval breadth: 10 distinct URLs across 1 grounded run(s) (0 shared by more than one, 10 deep pages, 0 site roots)`.
The agent called `submit_channel_plan` and recommended 6 channels.
`UngroundedRecommendationError` refused all six, correctly: every source on every
recommendation had been carried over from the approved positioning.

**The gap is citation behaviour, not grounding.** `:online` injects the retrieved
pages into context and records them on `annotations`, but nothing ever presented
those URLs to the model *as an enumerated set to cite from* — while the
positioning's sources arrive as structured `Source` objects it can see and copy.
It cited the list it could see.

## The two-step

| Run | Agent | Route | Job |
|---|---|---|---|
| 1 | `marketing-channel-evidence` (new) | `sonnet-4:online` | Retrieve and read. Returns one note per page via `submit_channel_evidence`. |
| 2 | `marketing-channel-plan` | `claude-opus-5`, **no** `:online` | Decide. Handed `retrieved_evidence` as the FIRST key of its payload. |

`retrieved_evidence` is one entry per URL the **runtime** recorded, each carrying
the annotation's `title`, any page text the runtime captured, and `what_it_says`
— step one's reading of that page.

## The four decisions, made deliberately

**1. Where the URLs come from: `annotations`, never the model.** `annotations`
is the runtime's own record (#82) and is already what `evidence_profile` reads.
Step one's notes are merged onto that spine by `_url_key`; a note for a URL the
runtime never recorded is **dropped**, not forwarded. Using the model's account
of what it read would let it invent a URL in step one and then "cite what it
retrieved" in step two — satisfying the very guard that exists to catch it. The
tri-state is preserved end to end: `None` in, `None` out.

**2. Does step two need `:online`? No.** It is handed the evidence, so a second
retrieval buys nothing, bills a second time (`:online` bills per result), and
would inject a *second unenumerated set* into the context — the exact condition
this change exists to remove. It also means step two's own `annotations` is
`None`, so it is structurally incapable of widening the citable set.

**3. The guard's subject is step ONE's annotations.** Step two never grounds, so
its own `annotations` can only ever be the "not a grounded run" state — which
*skips* both evidence checks. Reading it would leave `UngroundedRecommendationError`
unable to fire without a line of it being deleted. That is the identical defect
issue #90 found in `advance_research`, and `_aggregate_research_annotations` is
the same fix one stage up. **Nothing about the guard is softened** — every
assertion #155 shipped still holds, and `test_the_plan_is_judged_against_the_grounding_runs_retrieval`
pins exactly this.

**4. Sequential, not fanned out.** Research's fan-out fans in through the
orchestration engine, which passes the children's *outputs* — it has no way to
pass `annotations`, the one input here worth having precisely because the model
did not write it — and its config is a frozen seeded copy (#160/#161), so using
it would add a second seeded workflow to keep in step across environments. There
is also one sibling to wait for, not N. Reading already advances this pipeline
(`admin_app._advance_artefact`), so step two is started from the poll that
observes step one finishing: **one `causation_id` across both runs**, no second
orchestration pattern. The started run's id is persisted on the pending
artefact, which is what makes the transition happen exactly once rather than
starting (and billing) a planning run on every poll.

## The tier the split gives back

`DEFAULT_CHANNEL_PLAN_MODEL` returns to `claude-opus-5` — the family every other
artefact-producing stage uses. #155's downgrade to `sonnet-4:online` was *forced*,
not chosen: a stage that had to retrieve could only run on the one route #136
observed grounding. Splitting retrieval out lifts the constraint.

**The `:online` pin is not relaxed — it moves to the run that retrieves.**
`DEFAULT_CHANNEL_EVIDENCE_MODEL == "anthropic/claude-sonnet-4:online"`, and
`test_marketing_stage_models.py` now asserts *both* halves (`channel_evidence`
must be the observed grounded route; `channel_plan` must be Claude 5 and must
**not** carry `:online`), so neither can drift quietly.

## Cost and wall clock

- **Retrieval bill unchanged.** Exactly one run carries `:online`, and `:online`
  bills per result.
- **Roughly a doubling overall.** The failing single run billed **$0.1344**. Step
  one is that run's shape minus the plan generation; step two adds an Opus-tier
  call (list $5 / $25 per MTok) over ~10 evidence entries plus the positioning
  body. Page text carried forward is bounded per page (`EVIDENCE_EXCERPT_CHARS`)
  so the payload cannot grow without limit.
- **No run gets closer to the ceiling.** `AGENT_TIMEOUT_SECONDS` is 240s and the
  clock is **per run**; the stage is advanced by polling rather than held open
  across both, so each run has the full budget. The failing run took 16.6s.
- **One extra poll interval** (~2s on the live run) at the hand-over.

## Also fixed: the breadth line, once per run

Logged five times in eight seconds live (13:26:22, :24, :26, :28, :30) — once
per *poll*, because a terminal run that cannot be advanced past is re-read for as
long as an operator leaves the page open. `_log_evidence_profile` now
de-duplicates on `(stage, chain, run ids)`, which covers research's identical
case in the same implementation rather than a near-copy. `_BREADTH_REPORTED`
states plainly what that does and does not promise: one line per run set per
warm container; a cold start repeats a line, never a wrong number.

## Tests: failed first, pass now

`tests/test_marketing_two_step_channel_plan.py` is new (13 tests). Before the
change it could not even be collected:

```
$ uv run pytest tests/test_marketing_two_step_channel_plan.py -x -q
ERROR collecting tests/test_marketing_two_step_channel_plan.py
E   ImportError: cannot import name 'CHANNEL_EVIDENCE_AGENT_NAME' from 'marketing.definitions'
1 error in 0.38s
```

After:

```
$ uv run pytest tests/test_marketing_two_step_channel_plan.py -q
.............                                                            [100%]
13 passed in 0.14s

$ uv run pytest -q
773 passed, 4 skipped, 4 warnings in 6.87s
```

Two existing guards fired on the way through and were acknowledged, not worked
around: `discover_definition_factories()`'s count pin (5 → 6) and
`test_every_persisted_body_write_stamps_element_ids` (the new PATCH now goes
through `with_element_ids`).

## Seeding

**`SEEDED_CONFIG_FINGERPRINT` does not move.** It covers the research-synthesis
fan-in `action_config` only, and nothing here touches that prompt — the
fingerprint test is green in this PR. No re-seed is required *for this change*;
the one #162 recorded is still outstanding and unaffected.

## What this does not claim

**Whether the model now cites the list it is handed is only provable on a live
run.** These tests prove the enumerated set is built from the runtime's record
rather than the model's account, that the planning run is started exactly once,
that the guard reads the grounding run's annotations, and that a plan resting on
positioning's sources still fails — none of which is evidence about model
behaviour. Campaign `VERIFY GROUNDING 0814` (`b28334cd-8e6a-4b67-997c-2e7eb71d981d`)
is parked at exactly this stage.

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
