### PR TITLE
fix(marketing): report WHY a run failed, not only that it did

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -448,6 +448,15 @@ class _CoreAgentGateway:
             # because `synthesis_config_drift` must not read an unknown
             # snapshot as a clean bill of health.
             definition_snapshot=run.get("definition_snapshot"),
+            # Why a failed run failed, in the runtime's own words (issue #164).
+            # Core's `AgentRunResponse.error` — the one field that separates
+            # "the provider refused the request" from "the model produced
+            # nothing" from "the wall clock ran out", all three of which reach
+            # an operator as the same sentence without it. Absent stays `None`
+            # ("not known"), never `""`, for the same reason as the two fields
+            # above: `run_not_succeeded` says "Core recorded no reason" out
+            # loud, and it must only say that when there genuinely was none.
+            error=run.get("error"),
         )
 
 

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -201,7 +201,12 @@ class MalformedOutputError(PipelineError):
 
 
 class RunNotSucceededError(PipelineError):
-    """An agent run this stage was waiting on finished without succeeding."""
+    """An agent run this stage was waiting on finished without succeeding.
+
+    **Always constructed through :func:`run_not_succeeded`, never directly** —
+    see that function for why, and ``tests/test_marketing_run_failure_reason.py``
+    for the sweep that enforces it.
+    """
 
 
 class ArtefactNotApprovedError(PipelineError):
@@ -1239,6 +1244,15 @@ class AgentRunView:
     snapshot is carried here at all. ``None`` means "not known": a view built
     from a list row rather than the detail endpoint, or a Core too old to
     return the field. It never means "matches".
