### PR TITLE
feat(marketing): let an operator re-seed the fan-in workflow from the studio

### DIFF
--- a/scripts/seed_fan_in_workflow.py
+++ b/scripts/seed_fan_in_workflow.py
@@ -73,7 +73,8 @@ not assumed:
   would still leave the limits frozen here.
 
 So the snapshot stays, and what changes instead is that its staleness is no
-longer silent, in three places that each read a different document:
+longer silent, in three places that each read a different document — and, since
+#160, is no longer something only a shell can fix:
 
 1. :func:`config_fingerprint` / :data:`SEEDED_CONFIG_FINGERPRINT` — a pin over
    the whole ``action_config`` this checkout would seed, asserted by
@@ -90,12 +91,27 @@ longer silent, in three places that each read a different document:
    ``definition_snapshot`` of the synthesis run that **actually ran** and
    reports drift on every terminal research chain. No token, no operator: it
    fires by itself, in the environment where it is wrong.
+
+**And the fourth thing, which is not a detector.** Every one of the three above
+ends by naming this script, and for months that was the problem: applying the
+fix needed a checkout, a shell and a real Cognito admin token pasted into an
+environment variable, so the reports accumulated and the re-seed did not
+happen. The plugin's admin UI now shows the same drift **and applies it**
+(``web-admin``'s ``FanInWorkflow``, served by ``admin_app``'s
+``GET /fan-in-workflow``), using the admin session the operator already has —
+Core's workflow routes take a Cognito token, which a browser has and this
+plugin's SigV4-signing Lambda never can.
+
+This script keeps its job. An environment with no browser, a first seed during
+provisioning, and ``--check`` in an ops runbook all still want a CLI, and
+``--dry-run`` is still the only way to read the config without a Core at all.
+What it no longer is, is the *only* way. The declaration it writes lives in
+``marketing.fan_in_workflow`` so that both callers seed the same document.
 """
 
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import os
 import sys
@@ -112,16 +128,16 @@ from typing import Any
 # with `uv run python scripts/seed_fan_in_workflow.py` from the checkout.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from marketing.definitions import (  # noqa: E402
-    DEFAULT_SYNTHESIS_MODEL,
-    RESEARCH_AGENT_NAMES,
-    RESEARCH_SYNTHESIS_AGENT_NAME,
-    RESEARCH_SYNTHESIS_INSTRUCTIONS,
-    research_synthesis_definition,
-    research_synthesis_tool_schema,
+# The declared configuration itself lives in the package, not here, so that the
+# admin UI can serve and act on the same declaration this script seeds — see
+# `marketing.fan_in_workflow`'s docstring for why that seam exists (#160).
+from marketing.fan_in_workflow import (  # noqa: E402
+    SEEDED_CONFIG_FINGERPRINT,  # noqa: F401 — re-exported for the CI fingerprint test
+    WORKFLOW_NAME,
+    config_drift,
+    config_fingerprint,
+    definition,
 )
-
-WORKFLOW_NAME = "Marketing — synthesise research once both angles complete"
 
 #: Core mounts the orchestration router at `/api/v1/orchestration`, NOT under
 #: `/api/v1/admin`. This carried a stray `admin/` segment until 2026-08-11,
@@ -131,108 +147,6 @@ WORKFLOW_NAME = "Marketing — synthesise research once both angles complete"
 #: `/api/v1/orchestration/workflows` answers 200 and the `admin/` variant
 #: answers 404, indistinguishable from a route that does not exist.
 _DEFINITIONS_PATH = "/api/v1/orchestration/workflows"
-
-
-def definition(*, synthesis_model: str = DEFAULT_SYNTHESIS_MODEL) -> dict:
-    """The workflow this plugin needs in order to finish a research run on its
-    own.
-
-    Triggered by every ``agent.run.completed``: the fan-in action itself
-    decides whether the event belongs to a chain it cares about, and no-ops
-    otherwise. Filtering by agent name in the trigger would still fire twice
-    per research run (once per angle); the action's own
-    all-siblings-terminal check is what collapses those two into one.
-    """
-    run_definition = research_synthesis_definition(
-        model=synthesis_model, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
-    )
-    return {
-        "name": WORKFLOW_NAME,
-        "trigger_source": "biffo.core",
-        "trigger_detail_type": "agent.run.completed",
-        "action_type": "agent_fan_in",
-        "action_config": {
-            # The set to wait for. These names must match what the plugin
-            # actually requests — see marketing.pipeline.start_research.
-            "expect_agents": ",".join(RESEARCH_AGENT_NAMES),
-            "agent_name": RESEARCH_SYNTHESIS_AGENT_NAME,
-            **run_definition,
-            "output_tools": [research_synthesis_tool_schema()],
-        },
-        "enabled": True,
-    }
-
-
-#: A value that can never be compared, because Core masks it on read
-#: (``schemas/orchestration.py``'s ``redact_secrets``, where it is called
-#: ``SECRET_SENTINEL``): a credential-bearing config field comes back as this
-#: placeholder rather than its stored value. ``agent_fan_in`` declares no such
-#: field today, so this is a guard against a future one being reported as
-#: permanent, unfixable drift rather than as "cannot tell".
-REDACTED_SENTINEL = "••••••••"
-
-
-def config_fingerprint(config: dict[str, Any]) -> str:
-    """A stable digest of the whole ``action_config`` this checkout would seed.
-
-    **The whole config, not the model.** #62 recorded its lesson as "synthesis
-    is stuck on an old model", so #131's timeout change sailed past it two days
-    later on the same mechanism. Every key here is a copy that a deploy does
-    not update — the prompt, the tool schema, the turn budget and the wall
-    clock exactly as much as the model — so the thing that gets pinned is the
-    snapshot, and a change to any part of it has to be acknowledged.
-
-    Truncated to 16 hex characters: long enough that a change cannot collide
-    with the pinned value in practice, short enough to read in a diff.
-    """
-    return (
-        "sha256:"
-        + hashlib.sha256(json.dumps(config, sort_keys=True, default=str).encode()).hexdigest()[:16]
-    )
-
-
-#: The fingerprint of the ``action_config`` this checkout seeds.
-#:
-#: **This is a tripwire, not a record of what is deployed.** It goes red in CI
-#: the moment anyone changes the synthesis model, prompt, tool schema, turn
-#: budget or wall clock — which is the moment someone can still act on it,
-#: rather than two days later while reading a table in the portal. Updating it
-#: is the acknowledgement that the deployed workflow now needs
-#: ``--replace`` run against every environment.
-#:
-#: What it deliberately does NOT claim: that anybody actually re-seeded
-#: anything. Nothing inside this repo can know that — only ``--check`` against
-#: a live Core, or ``marketing.pipeline.synthesis_config_drift`` reading a real
-#: run's ``definition_snapshot``, can.
-SEEDED_CONFIG_FINGERPRINT = "sha256:31883429cd45ebe4"
-
-
-def config_drift(
-    deployed: dict[str, Any] | None, desired: dict[str, Any] | None = None
-) -> dict[str, tuple[Any, Any]]:
-    """``{key: (deployed, desired)}`` for every key that differs, empty if none.
-
-    Compares the **whole** ``action_config``, including keys the deployed copy
-    has and this checkout does not (reported with a desired value of ``None``)
-    — a leftover key from an older seed is drift too.
-
-    A key Core has masked as a secret is skipped rather than reported: its real
-    value cannot be read back, so calling it drift would mean permanent,
-    unfixable red. ``deployed`` of ``None`` — nothing seeded at all — is not
-    expressible as a per-key diff and is the caller's job to report.
-    """
-    desired = definition()["action_config"] if desired is None else desired
-    if deployed is None:
-        return {}
-    drift: dict[str, tuple[Any, Any]] = {}
-    for key in sorted(set(desired) | set(deployed)):
-        deployed_value = deployed.get(key)
-        if deployed_value == REDACTED_SENTINEL:
-            continue
-        desired_value = desired.get(key)
-        if deployed_value != desired_value:
-            drift[key] = (deployed_value, desired_value)
-    return drift
 
 
 def _short(value: Any) -> str:

--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -69,6 +69,8 @@ from pydantic import BaseModel, Field
 from . import pipeline, principal_client
 from .config import public_base_url_for
 from .definitions import ARTEFACT_KINDS, MEDIA_KINDS, PIPELINE_STAGES, PLACEMENTS
+from .fan_in_workflow import WORKFLOW_NAME, config_fingerprint
+from .fan_in_workflow import definition as fan_in_definition
 from .image_routes import router as image_router
 from .links import destination_with_utms, mint_token, tracked_url
 
@@ -112,6 +114,30 @@ async def config() -> dict[str, Any]:
         "media_kinds": list(MEDIA_KINDS),
         "placements": list(PLACEMENTS),
         "pipeline_stages": list(PIPELINE_STAGES),
+    }
+
+
+@router.get("/fan-in-workflow")
+async def fan_in_workflow() -> dict[str, Any]:
+    """The fan-in workflow definition **this build declares** (issue #160).
+
+    Read-only, and deliberately so: this route reports what ought to be
+    deployed, and the admin UI compares it against what Core actually holds.
+    Applying the difference is a separate act, performed by the browser
+    against Core's own admin API with the operator's Cognito token — not by
+    this Lambda, which has no credential that Core's workflow-definition
+    routes accept (see ``marketing.fan_in_workflow``).
+
+    Serving the declaration rather than restating it in TypeScript is the same
+    argument as ``/config`` above, with more at stake: a hand-copied
+    ``action_config`` in the UI would be a *fourth* copy of the thing whose
+    copies going stale is the entire subject of #160.
+    """
+    declared = fan_in_definition()
+    return {
+        "name": WORKFLOW_NAME,
+        "definition": declared,
+        "fingerprint": config_fingerprint(declared["action_config"]),
     }
 
 

--- a/src/marketing/fan_in_workflow.py
+++ b/src/marketing/fan_in_workflow.py
@@ -1,0 +1,147 @@
+"""The fan-in workflow definition this build declares, and how to compare it.
+
+**Separated from ``scripts/seed_fan_in_workflow.py`` so that more than one
+thing can act on it (issue #160).** The declared configuration used to live
+only inside the seeding script, which meant the only way to apply it was to
+be an operator with a shell, a checkout and a real Cognito admin token. Three
+detectors then grew around that script — a CI fingerprint pin, its own
+``--check``, and ``pipeline.synthesis_config_drift`` — and every one of them
+could only ever *report* the staleness it found, because the fix lived in a
+place none of them could reach.
+
+Importing it here changes nothing about what is seeded: the script still owns
+the CLI, the HTTP calls and the operator procedure, and imports these names
+rather than defining them. What it adds is a second caller — ``admin_app``'s
+``GET /fan-in-workflow``, which serves this same declaration to the admin UI
+so an operator can see the drift and re-seed from the browser they already
+have an admin session in.
+
+**Why the browser, and not this Lambda.** Creating or replacing a workflow
+definition is admin-Cognito-gated on Core's ``/api/v1/orchestration/workflows``
+router; there is no service-principal counterpart, so a plugin's SigV4-signed
+Lambda cannot do it (measured against ``tabsii-platform`` @ 2026-08-15:
+``WorkflowDefinition`` writes appear only in ``routers/orchestration.py``,
+never in a ``require_service_principal`` router). The plugin's own web-admin,
+though, already runs inside an admin's session and already holds a Cognito ID
+token — so it is the one component in this repo that can both read what is
+deployed and replace it. That is the seam this module exists to serve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from .definitions import (
+    DEFAULT_SYNTHESIS_MODEL,
+    RESEARCH_AGENT_NAMES,
+    RESEARCH_SYNTHESIS_AGENT_NAME,
+    RESEARCH_SYNTHESIS_INSTRUCTIONS,
+    research_synthesis_definition,
+    research_synthesis_tool_schema,
+)
+
+WORKFLOW_NAME = "Marketing — synthesise research once both angles complete"
+
+
+def definition(*, synthesis_model: str = DEFAULT_SYNTHESIS_MODEL) -> dict:
+    """The workflow this plugin needs in order to finish a research run on its
+    own.
+
+    Triggered by every ``agent.run.completed``: the fan-in action itself
+    decides whether the event belongs to a chain it cares about, and no-ops
+    otherwise. Filtering by agent name in the trigger would still fire twice
+    per research run (once per angle); the action's own
+    all-siblings-terminal check is what collapses those two into one.
+    """
+    run_definition = research_synthesis_definition(
+        model=synthesis_model, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
+    )
+    return {
+        "name": WORKFLOW_NAME,
+        "trigger_source": "biffo.core",
+        "trigger_detail_type": "agent.run.completed",
+        "action_type": "agent_fan_in",
+        "action_config": {
+            # The set to wait for. These names must match what the plugin
+            # actually requests — see marketing.pipeline.start_research.
+            "expect_agents": ",".join(RESEARCH_AGENT_NAMES),
+            "agent_name": RESEARCH_SYNTHESIS_AGENT_NAME,
+            **run_definition,
+            "output_tools": [research_synthesis_tool_schema()],
+        },
+        "enabled": True,
+    }
+
+
+#: A value that can never be compared, because Core masks it on read
+#: (``schemas/orchestration.py``'s ``redact_secrets``, where it is called
+#: ``SECRET_SENTINEL``): a credential-bearing config field comes back as this
+#: placeholder rather than its stored value. ``agent_fan_in`` declares no such
+#: field today, so this is a guard against a future one being reported as
+#: permanent, unfixable drift rather than as "cannot tell".
+REDACTED_SENTINEL = "••••••••"
+
+
+def config_fingerprint(config: dict[str, Any]) -> str:
+    """A stable digest of the whole ``action_config`` this checkout would seed.
+
+    **The whole config, not the model.** #62 recorded its lesson as "synthesis
+    is stuck on an old model", so #131's timeout change sailed past it two days
+    later on the same mechanism. Every key here is a copy that a deploy does
+    not update — the prompt, the tool schema, the turn budget and the wall
+    clock exactly as much as the model — so the thing that gets pinned is the
+    snapshot, and a change to any part of it has to be acknowledged.
+
+    Truncated to 16 hex characters: long enough that a change cannot collide
+    with the pinned value in practice, short enough to read in a diff.
+    """
+    return (
+        "sha256:"
+        + hashlib.sha256(json.dumps(config, sort_keys=True, default=str).encode()).hexdigest()[:16]
+    )
+
+
+#: The fingerprint of the ``action_config`` this checkout seeds.
+#:
+#: **This is a tripwire, not a record of what is deployed.** It goes red in CI
+#: the moment anyone changes the synthesis model, prompt, tool schema, turn
+#: budget or wall clock — which is the moment someone can still act on it,
+#: rather than two days later while reading a table in the portal. Updating it
+#: is the acknowledgement that the deployed workflow now needs
+#: ``--replace`` run against every environment.
+#:
+#: What it deliberately does NOT claim: that anybody actually re-seeded
+#: anything. Nothing inside this repo can know that — only ``--check`` against
+#: a live Core, or ``marketing.pipeline.synthesis_config_drift`` reading a real
+#: run's ``definition_snapshot``, can.
+SEEDED_CONFIG_FINGERPRINT = "sha256:31883429cd45ebe4"
+
+
+def config_drift(
+    deployed: dict[str, Any] | None, desired: dict[str, Any] | None = None
+) -> dict[str, tuple[Any, Any]]:
+    """``{key: (deployed, desired)}`` for every key that differs, empty if none.
+
+    Compares the **whole** ``action_config``, including keys the deployed copy
+    has and this checkout does not (reported with a desired value of ``None``)
+    — a leftover key from an older seed is drift too.
+
+    A key Core has masked as a secret is skipped rather than reported: its real
+    value cannot be read back, so calling it drift would mean permanent,
+    unfixable red. ``deployed`` of ``None`` — nothing seeded at all — is not
+    expressible as a per-key diff and is the caller's job to report.
+    """
+    desired = definition()["action_config"] if desired is None else desired
+    if deployed is None:
+        return {}
+    drift: dict[str, tuple[Any, Any]] = {}
+    for key in sorted(set(desired) | set(deployed)):
+        deployed_value = deployed.get(key)
+        if deployed_value == REDACTED_SENTINEL:
+            continue
+        desired_value = desired.get(key)
+        if deployed_value != desired_value:
+            drift[key] = (deployed_value, desired_value)
+    return drift

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -1716,7 +1716,18 @@ async def _log_evidence_profile_for(
 #: The exact command that re-seeds the workflow definition, quoted verbatim
 #: anywhere this repo reports drift. Anyone reading a drift report is one
 #: command away from fixing it and should never have to go and find which one.
-RESEED_COMMAND = "uv run python scripts/seed_fan_in_workflow.py --replace"
+#:
+#: It now names the browser route first (#160). Whoever reads this line is by
+#: definition looking at a *deployed* environment that is stale, and the
+#: campaign studio's own panel re-seeds it from the admin session they are
+#: already in — where the command below first needs a checkout of this repo,
+#: and a Cognito admin token in an environment variable, which is the friction
+#: that kept the re-seed from happening for two days while all three detectors
+#: reported it correctly.
+RESEED_COMMAND = (
+    "the campaign studio's 'Research fan-in workflow' panel → Re-seed it now, "
+    "or uv run python scripts/seed_fan_in_workflow.py --replace"
+)
 
 #: The keys of the frozen copy this plugin can compare a *run* against.
 #:

--- a/tests/test_marketing_fan_in_workflow_route.py
+++ b/tests/test_marketing_fan_in_workflow_route.py
@@ -1,0 +1,70 @@
+"""The admin route that serves the fan-in workflow this build declares (#160).
+
+The point of the route is that the admin UI never authors a copy of the
+declaration. So what these tests hold is **identity with the declaration**, not
+the declaration's contents — those are asserted once, against
+`fan_in_workflow.definition()` itself, in `test_marketing_seed_fan_in_workflow.py`.
+Restating them here would create the second copy the route exists to prevent.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from marketing import admin_app as admin_app_module
+from marketing.fan_in_workflow import (
+    WORKFLOW_NAME,
+    config_fingerprint,
+    definition,
+)
+
+
+def _client() -> TestClient:
+    """The admin app with its `admin`-group gate satisfied.
+
+    The router carries `Depends(require_admin)` for every route, so an
+    unauthenticated call 401s before reaching any handler — which is correct,
+    and is asserted separately below rather than worked around silently.
+    """
+    app = admin_app_module.build_app()
+    app.dependency_overrides[admin_app_module.require_admin] = lambda: None
+    return TestClient(app)
+
+
+def test_it_serves_exactly_what_the_seed_script_would_write() -> None:
+    """The UI's declared half and the script's are the same document.
+
+    This is the whole reason the declaration moved out of `scripts/` into the
+    package. If these two could differ, an operator could re-seed from the
+    browser and produce a config the CI fingerprint never saw.
+    """
+    response = _client().get("/fan-in-workflow")
+
+    assert response.status_code == 200
+    assert response.json()["definition"] == definition()
+
+
+def test_it_names_the_workflow_the_script_looks_up_by() -> None:
+    """The browser matches Core's deployed list by name, exactly as
+    `seed_fan_in_workflow.main` does. A different name here would mean the UI
+    reporting 'not seeded' beside a workflow that is seeded, and then creating
+    a second one that fires on the same trigger."""
+    assert _client().get("/fan-in-workflow").json()["name"] == WORKFLOW_NAME
+
+
+def test_it_carries_the_fingerprint_of_the_config_it_serves() -> None:
+    """Served rather than recomputed in TypeScript: the fingerprint is what an
+    operator reads back to say which build is deployed, and a second
+    implementation of the hash would eventually disagree with the pinned one."""
+    body = _client().get("/fan-in-workflow").json()
+
+    assert body["fingerprint"] == config_fingerprint(body["definition"]["action_config"])
+
+
+def test_it_is_admin_gated_like_every_other_route_on_this_app() -> None:
+    """Not decoration: the response is the input to a control that WRITES a
+    workflow definition. Serving it to a non-admin would hand the shape of the
+    estate's orchestration to anyone who could reach the mount."""
+    response = TestClient(admin_app_module.build_app()).get("/fan-in-workflow")
+
+    assert response.status_code in (401, 403)

--- a/tests/test_marketing_seed_fan_in_workflow.py
+++ b/tests/test_marketing_seed_fan_in_workflow.py
@@ -20,6 +20,13 @@ from marketing.definitions import (
     RESEARCH_SYNTHESIS_TOOL_NAME,
 )
 
+# The declaration and its comparison helpers moved into the package for #160,
+# so the admin UI can serve and act on the same document the script seeds. The
+# script re-exports them, so everything below still reads the script's own
+# contract; only the sentinel — which the script no longer references itself —
+# is imported from its new home.
+from marketing.fan_in_workflow import REDACTED_SENTINEL
+
 _seed = load_script("seed_fan_in_workflow")
 WORKFLOW_NAME = _seed.WORKFLOW_NAME
 definition = _seed.definition
@@ -192,7 +199,7 @@ def test_config_drift_skips_a_value_core_masked_as_a_secret() -> None:
     stored value cannot be compared. Reporting the sentinel as drift would be
     permanent red no re-seed could clear — an alarm nobody can silence gets
     ignored, which is how the real one gets missed."""
-    deployed = {**definition()["action_config"], "model": _seed.REDACTED_SENTINEL}
+    deployed = {**definition()["action_config"], "model": REDACTED_SENTINEL}
 
     assert _seed.config_drift(deployed) == {}
 

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { CampaignDetail } from './components/CampaignDetail'
+import { FanInWorkflow } from './components/FanInWorkflow'
 import { MintLinks } from './components/MintLinks'
 import { createCampaign, listCampaigns, type Campaign } from './lib/api'
 import { campaignUrl, readCampaignParam } from './lib/campaignLink'
@@ -143,6 +144,13 @@ export default function App() {
     <main>
       <h1>Campaign studio</h1>
       <p className="lede">Campaigns for this tenant, and the tracked links minted from them.</p>
+
+      {/* On the list rather than inside a campaign (#160). The workflow is
+          per-deployment, not per-campaign — it decides whether research can
+          finish for every campaign here — and the operator who needs to see
+          it stale is the one arriving at the studio, not the one already
+          three stages into one run. */}
+      <FanInWorkflow />
 
       <form onSubmit={submit} aria-label="Create a campaign">
         <h2>New campaign</h2>

--- a/web-admin/src/components/FanInWorkflow.test.tsx
+++ b/web-admin/src/components/FanInWorkflow.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as api from '../lib/api'
+import { FanInWorkflow } from './FanInWorkflow'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const NAME = 'Marketing — synthesise research once both angles complete'
+
+function declaration(config: Record<string, unknown> = { model: 'anthropic/claude-opus-5' }) {
+  return {
+    name: NAME,
+    fingerprint: 'sha256:31883429cd45ebe4',
+    definition: {
+      name: NAME,
+      trigger_source: 'biffo.core',
+      trigger_detail_type: 'agent.run.completed',
+      action_type: 'agent_fan_in',
+      action_config: config,
+      enabled: true,
+    },
+  }
+}
+
+function stub(
+  declared: ReturnType<typeof declaration>,
+  workflows: { id: string; name: string; action_config: Record<string, unknown> | null }[],
+) {
+  vi.spyOn(api, 'getDeclaredFanInWorkflow').mockResolvedValue(declared)
+  vi.spyOn(api, 'listCoreWorkflows').mockResolvedValue(workflows)
+}
+
+describe('FanInWorkflow', () => {
+  it('says it is in step when the deployed config matches, and offers no button', async () => {
+    stub(declaration(), [{ id: 'w1', name: NAME, action_config: { model: 'anthropic/claude-opus-5' } }])
+
+    render(<FanInWorkflow />)
+
+    expect(await screen.findByText(/In step/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /seed/i })).not.toBeInTheDocument()
+  })
+
+  it('names every stale key with both values, not just that something differs', async () => {
+    // #62 recorded its lesson as "synthesis is stuck on an old model", so
+    // #131's timeout change sailed past on the same mechanism two days later.
+    // A panel that said only "stale" would repeat that.
+    stub(declaration({ model: 'anthropic/claude-opus-5', timeout_seconds: 240 }), [
+      { id: 'w1', name: NAME, action_config: { model: 'anthropic/claude-opus-4.8' } },
+    ])
+
+    render(<FanInWorkflow />)
+
+    expect(await screen.findByText(/Stale in 2 keys/)).toBeInTheDocument()
+    expect(screen.getByRole('row', { name: /model/ })).toHaveTextContent('anthropic/claude-opus-4.8')
+    expect(screen.getByRole('row', { name: /timeout_seconds/ })).toHaveTextContent('(absent)')
+  })
+
+  it('replaces the existing definition rather than creating a second one', async () => {
+    // Two definitions on the same trigger would fire synthesis twice per
+    // chain — the plugin would pay for a duplicate run and reconcile the
+    // wrong one.
+    stub(declaration(), [{ id: 'w1', name: NAME, action_config: { model: 'old' } }])
+    const seed = vi.spyOn(api, 'seedFanInWorkflow').mockResolvedValue(undefined)
+
+    render(<FanInWorkflow />)
+    await userEvent.click(await screen.findByRole('button', { name: /Re-seed it now/ }))
+
+    await waitFor(() => expect(seed).toHaveBeenCalledWith(expect.objectContaining({ name: NAME }), 'w1'))
+  })
+
+  it('offers to seed, with no id, when Core holds no workflow of this name', async () => {
+    stub(declaration(), [{ id: 'other', name: 'Something else', action_config: {} }])
+    const seed = vi.spyOn(api, 'seedFanInWorkflow').mockResolvedValue(undefined)
+
+    render(<FanInWorkflow />)
+
+    expect(await screen.findByText(/Not seeded/)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Seed it now/ }))
+    await waitFor(() => expect(seed).toHaveBeenCalledWith(expect.anything(), null))
+  })
+
+  it('reports a failed read as a failure, never as "in step"', async () => {
+    // The fail-open shape this whole issue is about: a check that cannot read
+    // the deployed config must not render as a clean bill of health.
+    vi.spyOn(api, 'getDeclaredFanInWorkflow').mockResolvedValue(declaration())
+    vi.spyOn(api, 'listCoreWorkflows').mockRejectedValue(new Error('403 forbidden'))
+
+    render(<FanInWorkflow />)
+
+    expect(await screen.findByText(/Could not check the deployed workflow/)).toBeInTheDocument()
+    expect(screen.queryByText(/In step/)).not.toBeInTheDocument()
+  })
+
+  it('surfaces a refused write instead of reporting success it did not get', async () => {
+    stub(declaration(), [{ id: 'w1', name: NAME, action_config: { model: 'old' } }])
+    vi.spyOn(api, 'seedFanInWorkflow').mockRejectedValue(new Error('403 forbidden'))
+
+    render(<FanInWorkflow />)
+    await userEvent.click(await screen.findByRole('button', { name: /Re-seed it now/ }))
+
+    expect(await screen.findByText(/403 forbidden/)).toBeInTheDocument()
+  })
+
+  it('re-reads Core after seeding rather than assuming the write landed', async () => {
+    stub(declaration(), [{ id: 'w1', name: NAME, action_config: { model: 'old' } }])
+    vi.spyOn(api, 'seedFanInWorkflow').mockResolvedValue(undefined)
+
+    render(<FanInWorkflow />)
+    await userEvent.click(await screen.findByRole('button', { name: /Re-seed it now/ }))
+
+    await waitFor(() => expect(api.listCoreWorkflows).toHaveBeenCalledTimes(2))
+  })
+})

--- a/web-admin/src/components/FanInWorkflow.tsx
+++ b/web-admin/src/components/FanInWorkflow.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  getDeclaredFanInWorkflow,
+  listCoreWorkflows,
+  seedFanInWorkflow,
+  type DeclaredWorkflow,
+  type DeployedWorkflow,
+} from '../lib/api'
+import { configDrift, shortenValue, type ConfigDrift } from '../lib/workflowDrift'
+
+/** The fan-in workflow's deployed state, and the button that fixes it (#160).
+ *
+ * ## Why this panel exists at all
+ *
+ * The research stage does not finish by itself. A workflow definition stored
+ * in Core fires the synthesis agent once both research angles are terminal,
+ * and its `action_config` is a **copy** of this repo's declaration, frozen at
+ * the moment somebody last ran `scripts/seed_fan_in_workflow.py`. Nothing in
+ * a deploy updates it. Two days after every stage moved to the Claude 5
+ * family, the deployed synthesis run was still on `opus-4.8` and a 120s clock.
+ *
+ * Three guards were then built around that, and all three only ever *reported*
+ * it: a CI fingerprint pin, the script's `--check`, and
+ * `pipeline.synthesis_config_drift`. Each names the same remedy — re-run the
+ * script — and none can perform it. The remedy needs a checkout, a shell, and
+ * a real Cognito admin token pasted into an environment variable, which is
+ * why it kept not happening.
+ *
+ * This panel is the missing half: it shows the same drift **and applies it**,
+ * in the session of an operator who is already authenticated as an admin. It
+ * does not replace the script — an environment with no browser still has one —
+ * it removes the reason the script goes unrun.
+ *
+ * ## Why the browser does the writing
+ *
+ * Core's workflow-definition routes are Cognito-admin gated and have no
+ * service-principal counterpart, so the plugin's own Lambda cannot write one:
+ * every outbound call it makes is SigV4-signed. The operator's ID token, held
+ * here, is the only credential in the system that both halves accept. The
+ * plugin serves the declaration; the browser reads what is deployed, diffs,
+ * and writes.
+ */
+export function FanInWorkflow() {
+  const [declared, setDeclared] = useState<DeclaredWorkflow | null>(null)
+  const [deployed, setDeployed] = useState<DeployedWorkflow | null>(null)
+  // Tri-state, not a boolean. "Core has no workflow of this name" and "Core
+  // could not be read" lead to opposite actions — the first wants a seed, the
+  // second must never render as one — so "not loaded yet" stays distinct from
+  // "loaded, and absent" (`deployed === null` with `loaded === true`).
+  const [loaded, setLoaded] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [seeding, setSeeding] = useState(false)
+  const [seeded, setSeeded] = useState(false)
+
+  const load = useCallback(async () => {
+    setError(null)
+    setLoaded(false)
+    try {
+      const [declaration, workflows] = await Promise.all([
+        getDeclaredFanInWorkflow(),
+        listCoreWorkflows(),
+      ])
+      setDeclared(declaration)
+      setDeployed(workflows.find((w) => w.name === declaration.name) ?? null)
+      setLoaded(true)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function reseed() {
+    if (declared == null) return
+    setSeeding(true)
+    setError(null)
+    try {
+      await seedFanInWorkflow(declared, deployed?.id ?? null)
+      setSeeded(true)
+      // Re-read rather than assume. What matters is what Core now holds, and
+      // a panel that congratulated itself on a write it never verified would
+      // be the same fail-open shape this whole issue is about.
+      await load()
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSeeding(false)
+    }
+  }
+
+  if (error != null) {
+    return (
+      <section className="fan-in-workflow">
+        <h2>Research fan-in workflow</h2>
+        <p className="error">Could not check the deployed workflow: {error}</p>
+        <button type="button" onClick={() => void load()}>
+          Try again
+        </button>
+      </section>
+    )
+  }
+
+  if (!loaded || declared == null) {
+    return (
+      <section className="fan-in-workflow">
+        <h2>Research fan-in workflow</h2>
+        <p>Checking the deployed workflow…</p>
+      </section>
+    )
+  }
+
+  const drift: ConfigDrift[] =
+    deployed?.action_config != null
+      ? configDrift(deployed.action_config, declared.definition.action_config)
+      : []
+
+  return (
+    <section className="fan-in-workflow">
+      <h2>Research fan-in workflow</h2>
+      <p className="hint">
+        Research finishes only if this workflow is deployed and in step. Its configuration is a
+        copy taken when it was last seeded — a deploy does not update it.
+      </p>
+
+      {deployed == null ? (
+        <p className="error">
+          <strong>Not seeded.</strong> No workflow named “{declared.name}” exists in Core, so a
+          research run will never leave <code>pending</code> here.
+        </p>
+      ) : drift.length === 0 ? (
+        <p className="measured">
+          In step — the deployed configuration matches this build ({declared.fingerprint}).
+        </p>
+      ) : (
+        <>
+          <p className="error">
+            <strong>Stale in {drift.length} key{drift.length === 1 ? '' : 's'}.</strong> The
+            synthesis stage is running a configuration this build no longer declares.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Key</th>
+                <th scope="col">Deployed</th>
+                <th scope="col">This build</th>
+              </tr>
+            </thead>
+            <tbody>
+              {drift.map((entry) => (
+                <tr key={entry.key}>
+                  <th scope="row">{entry.key}</th>
+                  <td>{shortenValue(entry.deployed)}</td>
+                  <td>{shortenValue(entry.declared)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {(deployed == null || drift.length > 0) && (
+        <button type="button" onClick={() => void reseed()} disabled={seeding}>
+          {seeding ? 'Seeding…' : deployed == null ? 'Seed it now' : 'Re-seed it now'}
+        </button>
+      )}
+      {seeded && drift.length === 0 && deployed != null && (
+        <p className="measured">Seeded. Core now holds this build’s configuration.</p>
+      )}
+    </section>
+  )
+}

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -1209,3 +1209,32 @@ a:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
+
+/* ── The fan-in workflow panel (#160) ─────────────────────────────────────
+ *
+ * Carded like `form` above, because it is the same kind of thing to the eye:
+ * a bordered block on the campaign list that asks for an action. It sits
+ * above the campaign list rather than beside a campaign — the workflow is
+ * per-deployment, and when it is stale nothing in the list can finish
+ * researching.
+ */
+
+.fan-in-workflow {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1.5rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.fan-in-workflow table {
+  margin-top: 0.75rem;
+}
+
+/* The drift table's values are configuration, not prose — a model id, a
+ * timeout, a truncated prompt — so they read as the literals they are. */
+.fan-in-workflow td {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8125rem;
+  word-break: break-word;
+}

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -869,3 +869,91 @@ export interface ResultsResponse {
 export async function getResults(): Promise<ResultsResponse> {
   return request<ResultsResponse>('GET', '/results', undefined, ADMIN_BASE, 'load results')
 }
+
+// ── The fan-in workflow, and re-seeding it from here (issue #160) ────────────
+//
+// Two different APIs, on purpose. The DECLARED definition comes from the
+// plugin's own admin app, which reads it straight out of `definitions.py`. The
+// DEPLOYED one comes from Core's orchestration API, which is admin-Cognito
+// gated — and that gate is exactly why this lives in the browser: the plugin's
+// Lambda signs its Core calls with SigV4, which those routes do not accept, so
+// the operator's own session is the only credential in the system that can
+// both read and replace a workflow definition.
+
+/** Core's workflow-definition CRUD. NOT under `/admin` — that variant 404s,
+ * indistinguishable from a route that does not exist, which is how the seed
+ * script silently never seeded anything until 2026-08-11. */
+const CORE_ORCHESTRATION_BASE = '/api/v1/orchestration'
+
+/** The fan-in workflow definition this build declares. */
+export interface DeclaredWorkflow {
+  name: string
+  definition: {
+    name: string
+    trigger_source: string
+    trigger_detail_type: string
+    action_type: string
+    action_config: Record<string, unknown>
+    enabled: boolean
+  }
+  fingerprint: string
+}
+
+/** One workflow definition as Core holds it. Only the fields this panel reads
+ * are declared; Core returns more. */
+export interface DeployedWorkflow {
+  id: string
+  name: string
+  action_config: Record<string, unknown> | null
+}
+
+export async function getDeclaredFanInWorkflow(): Promise<DeclaredWorkflow> {
+  return request<DeclaredWorkflow>(
+    'GET',
+    '/fan-in-workflow',
+    undefined,
+    ADMIN_BASE,
+    'read the declared fan-in workflow',
+  )
+}
+
+export async function listCoreWorkflows(): Promise<DeployedWorkflow[]> {
+  const body = await request<unknown>(
+    'GET',
+    '/workflows',
+    undefined,
+    CORE_ORCHESTRATION_BASE,
+    'list the deployed workflows',
+  )
+  return Array.isArray(body) ? (body as DeployedWorkflow[]) : []
+}
+
+/** Write the declared definition to Core — replacing the existing one when
+ * `id` is given, creating it when it is not.
+ *
+ * The create/replace split is the seed script's, kept because the two are not
+ * interchangeable: POSTing over an existing name is what produces two
+ * definitions firing on the same trigger, and the engine would then run
+ * synthesis twice per chain. */
+export async function seedFanInWorkflow(
+  declared: DeclaredWorkflow,
+  existingId: string | null,
+): Promise<void> {
+  if (existingId) {
+    await request<unknown>(
+      'PUT',
+      `/workflows/${existingId}`,
+      declared.definition,
+      CORE_ORCHESTRATION_BASE,
+      're-seed the fan-in workflow',
+    )
+    return
+  }
+  await request<unknown>(
+    'POST',
+    '/workflows',
+    declared.definition,
+    CORE_ORCHESTRATION_BASE,
+    'seed the fan-in workflow',
+  )
+}

--- a/web-admin/src/lib/workflowDrift.test.ts
+++ b/web-admin/src/lib/workflowDrift.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { configDrift, REDACTED_SENTINEL, shortenValue } from './workflowDrift'
+
+describe('configDrift', () => {
+  it('reports nothing when the deployed copy matches the declaration', () => {
+    const config = { model: 'anthropic/claude-opus-5', timeout_seconds: 240 }
+
+    expect(configDrift({ ...config }, { ...config })).toEqual([])
+  })
+
+  it('reports a changed value with both sides, so an operator can see which is which', () => {
+    const drift = configDrift(
+      { model: 'anthropic/claude-opus-4.8' },
+      { model: 'anthropic/claude-opus-5' },
+    )
+
+    expect(drift).toEqual([
+      { key: 'model', deployed: 'anthropic/claude-opus-4.8', declared: 'anthropic/claude-opus-5' },
+    ])
+  })
+
+  it('reports a key the deployed copy is missing entirely', () => {
+    // This is the shape that produced #160's 120s clock: nothing wrote
+    // `timeout_seconds`, and the runtime silently substituted its own default.
+    // An absent key is drift, not agreement.
+    const drift = configDrift({}, { timeout_seconds: 240 })
+
+    expect(drift).toEqual([{ key: 'timeout_seconds', deployed: undefined, declared: 240 }])
+  })
+
+  it('reports a leftover key this build no longer declares', () => {
+    const drift = configDrift({ retired_option: true }, {})
+
+    expect(drift).toEqual([{ key: 'retired_option', deployed: true, declared: undefined }])
+  })
+
+  it('compares nested structures by value, not identity', () => {
+    // `output_tools` is a list of nested JSON schemas rebuilt on every fetch,
+    // so an identity comparison would report permanent drift on a config that
+    // is in step — and a permanently red panel is one people stop reading.
+    const tools = [{ type: 'function', function: { name: 'submit_research_synthesis' } }]
+
+    expect(
+      configDrift({ output_tools: structuredClone(tools) }, { output_tools: tools }),
+    ).toEqual([])
+  })
+
+  it('skips a value Core masked as a secret rather than calling it permanent drift', () => {
+    const drift = configDrift({ model: REDACTED_SENTINEL }, { model: 'anthropic/claude-opus-5' })
+
+    expect(drift).toEqual([])
+  })
+
+  it('sorts by key so the same drift renders in the same order twice', () => {
+    const drift = configDrift({}, { model: 'a', agent_name: 'b', timeout_seconds: 1 })
+
+    expect(drift.map((d) => d.key)).toEqual(['agent_name', 'model', 'timeout_seconds'])
+  })
+})
+
+describe('shortenValue', () => {
+  it('renders an absent value as absent, not as the string "undefined"', () => {
+    expect(shortenValue(undefined)).toBe('(absent)')
+  })
+
+  it('leaves a short value alone', () => {
+    expect(shortenValue('anthropic/claude-opus-5')).toBe('anthropic/claude-opus-5')
+  })
+
+  it('truncates a long one and says how long it was', () => {
+    // The useful thing about a 2,800-character prompt differing is that it is
+    // a prompt and roughly how big — not its first 70 characters alone.
+    const long = 'x'.repeat(200)
+
+    expect(shortenValue(long)).toBe(`${'x'.repeat(70)}… (200 chars)`)
+  })
+
+  it('serialises a structured value rather than printing [object Object]', () => {
+    expect(shortenValue({ a: 1 })).toBe('{"a":1}')
+  })
+})

--- a/web-admin/src/lib/workflowDrift.ts
+++ b/web-admin/src/lib/workflowDrift.ts
@@ -1,0 +1,66 @@
+/** Comparing the fan-in workflow Core actually holds against the one this
+ * build declares (issue #160).
+ *
+ * A TypeScript port of `marketing.fan_in_workflow.config_drift`, kept
+ * deliberately narrow: it decides nothing about what to seed, it only answers
+ * "which keys differ". The declared side is never authored here — it arrives
+ * from `GET /admin/fan-in-workflow`, so there is exactly one declaration in
+ * the repo and this module holds none of it.
+ *
+ * Why a port rather than asking the server: the *deployed* half can only be
+ * read with the operator's Cognito token, which lives in this browser and
+ * nowhere the plugin's Lambda can reach. So the comparison has to happen on
+ * the side that can see both documents, and that side is here.
+ */
+
+/** What Core masks a credential-bearing config field with on read
+ * (`schemas/orchestration.py`'s `SECRET_SENTINEL`). Its real value cannot be
+ * read back, so a key holding it is skipped rather than reported as drift —
+ * calling it stale would mean permanent, unfixable red. Must stay in step
+ * with `fan_in_workflow.REDACTED_SENTINEL`. */
+export const REDACTED_SENTINEL = '••••••••'
+
+export type ConfigDrift = {
+  key: string
+  /** `undefined` when the deployed copy has no such key at all. */
+  deployed: unknown
+  /** `undefined` when this build no longer declares the key — a leftover from
+   * an older seed is drift too, in the direction nothing else reports. */
+  declared: unknown
+}
+
+/** Every key whose deployed value differs from the declared one, sorted by key.
+ *
+ * Compares the **union** of both key sets, not just the declared ones. A key
+ * the deployed copy carries and this build does not is exactly as stale as a
+ * changed model, and is the case a "does the declared config appear in the
+ * deployed one" check would miss.
+ */
+export function configDrift(
+  deployed: Record<string, unknown>,
+  declared: Record<string, unknown>,
+): ConfigDrift[] {
+  const keys = [...new Set([...Object.keys(declared), ...Object.keys(deployed)])].sort()
+  const drift: ConfigDrift[] = []
+  for (const key of keys) {
+    const deployedValue = deployed[key]
+    if (deployedValue === REDACTED_SENTINEL) continue
+    const declaredValue = declared[key]
+    // Structural comparison: `output_tools` is a list of nested schema objects,
+    // so identity would report drift on every render and `===` on every fetch.
+    if (JSON.stringify(deployedValue) !== JSON.stringify(declaredValue)) {
+      drift.push({ key, deployed: deployedValue, declared: declaredValue })
+    }
+  }
+  return drift
+}
+
+/** One drift value, short enough to sit in a table cell. Mirrors the script's
+ * `_short`, including its length suffix — the useful thing about a 2,800-character
+ * prompt differing is usually that it is a prompt, and how long. */
+export function shortenValue(value: unknown): string {
+  if (value === undefined) return '(absent)'
+  const text = typeof value === 'string' ? value : JSON.stringify(value)
+  if (text == null) return String(value)
+  return text.length > 70 ? `${text.slice(0, 70)}… (${text.length} chars)` : text
+}


### PR DESCRIPTION
Closes #160.

## The complaint this closes

The synthesis stage runs a **copy** of this repo's declaration, frozen at the moment somebody last ran `scripts/seed_fan_in_workflow.py`. Nothing in a deploy updates it. Three guards grew around that — the CI fingerprint pin, the script's `--check`, and `pipeline.synthesis_config_drift` — and every one of them can only *report* what it finds. Each ends by naming the same remedy, and that remedy needs a checkout, a shell, and a real Cognito admin token pasted into an environment variable.

That is not a hypothetical cost. `synthesis_config_drift` fired correctly on tabsii dev at 15:26 on 2026-08-14, hours after shipping, and the config was still stale this morning. A detector whose fix nobody can reach reports for ever.

## What changes

The half that *applies* the fix, in the place the operator already is:

- **`marketing/fan_in_workflow.py`** (new) — the declaration moves out of `scripts/` into the package, so more than one caller can act on it. Nothing about the declaration itself changes; the seeded fingerprint is still `sha256:31883429cd45ebe4`.
- **`admin_app`: `GET /fan-in-workflow`** — serves that declaration, admin-gated like every other route on the app. Read-only.
- **`web-admin`: a "Research fan-in workflow" panel** on the campaign list — reads the deployed definition from Core, diffs it key by key, names every stale key with both values, and re-seeds on a click.
- `RESEED_COMMAND` now names the panel first; the script is still quoted after it.

## Why the browser does the writing

It is the only component that can. Core's workflow-definition routes are Cognito-admin gated and have no service-principal counterpart — checked against `tabsii-platform`, where every `WorkflowDefinition` write lives in `routers/orchestration.py` and none in a `require_service_principal` router. The plugin's Lambda SigV4-signs its Core calls, which those routes do not accept, so it cannot seed itself however much we would prefer it to. The operator's Cognito ID token is the one credential both halves take, and the plugin's web-admin already holds it.

An upstream issue for the service-principal route that would remove the operator from this loop entirely is filed separately against `biffo-template`.

## The script keeps its job

A first seed during provisioning, a browserless environment, and `--check` in an ops runbook all still want a CLI, and `--dry-run` is still the only way to read the config with no Core at all. It is simply no longer the *only* way — and both callers now seed the same document rather than two copies of it, which is the failure mode this issue is named for.

## Tests

- `tests/test_marketing_fan_in_workflow_route.py` — the route serves exactly what the script would write (identity with the declaration, not a restatement of its contents), names the workflow the lookup matches on, carries a fingerprint of what it served, and is admin-gated.
- `web-admin/src/lib/workflowDrift.test.ts` — changed / absent / leftover keys, structural comparison, the redacted sentinel, stable ordering.
- `web-admin/src/components/FanInWorkflow.test.tsx` — in-step, stale-with-both-values, replace-not-create, seed-when-absent, and the two fail-open shapes: an unreadable Core must never render as "in step", and a refused write must never render as success.

790 python tests and 236 front-end tests pass locally; the full push gate is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)