### PR TITLE
chore(web-admin): add pnpm overrides floor for js-yaml/nanoid/brace-expansion

### DIFF
--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -31,5 +31,12 @@
     "typescript-eslint": "^8.20.0",
     "vite": "^6.0.7",
     "vitest": "^3.0.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@<5.0.9": ">=5.0.9",
+      "js-yaml@<4.3.1": ">=4.3.1 <5",
+      "nanoid@<3.3.17": ">=3.3.17 <4"
+    }
   }
 }

--- a/web-admin/pnpm-lock.yaml
+++ b/web-admin/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<5.0.9: '>=5.0.9'
+  js-yaml@<4.3.1: '>=4.3.1 <5'
+  nanoid@<3.3.17: '>=3.3.17 <4'
+
 importers:
 
   .:
@@ -778,9 +783,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -792,9 +794,6 @@ packages:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -837,9 +836,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2241,18 +2237,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.13: {}
-
-  brace-expansion@1.1.18:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2298,8 +2287,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2633,7 +2620,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.18
+      brace-expansion: 5.0.9
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## What

`web-admin/package.json` had no `pnpm.overrides` block at all, unlike its
sibling plugin frontends (`biffo-plugin-idea-scout`, `biffo-plugin-ideation`),
which both declare the estate's canonical dependency-override floor. This adds
it here too:

```json
"pnpm": {
  "overrides": {
    "brace-expansion@<5.0.9": ">=5.0.9",
    "js-yaml@<4.3.1": ">=4.3.1 <5",
    "nanoid@<3.3.17": ">=3.3.17 <4"
  }
}
```

Copied byte-for-byte from biffo-template's root `package.json` and
`_skeletons/plugin-template/web-admin/package.json`, and matches the key
order both sibling repos already use. This repo has only a `web-admin/`
directory — no `web/` — verified before starting, so that's the only tree
needing the floor.

biffo-template's overridesFloor check (from that repo's issue 1589) recently
extended to cover plugin frontends and flagged this repo as the one gap.

## Why not automated

`shared-sync.sh --deliver-overrides` can't fix this on its own: its writer
is an additive splice that inserts a key after an existing `"overrides": {`
line and deliberately refuses when there is none. This file had no
`pnpm` block at all, so it needed a hand-authored change.

## No live vulnerability

The lockfile already resolved safe versions before this change
(`js-yaml@4.3.1`, `nanoid@3.3.18`, `brace-expansion@5.0.9` for the direct
override path). This PR declares the floor so a future install/lockfile
refresh can't silently resolve back down — it doesn't fix an active
exposure. One transitive path (`minimatch@3.1.5` -> `brace-expansion`) *was*
still resolving to the vulnerable `1.1.18` because nothing forced it; that
now also resolves to `5.0.9`. Resolved versions only ever went up or stayed
the same, never down.

## Verification

Reinstalled with `pnpm install --ignore-workspace` in `web-admin/` (it's not
a workspace member of anything, so a plain `pnpm install` there would
silently install the wrong tree).

Repo-wide audit script (`sh scripts/js-dependency-audit.sh`, run from repo
root so it discovers every `pnpm-lock.yaml` tree):

```
js-dependency-audit: discovered 1 pnpm-lock.yaml tree(s):
  - web-admin
pnpm audit (web-admin): 0 critical, 0 high across 332 package(s) (0 moderate, 0 low — reported, not blocking); registry answered 2026-08-14T16:03:24Z.
js-dependency-audit: audited 1 tree(s), 0 blocking findings.
```

Denominator: 332 packages audited, 0 moderate/low findings reported (not
blocking), 0 high/critical.

`web-admin/`'s own gates, all green after the reinstall:

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean
- `pnpm run test` — 218 tests passed (25 files)
- `pnpm run build` — succeeded

## Not verified

CI on this PR — reporting at "pushed, PR open" rather than waiting on it,
per this repo's AGENTS.md delegation guidance.