+
+    ``error`` is Core's ``AgentRunResponse.error``: **why** the run failed, in
+    the runtime's own words — the provider's status line, the wall-clock hard
+    stop, an unregistered tool. It is the only place that reason exists (issue
+    #164: a positioning run died in 0.048s, the runtime logged no ERROR because
+    it had not failed *itself*, and Core held ``OpenRouter returned 402: This
+    request requires more credits…`` that nothing read). Same tri-state as the
+    two fields above: ``None`` means "not known", never "the run failed for no
+    reason".
     """
 
     id: str
@@ -1246,6 +1260,7 @@ class AgentRunView:
     messages: list[dict[str, Any]] = field(default_factory=list)
     annotations: list[dict[str, Any]] | None = None
     definition_snapshot: dict[str, Any] | None = None
+    error: str | None = None
 
     @property
     def is_terminal(self) -> bool:
@@ -1254,6 +1269,66 @@ class AgentRunView:
     @property
     def succeeded(self) -> bool:
         return self.status == RUN_COMPLETED
+
+
+#: How much of a failed run's recorded error travels in the message an operator
+#: is shown.
+#:
+#: The runtime already truncates a provider's response body before storing it,
+#: so this bounds a string that is usually a few hundred characters — enough to
+#: carry ``OpenRouter returned 402: This request requires more credits, or fewer
+#: max_tokens. You requested up to 65536 tokens, but can only afford 57975``,
+#: which is the whole diagnosis, while keeping a provider that returns an HTML
+#: error page from filling a toast.
+RUN_ERROR_EXCERPT_CHARS = 400
+
+
+def _run_error_excerpt(error: str | None) -> str:
+    """One failed run's reason, collapsed onto a single line and bounded.
+
+    Returns ``""`` for anything unusable — absent, blank, or not a string — so
+    the caller's "Core recorded no reason" branch means exactly that.
+    """
+    if not isinstance(error, str):
+        return ""
+    collapsed = " ".join(error.split())
+    if len(collapsed) <= RUN_ERROR_EXCERPT_CHARS:
+        return collapsed
+    return f"{collapsed[:RUN_ERROR_EXCERPT_CHARS]}…"
+
+
+def run_not_succeeded(message: str, *views: AgentRunView | None) -> RunNotSucceededError:
+    """The failure a stage raises when the run it waited on did not succeed —
+    **carrying the reason Core recorded**, not just the fact.
+
+    Every ``RunNotSucceededError`` in this module is built here, and the sweep
+    in ``tests/test_marketing_run_failure_reason.py`` fails if one is
+    constructed directly, for the reason issue #164 cost an afternoon:
+    ``"The positioning run did not complete successfully."`` is true of a bad
+    definition, a wall-clock timeout, a provider outage and an exhausted
+    OpenRouter balance alike, and it is the entire text an operator (or the
+    next agent to debug this) is given. The distinguishing sentence already
+    existed one hop away, on the run row, and every stage discarded it — so the
+    diagnosis went to CloudWatch, to three merged PRs and to a bisect, and the
+    answer was "add credits".
+
+    Deliberately variadic: research's fan-in fails against a *set* of runs, and
+    two runs that died differently are two different diagnoses. Duplicate
+    reasons collapse — two runs killed by the same exhausted balance is one
+    fact, not two.
+    """
+    reasons: list[str] = []
+    for view in views:
+        reason = _run_error_excerpt(view.error if view is not None else None)
+        if reason and reason not in reasons:
+            reasons.append(reason)
+    if not reasons:
+        # Said out loud rather than left as a bare sentence: "Core recorded no
+        # reason" and "nobody looked" are different problems with different
+        # fixes, and the whole point of this function is that the reader can
+        # tell which one they have.
+        return RunNotSucceededError(f"{message} Core recorded no reason for the failure.")
+    return RunNotSucceededError(f"{message} The run reported: {' | '.join(reasons)}")
 
 
 class AgentGateway(Protocol):
@@ -1825,7 +1900,9 @@ async def advance_research(
             await _log_evidence_profile_for(
                 gateway, chain_id=chain_id, research_run_ids=research_run_ids
             )
-            raise RunNotSucceededError("The research-synthesis run did not complete successfully.")
+            raise run_not_succeeded(
+                "The research-synthesis run did not complete successfully.", synthesis_run
+            )
         research_views = [await gateway.get_agent_run(run_id=rid) for rid in research_run_ids]
         _log_evidence_profile(chain_id=chain_id, views=research_views)
         return extract_research_synthesis(
@@ -1849,9 +1926,10 @@ async def advance_research(
     # have retrieved before it died, and "what did retrieval return?" is the
     # whole question on this path.
     _log_evidence_profile(chain_id=chain_id, views=views)
-    raise RunNotSucceededError(
+    raise run_not_succeeded(
         "Every research agent failed to return usable findings. Nothing was found "
-        "to synthesise — try running research again."
+        "to synthesise — try running research again.",
+        *views,
     )
 
 
@@ -1905,7 +1983,7 @@ async def advance_positioning(
     if view is None or not view.is_terminal:
         return None
     if not view.succeeded:
-        raise RunNotSucceededError("The positioning run did not complete successfully.")
+        raise run_not_succeeded("The positioning run did not complete successfully.", view)
     return extract_positioning(
         view.messages, allowed_source_urls=allowed_source_urls, annotations=view.annotations
     )
@@ -2110,7 +2188,9 @@ async def advance_channel_plan(
     # while it is still in flight.
     _log_evidence_profile(chain_id=causation_id, views=[evidence_view], stage="channel_plan")
     if not evidence_view.succeeded:
-        raise RunNotSucceededError("The channel-plan evidence run did not complete successfully.")
+        raise run_not_succeeded(
+            "The channel-plan evidence run did not complete successfully.", evidence_view
+        )
 
     if plan_run_id is None:
         evidence_set = extract_channel_evidence(evidence_view.messages)
@@ -2150,7 +2230,7 @@ async def advance_channel_plan(
     if plan_view is None or not plan_view.is_terminal:
         return ChannelPlanAdvance()
     if not plan_view.succeeded:
-        raise RunNotSucceededError("The channel-plan run did not complete successfully.")
+        raise run_not_succeeded("The channel-plan run did not complete successfully.", plan_view)
     return ChannelPlanAdvance(
         plan=extract_channel_plan(
             plan_view.messages,
@@ -2204,7 +2284,7 @@ async def advance_copy(
     if view is None or not view.is_terminal:
         return None
     if not view.succeeded:
-        raise RunNotSucceededError("The copy run did not complete successfully.")
+        raise run_not_succeeded("The copy run did not complete successfully.", view)
     return extract_copy(
         view.messages,
         channel_plan_channels=channel_plan_channels,

--- a/tests/test_marketing_run_failure_reason.py
+++ b/tests/test_marketing_run_failure_reason.py
@@ -1,0 +1,335 @@
+"""A failed agent run must tell an operator WHY, not only that it failed
+(issue #164).
+
+## The defect this closes
+
+On 2026-08-14 the positioning stage began failing on a fresh campaign in
+**0.048 seconds**. The runtime logged no `ERROR` — it had not failed itself, it
+had faithfully reported someone else's failure — and the plugin rendered:
+
+    The positioning run did not complete successfully. (502)
+
+That sentence is true of a malformed definition, an unregistered tool, a
+wall-clock timeout, a provider outage and an exhausted OpenRouter balance
+alike. So the diagnosis went to CloudWatch, then to the three PRs that had
+merged since the last success, then towards a bisect — while Core had held the
+answer on the run row the whole time:
+
+    LLM call failed on turn 1: OpenRouter returned 402: This request requires
+    more credits, or fewer max_tokens. You requested up to 65536 tokens, but
+    can only afford 57975.
+
+Nothing in this plugin read `AgentRunResponse.error`. `AgentRunView` had no
+field for it, so it could not have.
+
+## What is guarded here, and what is NOT
+
+**Is:** the reason survives the trip from Core's JSON onto the view and into
+the message an operator is shown, for **every** stage — swept from the source
+rather than listed, because "adopted at some call sites and not others" is this
+repo's most-repeated defect class (`test_marketing_helper_adoption_sweep.py`'s
+docstring; #72, #49/#111).
+
+**Is not:** the 402 itself. No unit test can produce a real provider's
+credit refusal — that needs a real run against a real account with a real
+balance. What a test *can* guarantee is that when it happens again, the person
+looking at the screen is told which of the five candidate causes it was. That
+is the difference between an afternoon and a minute, and it is the whole of
+what ships here.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from marketing import admin_app, pipeline
+
+#: The real thing, verbatim from run `64ee7319-c623-4137-89db-ac7017260e2c` on
+#: tabsii dev (truncated by the runtime before it was stored, as every provider
+#: body is). Used rather than `"boom"` so the assertions below are about the
+#: string an operator will actually meet.
+_REAL_402 = (
+    "LLM call failed on turn 1: OpenRouter returned 402: "
+    '{"error":{"message":"This request requires more credits, or fewer max_tokens. '
+    "You requested up to 65536 tokens, but can only afford 57975. To increase, visit "
+    'https://openrouter.ai/settings/credits and add more credits","code":402}}'
+)
+
+_PIPELINE_SOURCE = Path(pipeline.__file__)
+
+
+class _FailingGateway:
+    """Every run this gateway is asked about is terminal, failed, and carries
+    `error`. Enough for the advancers below, which all read the same seam."""
+
+    def __init__(self, error: str | None = _REAL_402) -> None:
+        self._error = error
+        self.requested: list[str] = []
+
+    async def request_agent_run(
+        self,
+        *,
+        agent_name: str,
+        definition: dict[str, Any],
+        output_tool: dict[str, Any],
+        input_payload: dict[str, Any],
+        causation_id: str,
+    ) -> str:
+        del definition, output_tool, input_payload, causation_id
+        self.requested.append(agent_name)
+        return "run-started"
+
+    async def find_chain_run(
+        self, *, chain_id: str, agent_name: str
+    ) -> pipeline.AgentRunView | None:
+        del chain_id
+        if agent_name != pipeline.RESEARCH_SYNTHESIS_AGENT_NAME:
+            return None
+        return self._view("synthesis-run")
+
+    async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView | None:
+        return self._view(run_id)
+
+    def _view(self, run_id: str) -> pipeline.AgentRunView:
+        return pipeline.AgentRunView(id=run_id, status="failed", messages=[], error=self._error)
+
+
+class _NoSynthesisGateway(_FailingGateway):
+    """Research's other terminal path: the engine never fired a synthesis run
+    because every research run had already failed (#164 touches this one too —
+    two runs that died differently are two diagnoses)."""
+
+    async def find_chain_run(
+        self, *, chain_id: str, agent_name: str
+    ) -> pipeline.AgentRunView | None:
+        del chain_id, agent_name
+        return None
+
+
+# ── Every stage surfaces the reason ───────────────────────────────────────────
+#
+# One case per advancer, named by the stage, so a failure says which surface
+# regressed. The sweep further down is what stops a *seventh* stage being added
+# without one.
+
+
+async def _advance_research(gateway: Any) -> None:
+    await pipeline.advance_research(
+        gateway, chain_id="chain-1", research_run_ids=["research-1", "research-2"]
+    )
+
+
+async def _advance_positioning(gateway: Any) -> None:
+    await pipeline.advance_positioning(gateway, run_id="positioning-1")
+
+
+async def _advance_channel_evidence(gateway: Any) -> None:
+    taxonomy: dict[str, Literal["organic", "paid"]] = {"linkedin_organic": "organic"}
+    await pipeline.advance_channel_plan(gateway, evidence_run_id="evidence-1", taxonomy=taxonomy)
+
+
+async def _advance_copy(gateway: Any) -> None:
+    channels: dict[str, Literal["organic", "paid"]] = {"linkedin_organic": "organic"}
+    await pipeline.advance_copy(gateway, run_id="copy-1", channel_plan_channels=channels)
+
+
+_STAGES = {
+    "research-synthesis": _advance_research,
+    "positioning": _advance_positioning,
+    "channel-plan evidence": _advance_channel_evidence,
+    "copy": _advance_copy,
+}
+
+
+@pytest.mark.parametrize("stage", sorted(_STAGES))
+@pytest.mark.asyncio
+async def test_every_stage_reports_the_reason_core_recorded(stage: str) -> None:
+    """The provider's own words reach the exception message — the sentence
+    that would have ended #164's diagnosis on sight."""
+    with pytest.raises(pipeline.RunNotSucceededError) as raised:
+        await _STAGES[stage](_FailingGateway())
+
+    message = str(raised.value)
+    assert "402" in message
+    assert "more credits" in message
+    # The stage is still named: the reason is added to the existing sentence,
+    # never substituted for it — an operator needs both "which stage" and "why".
+    assert "did not complete successfully" in message or "research agent failed" in message
+
+
+@pytest.mark.asyncio
+async def test_research_reports_the_reason_when_no_synthesis_run_ever_fired() -> None:
+    """Research's second terminal path: no synthesis run exists because every
+    research run failed. The reasons come off the research runs themselves."""
+    with pytest.raises(pipeline.RunNotSucceededError) as raised:
+        await _advance_research(_NoSynthesisGateway())
+
+    assert "402" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_the_channel_plan_run_reports_its_own_reason() -> None:
+    """The planning run, not the grounding run — the only advancer with two
+    runs of its own, and the one a `*_view` mix-up would silently skip."""
+
+    class _EvidenceSucceeded(_FailingGateway):
+        async def get_agent_run(self, *, run_id: str) -> pipeline.AgentRunView | None:
+            if run_id == "evidence-1":
+                return pipeline.AgentRunView(
+                    id=run_id,
+                    status="completed",
+                    messages=[],
+                    annotations=[{"type": "url_citation", "url": "https://example.com/a"}],
+                )
+            return self._view(run_id)
+
+    taxonomy: dict[str, Literal["organic", "paid"]] = {"linkedin_organic": "organic"}
+    with pytest.raises(pipeline.RunNotSucceededError) as raised:
+        await pipeline.advance_channel_plan(
+            _EvidenceSucceeded(),
+            evidence_run_id="evidence-1",
+            plan_run_id="plan-1",
+            taxonomy=taxonomy,
+        )
+
+    assert "402" in str(raised.value)
+
+
+# ── "No reason recorded" is said out loud ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_run_with_no_recorded_error_says_so_rather_than_going_quiet() -> None:
+    """`None` means "Core recorded nothing", which is a different problem from
+    "nobody looked" and must not read like the old bare sentence — otherwise
+    the next reader cannot tell whether this fix is even deployed."""
+    with pytest.raises(pipeline.RunNotSucceededError) as raised:
+        await pipeline.advance_positioning(_FailingGateway(error=None), run_id="p-1")
+
+    assert "Core recorded no reason" in str(raised.value)
+
+
+def test_the_reason_is_bounded_and_collapsed_onto_one_line() -> None:
+    """A provider that answers with an HTML error page must not fill the
+    operator's screen, and a multi-line body must not break the message."""
+    built = pipeline.run_not_succeeded(
+        "The positioning run did not complete successfully.",
+        pipeline.AgentRunView(id="r", status="failed", error="a\nb   c" + "x" * 5000),
+    )
+
+    message = str(built)
+    assert "\n" not in message
+    assert "a b cxxx" in message
+    assert len(message) < 200 + pipeline.RUN_ERROR_EXCERPT_CHARS
+    assert message.endswith("…")
+
+
+def test_two_runs_that_failed_identically_report_one_reason() -> None:
+    """Both research angles killed by the same exhausted balance is one fact.
+    Repeating it twice is how a useful message becomes an ignored one."""
+    views = [
+        pipeline.AgentRunView(id="a", status="failed", error=_REAL_402),
+        pipeline.AgentRunView(id="b", status="failed", error=_REAL_402),
+    ]
+
+    message = str(pipeline.run_not_succeeded("Every research agent failed.", *views))
+
+    assert message.count("can only afford 57975") == 1
+
+
+def test_two_runs_that_failed_differently_report_both_reasons() -> None:
+    """…and two different deaths are two diagnoses. Collapsing them would hide
+    the interesting one behind the boring one."""
+    views = [
+        pipeline.AgentRunView(id="a", status="failed", error=_REAL_402),
+        pipeline.AgentRunView(
+            id="b", status="failed", error="Wall-clock limit of 240s reached before turn 1"
+        ),
+    ]
+
+    message = str(pipeline.run_not_succeeded("Every research agent failed.", *views))
+
+    assert "402" in message
+    assert "Wall-clock limit" in message
+
+
+# ── The seam: Core's JSON -> the view ─────────────────────────────────────────
+
+
+class _FakeClient:
+    """`_CoreAgentGateway` only ever calls `.get`/`.post` on its client —
+    see `test_marketing_agent_gateway.py`'s docstring for why a duck type is
+    enough here."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        del path, params
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_carries_cores_error_onto_the_view() -> None:
+    """The field the whole fix rests on. Inert unless it survives this hop —
+    exactly the failure mode `annotations` and `definition_snapshot` each have
+    their own test for in `test_marketing_agent_gateway.py`."""
+    run = {"id": "run-1", "status": "failed", "messages": [], "error": _REAL_402}
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.error == _REAL_402
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_defaults_a_missing_error_to_none() -> None:
+    """Absent stays `None` ("not known"), never `""` — `run_not_succeeded`
+    reports "Core recorded no reason" only when there genuinely was none."""
+    run = {"id": "run-1", "status": "completed", "messages": []}
+    gateway = admin_app._CoreAgentGateway(_FakeClient(run))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-1")
+
+    assert view is not None
+    assert view.error is None
+
+
+# ── The sweep: no stage may bypass the helper ─────────────────────────────────
+
+
+def test_no_stage_constructs_run_not_succeeded_error_directly() -> None:
+    """`RunNotSucceededError(...)` is built in exactly one place.
+
+    Derived from the source, not from a list of stages, for the reason
+    `test_marketing_helper_adoption_sweep.py` exists: a helper adopted at some
+    call sites and not others leaves the defect in place behind a closed issue.
+    A seventh stage added next month gets this for free — or fails here.
+    """
+    tree = ast.parse(_PIPELINE_SOURCE.read_text(encoding="utf-8"))
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "RunNotSucceededError"
+    ]
+    inside_helper = {
+        node.lineno
+        for func in ast.walk(tree)
+        if isinstance(func, ast.FunctionDef) and func.name == "run_not_succeeded"
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+    }
+
+    bypassed = sorted(set(offenders) - inside_helper)
+    assert not bypassed, (
+        f"{_PIPELINE_SOURCE.name} constructs RunNotSucceededError directly at line(s) "
+        f"{bypassed}. Build it with `run_not_succeeded(message, view)` so the reason "
+        "Core recorded reaches the operator (issue #164)."
+    )


### PR DESCRIPTION
Refs #164.

## The diagnosis first — this was not a code regression

Positioning failing in ~0.05s on tabsii dev was **not** caused by #161/#162/#163. Read directly off the failed run (`64ee7319-c623-4137-89db-ac7017260e2c`) via Core's `GET /api/v1/internal/agent-runs/{id}`:

```
error: LLM call failed on turn 1: OpenRouter returned 402:
  "This request requires more credits, or fewer max_tokens. You requested up to
   65536 tokens, but can only afford 57975."
```

The run's `definition_snapshot` was exactly what `positioning_definition` produces today — `instructions` 2841 chars, `model: anthropic/claude-opus-5`, `tools: []`, `max_turns: 3`, `timeout_seconds: 240.0`, `output_tools: ["submit_positioning"]`. No malformed schema, no tool-name collision, no stale constant.

The OpenRouter account is at **$10.00 credit / $8.75 used**, and an `anthropic/claude-opus-5` request reserves its full 65,536-token output ceiling. Research (sonnet) and synthesis got in under the wire; positioning, 90 seconds later, did not. That is why the same stage succeeded at 13:30 and failed at 15:26 — the balance moved, the code did not. **Adding credit is the operational fix; nothing in this repo can supply it.**

## What this PR actually changes

The reason the incident cost an afternoon: the plugin discarded the one field that answered it. `advance_positioning` raised `RunNotSucceededError("The positioning run did not complete successfully.")` and `_pipeline_error_to_http` rendered `str(exc)` — a sentence equally true of a malformed definition, an unregistered tool, a wall-clock timeout, a provider outage and an exhausted balance. `AgentRunView` had no `error` field, so no stage could have said which.

- **`AgentRunView.error`** carries Core's `AgentRunResponse.error`, populated in `_CoreAgentGateway.get_agent_run`. Tri-state like `annotations` and `definition_snapshot`: absent stays `None` ("not known"), never `""`.
- **`run_not_succeeded(message, *views)`** builds every `RunNotSucceededError` in the module, appending the recorded reason — collapsed to one line, bounded at `RUN_ERROR_EXCERPT_CHARS`, de-duplicated across a failed set (both research angles killed by one exhausted balance is one fact) — or saying `Core recorded no reason for the failure.` out loud, because "Core recorded nothing" and "nobody looked" are different problems.
- Adopted at all six raise sites: research-synthesis, the research fan-in set, positioning, channel-plan evidence, channel plan, copy.
- **An AST sweep** (`test_no_stage_constructs_run_not_succeeded_error_directly`) fails if any stage constructs the error directly, so a seventh stage cannot quietly reintroduce the silence — the `helper_adoption_sweep` pattern, not a hand-listed set.

The operator would now have read `The positioning run did not complete successfully. The run reported: LLM call failed on turn 1: OpenRouter returned 402: … requires more credits …` and been done.

## Could a test have caught this before deploy?

**The 402 itself: no.** Only a real run against a real provider account with a real balance produces it, and no fixture can. A harness that would have caught it is an operational one, not a unit one: a pre-flight balance check against `GET https://openrouter.ai/api/v1/credits` compared to the most expensive model's output ceiling, run on deploy or on a schedule — that belongs in the platform/runtime, not here.

**The diagnostic gap: yes, entirely.** 13 tests, all of which fail on `origin/dev` and pass here (verified by stashing `src/` and re-running). They assert the reason survives Core's JSON → the view → the message, for every stage.

## Verification

- `uv run pytest` — 786 passed, 4 skipped
- `ruff check` / `ruff format --check` / `pyright` — clean
- pre-push `verify` gate green including web-admin lint/typecheck/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)