### PR TITLE
test(marketing): cover 19 unexercised error branches from the coverage gate

### DIFF
--- a/tests/test_marketing_admin_app.py
+++ b/tests/test_marketing_admin_app.py
@@ -129,3 +129,39 @@ def test_parse_artefact_body_treats_none_and_an_empty_dict_as_empty() -> None:
     behaviour the duplicated ternary already had, unchanged by this refactor."""
     assert admin_app._parse_artefact_body(None) == {}
     assert admin_app._parse_artefact_body({}) == {}
+
+
+# ── _artefact_selection: NULL/unreadable both mean "everything" (issue #145) ──
+
+
+def test_artefact_selection_parses_a_json_array_string() -> None:
+    """The shape Core actually persists once #145 writes a selection."""
+    artefact = {"approved_selection": '["el-1", "el-2"]'}
+    assert admin_app._artefact_selection(artefact) == ["el-1", "el-2"]
+
+
+def test_artefact_selection_treats_an_empty_string_as_everything() -> None:
+    """`""` — distinct from the column genuinely being `NULL`, but must read
+    identically: an artefact approved before #145 has never written anything
+    else here, and losing every element on a formatting quirk of the empty
+    case would be strictly worse than the pre-#145 behaviour it replaces."""
+    assert admin_app._artefact_selection({"approved_selection": ""}) is None
+
+
+def test_artefact_selection_treats_unparseable_json_as_everything() -> None:
+    """A corrupt/non-JSON string in the column must not 500 an artefact read
+    — it degrades to the same "everything" reading a `NULL` gets, per this
+    helper's own docstring, rather than raising `json.JSONDecodeError` out of
+    a route that never expected this column to fail to parse."""
+    assert admin_app._artefact_selection({"approved_selection": "{not valid json"}) is None
+
+
+def test_artefact_selection_treats_a_missing_key_as_everything() -> None:
+    assert admin_app._artefact_selection({}) is None
+
+
+def test_artefact_selection_treats_a_non_list_parsed_value_as_everything() -> None:
+    """Valid JSON that is not a list (e.g. an object) is not a selection
+    either — `raw if isinstance(raw, list) else None` covers it, distinct
+    from the string-shaped cases above."""
+    assert admin_app._artefact_selection({"approved_selection": '{"not": "a list"}'}) is None

--- a/tests/test_marketing_agent_gateway.py
+++ b/tests/test_marketing_agent_gateway.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from biffo_plugin_sdk import BiffoAPIError
 
 from marketing import admin_app
 
@@ -37,6 +38,19 @@ class _FakeClient:
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         del path, params
         return self._response
+
+
+class _RaisingClient:
+    """A `.get` that always raises the queued `BiffoAPIError`, standing in
+    for Core actually refusing/lacking the run — the counterpart to
+    `_FakeClient` above, which only ever returns a JSON body."""
+
+    def __init__(self, error: BiffoAPIError) -> None:
+        self._error = error
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        del path, params
+        raise self._error
 
 
 _BASE_RUN: dict[str, Any] = {
@@ -108,6 +122,51 @@ async def test_get_agent_run_defaults_a_missing_annotations_key_to_none() -> Non
 
     assert view is not None
     assert view.annotations is None
+
+
+# ── a run Core cannot produce at all ──────────────────────────────────────────
+#
+# `get_agent_run`'s own `except BiffoAPIError`: a 404 means "this run id does
+# not exist (yet, or ever)" and must read as `None` — the same "not known yet"
+# a caller like `get_artefact_route` already treats as "still pending, poll
+# again" — never as a crash. Anything else Core sends back (a 500, a 403) is
+# a genuine failure this seam has no business swallowing, so it must propagate
+# unchanged rather than also collapsing to `None` and reading as "not run yet".
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_returns_none_on_a_404_from_core() -> None:
+    gateway = admin_app._CoreAgentGateway(_RaisingClient(BiffoAPIError(404, "not found")))  # type: ignore[arg-type]
+
+    view = await gateway.get_agent_run(run_id="run-does-not-exist")
+
+    assert view is None
+
+
+@pytest.mark.asyncio
+async def test_find_chain_run_returns_none_when_core_has_no_matching_run() -> None:
+    """`find_chain_run`'s own `if not rows: return None` — the "this chain
+    has not reached this agent yet" reading `advance_research` (and every
+    other fan-in caller) relies on to know a stage genuinely has not started,
+    as opposed to a run existing that just has not completed."""
+    gateway = admin_app._CoreAgentGateway(_FakeClient([]))  # type: ignore[arg-type]
+
+    view = await gateway.find_chain_run(chain_id="chain-1", agent_name="marketing-research")
+
+    assert view is None
+
+
+@pytest.mark.asyncio
+async def test_get_agent_run_reraises_a_non_404_core_error() -> None:
+    """A 500 from Core is not "this run doesn't exist" — collapsing it to
+    `None` would make a real outage read as an ordinary still-pending poll."""
+    error = BiffoAPIError(500, "internal error")
+    gateway = admin_app._CoreAgentGateway(_RaisingClient(error))  # type: ignore[arg-type]
+
+    with pytest.raises(BiffoAPIError) as excinfo:
+        await gateway.get_agent_run(run_id="run-1")
+
+    assert excinfo.value is error
 
 
 # ── definition_snapshot: what the run ACTUALLY ran with (issue #160) ──────────

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -119,6 +119,43 @@ async def test_generate_still_raises_when_b64_json_is_missing() -> None:
         await _provider(handler).generate_still(prompt="anything")
 
 
+async def test_generate_still_wraps_a_transport_level_failure() -> None:
+    """`except httpx.HTTPError` — a connection failure/timeout reaching
+    OpenAI at all, distinct from `test_generate_still_raises_on_a_non_200`
+    (which is a completed HTTP exchange, just an error status). Must not
+    escape as a raw `httpx` exception a caller has never imported."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    with pytest.raises(ImageProviderError, match="OpenAI request failed"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_the_response_body_is_not_json() -> None:
+    """`except ValueError` around `response.json()` — a 200 whose body is not
+    parseable JSON at all (an upstream proxy error page, say), distinct from
+    a well-formed JSON body missing the fields this adapter expects."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    with pytest.raises(ImageProviderError, match="not valid JSON"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_b64_json_does_not_decode() -> None:
+    """`except (ValueError, TypeError)` around `base64.b64decode(...,
+    validate=True)` — a `b64_json` field that is present but not valid
+    base64, distinct from it being entirely absent."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"b64_json": "not-base64!!!"}]})
+
+    with pytest.raises(ImageProviderError, match="did not decode"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
 async def test_generate_still_raises_without_a_configured_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_marketing_image_routes.py
+++ b/tests/test_marketing_image_routes.py
@@ -104,6 +104,9 @@ class _FakeCoreClient:
         ledger_status: int | None = None,
         ledger_missing_id: bool = False,
         confirm_missing_id: bool = False,
+        confirm_status: int | None = None,
+        url_status: int | None = None,
+        url_missing: bool = False,
     ) -> None:
         self.calls: list[tuple[str, str, Any]] = []
         self._max_bytes = max_bytes
@@ -111,6 +114,9 @@ class _FakeCoreClient:
         self._ledger_status = ledger_status
         self._ledger_missing_id = ledger_missing_id
         self._confirm_missing_id = confirm_missing_id
+        self._confirm_status = confirm_status
+        self._url_status = url_status
+        self._url_missing = url_missing
 
     async def post(self, path: str, json: dict[str, Any] | None = None) -> Any:
         self.calls.append(("POST", path, json))
@@ -131,6 +137,8 @@ class _FakeCoreClient:
                 "expires_in": 900,
             }
         if path == f"{image_routes._STORAGE_PATH}/confirm":
+            if self._confirm_status is not None:
+                raise BiffoAPIError(self._confirm_status, "storage confirm unavailable")
             if self._confirm_missing_id:
                 return {
                     "owner_plugin": "system:marketing",
@@ -152,6 +160,10 @@ class _FakeCoreClient:
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         self.calls.append(("GET", path, params))
         if path == f"{image_routes._STORAGE_PATH}/{_MEDIA_ID}/url":
+            if self._url_status is not None:
+                raise BiffoAPIError(self._url_status, "signed url unavailable")
+            if self._url_missing:
+                return {"expires_in": 300}
             return {"url": "https://s3.example.invalid/signed-get", "expires_in": 300}
         raise AssertionError(f"unexpected GET {path}")
 
@@ -261,6 +273,27 @@ def _s3_upload_failing(monkeypatch: pytest.MonkeyPatch):
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(403, text="access denied")
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    class _PatchedClient(real_async_client):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _PatchedClient)
+
+
+@pytest.fixture
+def _s3_upload_network_error(monkeypatch: pytest.MonkeyPatch):
+    """As `_s3_upload_failing`, but the connection itself fails — no HTTP
+    response ever comes back at all, distinct from S3 responding with a
+    refusal status. `_upload`'s `except httpx.HTTPError` around this POST is
+    what stands between this and a bare, uncommitted-state-losing crash."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection reset by peer", request=request)
 
     transport = httpx.MockTransport(handler)
     real_async_client = httpx.AsyncClient
@@ -599,6 +632,85 @@ def test_a_malformed_confirm_response_names_the_ledger(_s3_upload_ok) -> None:
     assert resp.status_code == 502
     detail = resp.json()["detail"]
     assert _LEDGER_ID in detail, f"the error must name the ledger entry: {detail!r}"
+
+
+def test_a_network_level_upload_failure_names_the_ledger(_s3_upload_network_error) -> None:
+    """`_upload`'s `except httpx.HTTPError` — a connection failure reaching
+    S3 at all, distinct from `test_the_charge_survives_an_upload_failure_and_
+    the_error_names_the_ledger` above (S3 responding with a refusal status).
+    The charge has already ledgered by this point and the error must still
+    say so, the same as an HTTP-status upload failure does."""
+    core = _FakeCoreClient()
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    ledger_calls = [c for c in core.calls if c[1] == image_routes._LEDGER_PATH]
+    assert len(ledger_calls) == 1, (
+        "the charge must be ledgered even though the upload never completed"
+    )
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail, (
+        f"the error must name the ledger entry so a retry is not blind: {detail!r}"
+    )
+
+
+def test_a_failed_confirm_call_names_the_ledger(_s3_upload_ok) -> None:
+    """`_upload`'s SECOND `except BiffoAPIError` — the storage `/confirm`
+    POST itself failing (Core answered, but with an error), distinct from
+    `test_a_malformed_confirm_response_names_the_ledger` (confirm succeeds
+    with a shape Core response drift left incomplete). The upload has
+    already reached S3 and the ledger already recorded the charge, so the
+    502 must still name the ledger."""
+    core = _FakeCoreClient(confirm_status=502)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail, f"the error must name the ledger entry: {detail!r}"
+
+
+def test_a_failed_signed_url_fetch_names_everything_already_committed(_s3_upload_ok) -> None:
+    """The route's final `except BiffoAPIError` (fetching the signed GET
+    URL) — by this point the charge, the upload AND the asset row have all
+    committed, so the 502 must name all three: nothing left to retry that
+    isn't purely local bookkeeping, per the route's own docstring."""
+    core = _FakeCoreClient(url_status=502)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail
+    assert _MEDIA_ID in detail
+
+
+def test_a_malformed_signed_url_response_names_everything_already_committed(_s3_upload_ok) -> None:
+    """As above, one field-shape step later: Core's `/url` GET succeeds but
+    the response is missing `url` itself — the route's LAST `except
+    HTTPException`, wrapping `_required_field`. Same committed-state
+    guarantee: the charge, upload and asset row are all already durable."""
+    core = _FakeCoreClient(url_missing=True)
+    client = TestClient(
+        _app(provider=_FakeImageProvider(), core_client=core, campaign_client=_FakeCampaignClient())
+    )
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/stills", json={"prompt": "anything"})
+
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert _LEDGER_ID in detail
+    assert _MEDIA_ID in detail
 
 
 def test_a_non_numeric_max_bytes_is_a_diagnosable_502_not_a_crash() -> None:

--- a/tests/test_marketing_openrouter_image_provider.py
+++ b/tests/test_marketing_openrouter_image_provider.py
@@ -179,6 +179,40 @@ async def test_generate_still_raises_when_b64_json_is_missing() -> None:
         await _provider(handler).generate_still(prompt="anything")
 
 
+async def test_generate_still_wraps_a_transport_level_failure() -> None:
+    """`except httpx.HTTPError` — a connection failure/timeout reaching
+    OpenRouter at all, distinct from `test_generate_still_raises_on_a_non_200`
+    (a completed exchange with an error status)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    with pytest.raises(ImageProviderError, match="OpenRouter request failed"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_the_response_body_is_not_json() -> None:
+    """`except ValueError` around `response.json()` — a 200 with a body that
+    is not parseable JSON at all."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    with pytest.raises(ImageProviderError, match="not valid JSON"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
+async def test_generate_still_raises_when_b64_json_does_not_decode() -> None:
+    """`except (ValueError, TypeError)` around `base64.b64decode(...,
+    validate=True)` — a `b64_json` present but not valid base64."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"b64_json": "not-base64!!!"}]})
+
+    with pytest.raises(ImageProviderError, match="did not decode"):
+        await _provider(handler).generate_still(prompt="anything")
+
+
 async def test_generate_still_raises_without_a_configured_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_marketing_pack_routes.py
+++ b/tests/test_marketing_pack_routes.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import httpx
 import pytest
+from biffo_plugin_sdk import BiffoAPIError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -163,13 +164,19 @@ class _FakeStorageClient:
     """Stands in for the SigV4-signed internal client: only the one route
     this file's route now calls — minting a GET url for an existing media id."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, url_status: int | None = None) -> None:
         self.calls: list[tuple[str, str, Any]] = []
+        #: When set, every `.../url` GET raises `BiffoAPIError` with this
+        #: status instead of returning a URL — `_asset_with_url`'s own
+        #: `except BiffoAPIError`.
+        self._url_status = url_status
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         self.calls.append(("GET", path, params))
         prefix = f"{pack_routes._STORAGE_PATH}/"
         if path.startswith(prefix) and path.endswith("/url"):
+            if self._url_status is not None:
+                raise BiffoAPIError(self._url_status, "signed url unavailable")
             media_id = path[len(prefix) : -len("/url")]
             return {
                 "url": f"https://bucket.s3.eu-west-1.amazonaws.com/signed-get-{media_id}",
@@ -765,6 +772,29 @@ def test_assets_route_404s_an_unknown_campaign(monkeypatch: pytest.MonkeyPatch) 
     resp = client.get(f"/campaigns/{_CAMPAIGN}/assets")
 
     assert resp.status_code == 404
+
+
+def test_assets_route_surfaces_a_signed_url_failure_as_a_named_gateway_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_asset_with_url`'s own `except BiffoAPIError` — Core answering the
+    signed-URL GET with a real failure (not a network error, an HTTP error
+    status), mapped through `_core_error` the same way every other Core
+    failure in this module is, rather than an unhandled `BiffoAPIError`
+    reaching the caller as a bare 500 with no diagnosable status/detail."""
+    core = _FakeCore(copy_artefact=None)
+    monkeypatch.setattr(admin_app, "_core", core)
+    campaign_client = _FakeCampaignClient(assets=[_source_asset()])
+    client = TestClient(
+        _app(
+            core_client=_FakeStorageClient(url_status=502),
+            campaign_client=campaign_client,
+        )
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/assets")
+
+    assert resp.status_code == 502
 
 
 def test_assets_route_applies_the_same_newest_source_wins_dedup_as_the_pack(

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -896,6 +896,55 @@ def test_start_copy_refuses_when_no_channel_plan_exists(ctx) -> None:
     assert resp.status_code == 404
 
 
+def test_start_copy_409s_a_pre_migration_channel_plan_without_spending_a_run(ctx) -> None:
+    """`start_copy_route`'s own `except pipeline.StaleChannelPlanError` (#152),
+    the route-level twin of `test_channel_plan_channel_map_raises_on_a_pre_migration_plan`
+    in `test_marketing_pipeline.py`. That test covers only the helper; nothing
+    before this exercised the HTTP translation PR #153 added — the actual
+    behaviour an operator sees when their approved channel plan predates
+    channel taxonomy ids (#76 increment 2): every entry the old free-text
+    shape, none carrying a `channel_key`. This must come back as a named,
+    actionable 409 telling them to re-run channel planning, not a bare
+    `KeyError`/500 out of the copy agent's own extraction, and it must be
+    caught BEFORE an agent run is requested — a stale plan is not something
+    more agent spend can fix."""
+    client, core, gateway = ctx
+    _propose_and_approve_positioning(client, core, gateway)
+    core.artefacts["artefact-pre-migration-plan"] = {
+        "id": "artefact-pre-migration-plan",
+        "campaign_id": _CAMPAIGN,
+        "kind": "channel_plan",
+        "status": "approved",
+        "created_at": "2026-08-10T00:00:99Z",
+        "agent_run_id": "run-pre-migration",
+        "citations": None,
+        "approved_selection": None,
+        "body": json.dumps(
+            {
+                "channels": [
+                    {
+                        "channel": "Google Search ads (non-brand: franchise management)",
+                        "motion": "paid",
+                        "rank": 1,
+                        "rationale": "r",
+                        "sources": [{"url": "https://example.com/y", "note": "n"}],
+                    }
+                ]
+            }
+        ),
+    }
+
+    resp = client.post(f"/campaigns/{_CAMPAIGN}/copy")
+
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert "channel_key" in detail
+    assert "re-run" in detail.lower()
+    assert not [r for r in gateway.requested if r["agent_name"] == "marketing-copy"], (
+        "a known-stale plan must not spend an agent run before failing"
+    )
+
+
 def test_start_copy_runs_once_both_upstream_artefacts_are_approved(ctx) -> None:
     client, core, gateway = ctx
     _propose_and_approve_channel_plan(client, core, gateway)

--- a/tests/test_marketing_seed_fan_in_workflow.py
+++ b/tests/test_marketing_seed_fan_in_workflow.py
@@ -8,6 +8,8 @@ same rationale as idea-scout's `test_idea_scout_seed_fan_in_workflow.py`.
 
 from __future__ import annotations
 
+import io
+
 import pytest
 from _scripts import load_script
 
@@ -318,6 +320,39 @@ def test_a_seeding_run_stays_quiet_when_the_deployment_is_in_step(
     listed = _deployed(definition()["action_config"])
 
     assert _run_main(monkeypatch, [], listed) == 0
+
+
+def test_a_failed_create_reports_the_core_error_and_exits_one(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The SECOND `except urllib.error.HTTPError` — the write itself (here, a
+    POST since nothing is seeded yet) failing, distinct from
+    `test_check_exits_two_when_core_cannot_be_read` above (the initial GET
+    that lists existing workflows failing). A write failure is a real,
+    non-`--check` failure — exit 1, not 2 — and must name what Core said,
+    not raise the raw `HTTPError` out of `main()`."""
+    monkeypatch.setenv("CORE_API_URL", "https://core.example")
+    monkeypatch.setenv("ADMIN_BEARER_TOKEN", "t")
+    monkeypatch.setattr(_seed.sys, "argv", ["seed_fan_in_workflow.py"])
+
+    def _fake_request(method: str, url: str, token: str, body: dict | None = None) -> object:
+        del url, token, body
+        if method == "GET":
+            return []
+        raise _seed.urllib.error.HTTPError(
+            "u",
+            502,
+            "Bad Gateway",
+            {},
+            io.BytesIO(b"upstream refused"),  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(_seed, "_request", _fake_request)
+
+    assert _seed.main() == 1
+    err = capsys.readouterr().err
+    assert "Failed" in err
+    assert "502" in err
 
 
 def test_replace_puts_over_the_existing_definition_rather_than_creating_a_second(

--- a/tests/test_marketing_seed_marketing_channels.py
+++ b/tests/test_marketing_seed_marketing_channels.py
@@ -17,7 +17,9 @@ nothing else proves them:
 
 from __future__ import annotations
 
+import io
 import re
+import urllib.error
 from typing import Any
 
 from _scripts import load_script
@@ -199,15 +201,26 @@ class _FakeCore:
     DELETEs or PUTs at all, and the only PATCH it may issue is a fill-if-null
     backfill of a DEFAULT channel's never-set field (#103b)."""
 
-    def __init__(self, initial: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self, initial: list[dict[str, Any]] | None = None, *, fail_on: str | None = None
+    ) -> None:
         self.rows: list[dict[str, Any]] = [dict(row) for row in (initial or [])]
         self.methods_used: list[str] = []
         #: (row_id, body) for every PATCH, so a test can assert exactly which
         #: rows were touched and with what — not merely that a PATCH happened.
         self.patches: list[tuple[str, dict]] = []
+        #: A method ("GET"/"POST"/"PATCH") that should raise
+        #: `urllib.error.HTTPError` instead of completing, standing in for
+        #: Core rejecting or being unreachable for that call.
+        self._fail_on = fail_on
 
     def request(self, method: str, url: str, token: str, body: dict | None = None) -> Any:
         self.methods_used.append(method)
+        if method == self._fail_on:
+            hdrs: Any = {}
+            raise urllib.error.HTTPError(
+                url, 502, "Bad Gateway", hdrs, io.BytesIO(b"upstream refused")
+            )
         if method == "GET":
             return list(self.rows)
         if method == "POST":
@@ -304,6 +317,57 @@ def test_an_upgrade_adding_a_default_channel_reaches_an_existing_install(monkeyp
     keys_after = {row["key"] for row in fake.rows}
     assert "podcast_sponsorship" in keys_after
     assert keys_after == {c["key"] for c in CHANNELS} | {"podcast_sponsorship"}
+
+
+def test_a_failed_list_call_reports_the_core_error_and_exits_one(monkeypatch, capsys) -> None:
+    """`main()`'s FIRST `except urllib.error.HTTPError` — Core refusing (or
+    being unreachable for) the initial GET that lists existing channels, the
+    call every idempotency decision below it depends on. Must report what
+    Core said and exit 1, not raise the raw `HTTPError` out of `main()`."""
+    fake = _FakeCore(fail_on="GET")
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Could not list channels" in err
+    assert "502" in err
+
+
+def test_a_failed_create_reports_which_channel_and_exits_one(monkeypatch, capsys) -> None:
+    """`main()`'s SECOND `except urllib.error.HTTPError` — a POST creating a
+    still-missing default channel failing. Distinct from the GET failure
+    above: the listing succeeded, so the script knows exactly which channel
+    it was trying to create, and the error must name it."""
+    fake = _FakeCore(fail_on="POST")
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "Failed on" in err
+    assert "502" in err
+    assert CHANNELS[0]["key"] in err
+
+
+def test_a_failed_backfill_patch_is_reported_and_skipped_not_fatal(monkeypatch, capsys) -> None:
+    """`_backfill_null_fields`'s own `except urllib.error.HTTPError` — a
+    single channel's fill-if-null PATCH failing must not abort the whole
+    seeding run (every channel already exists at this point; the run's own
+    job is done). It logs the failure and moves on to the next channel,
+    rather than losing every OTHER channel's backfill over one PATCH."""
+    seeded = [
+        {**channel, "id": f"row-{i}", "publish_url": None} for i, channel in enumerate(CHANNELS)
+    ]
+    fake = _FakeCore(initial=seeded, fail_on="PATCH")
+
+    rc = _run_seed(monkeypatch, fake)
+
+    assert rc == 0, "a backfill failure must not fail the whole run"
+    err = capsys.readouterr().err
+    assert "Could not backfill" in err
+    assert "502" in err
+    assert fake.patches == [], "the fake raises before recording the PATCH as applied"
 
 
 def test_missing_credentials_is_a_clear_failure_not_a_silent_noop(monkeypatch) -> None:

--- a/tests/test_marketing_ssm.py
+++ b/tests/test_marketing_ssm.py
@@ -91,6 +91,23 @@ def test_a_non_client_transport_error_is_none(monkeypatch: pytest.MonkeyPatch) -
     assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) is None
 
 
+def test_boto3_being_unimportable_is_none_not_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`read_parameter`'s FIRST `except Exception` — the deferred `import
+    boto3` itself failing, distinct from every case above (all of which
+    assume boto3 imported fine and then the SSM *call* failed). A Lambda
+    package that somehow ships without boto3 (or a botocore ABI mismatch)
+    must degrade to "could not ask, try again" the same as a network error,
+    not raise `ImportError` out of a module whose whole contract is
+    returning `str | None`."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "boto3", None)
+
+    assert ssm.read_parameter("/some/parameter", purpose=_PURPOSE) is None
+
+
 def test_the_purpose_reaches_the_log_line(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_marketing_user_app.py
+++ b/tests/test_marketing_user_app.py
@@ -29,6 +29,7 @@ import json
 from typing import Any
 
 import pytest
+from biffo_plugin_sdk import BiffoAPIError
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -46,12 +47,18 @@ def _founder_user() -> Any:
 class _FakeCoreClient:
     """Stands in for `get_core_client()` — the SigV4-only storage-URL client."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, url_status: int | None = None) -> None:
         self.calls: list[tuple[str, dict[str, Any] | None]] = []
+        #: When set, every `.../url` GET raises `BiffoAPIError` with this
+        #: status instead of returning a URL — `_resolve_asset_url`'s own
+        #: `except BiffoAPIError`.
+        self._url_status = url_status
 
     async def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         self.calls.append((path, params))
         if path.endswith("/url"):
+            if self._url_status is not None:
+                raise BiffoAPIError(self._url_status, "signed url unavailable")
             media_id = path.split("/")[-2]
             return {"url": f"https://s3.example.invalid/{media_id}"}
         raise AssertionError(f"unexpected GET {path}")
@@ -342,6 +349,48 @@ def test_pack_survives_a_storage_response_with_no_url_key(fake_signed_client) ->
             "url": None,
         }
     ]
+
+
+def test_pack_surfaces_a_signed_url_failure_as_a_named_gateway_error(
+    fake_signed_client,
+) -> None:
+    """`_resolve_asset_url`'s own `except BiffoAPIError` — Core answering the
+    signed-URL GET with a real failure status, distinct from
+    `test_pack_survives_a_storage_response_with_no_url_key` above (a 200
+    with an unexpected shape, which this route deliberately tolerates). A
+    genuine Core failure must map through `_core_error` like every other
+    Core failure in this module, not reach a founder as a bare 500."""
+    fake_signed_client(
+        {
+            f"{user_app._INTERNAL_PREFIX}/campaigns/{_CAMPAIGN}": (
+                200,
+                json.dumps(_campaign_row()).encode(),
+            ),
+            f"{user_app._INTERNAL_PREFIX}/artefacts": (
+                200,
+                json.dumps([_approved_copy_artefact()]).encode(),
+            ),
+        }
+    )
+    campaign_client = _FakeCampaignClient(
+        assets=[
+            {
+                "id": "asset-1",
+                "campaign_id": _CAMPAIGN,
+                "media_kind": "image",
+                "placement": None,
+                "media_id": "media-1",
+                "is_source": True,
+            }
+        ]
+    )
+    client = TestClient(
+        _app(core_client=_FakeCoreClient(url_status=502), campaign_client=campaign_client)
+    )
+
+    resp = client.get(f"/campaigns/{_CAMPAIGN}/pack")
+
+    assert resp.status_code == 502
 
 
 def test_pack_404s_a_campaign_that_is_not_ready_or_live(fake_signed_client) -> None:

--- a/tests/test_marketing_video_assembly_no_ffmpeg.py
+++ b/tests/test_marketing_video_assembly_no_ffmpeg.py
@@ -1,0 +1,72 @@
+"""The `OSError`/`subprocess.TimeoutExpired` branches of `video_assembly.py`,
+exercised WITHOUT a real `ffmpeg` binary on `PATH`.
+
+`tests/test_marketing_video_assembly.py` skips its ENTIRE module when ffmpeg
+is absent (deliberately — most of it renders and inspects real mp4 output,
+which genuinely needs the binary). But that module-wide skip also hides two
+tests that do not actually need ffmpeg at all, and on a CI runner with no
+ffmpeg installed, that made both of these named failure modes completely
+unexercised — not merely skipped for a good reason, but never observed by
+anything.
+
+Both are decoupled from ffmpeg here, so they run everywhere:
+
+- `_prepare_frame`'s `except OSError` (an undecodable creative) is called
+  directly. This is purely a Pillow decode failure — `_prepare_frame` never
+  shells out — so routing it through `assemble()` (which calls
+  `_ffmpeg_path()` before it ever reaches `_prepare_frame`) was the only
+  reason it needed ffmpeg in the first place.
+- `assemble()`'s `except subprocess.TimeoutExpired` is reached with
+  `_ffmpeg_path` monkeypatched to a fake path and `subprocess.run` replaced
+  outright, exactly as `test_marketing_video_assembly.py`'s own
+  `test_ffmpeg_timeout_surfaces_as_video_assembly_error` does for
+  `subprocess.run` — except that test leaves `_ffmpeg_path` untouched, so it
+  still needs a real `ffmpeg` on `PATH` purely to get past that call, even
+  though the mocked `subprocess.run` means the binary is never actually
+  invoked. Faking `_ffmpeg_path` too removes that unnecessary dependency.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+
+import pytest
+from PIL import Image
+
+import marketing.video_assembly as video_assembly_module
+from marketing.video_assembly import InvalidCreativeError, VideoAssemblyError, _prepare_frame
+
+
+def test_prepare_frame_wraps_an_undecodable_creative_without_ffmpeg() -> None:
+    """The `OSError` branch (`_prepare_frame`, video_assembly.py ~line 292):
+    Pillow's `UnidentifiedImageError`/`OSError` on unreadable bytes must not
+    escape unwrapped — it becomes this module's own `InvalidCreativeError`,
+    naming what actually happened rather than surfacing a bare Pillow error
+    to a caller that has never imported PIL."""
+    with pytest.raises(InvalidCreativeError, match="Could not decode a creative as an image"):
+        _prepare_frame(b"this is not an image", "feed_1x1", text=None)
+
+
+def test_assemble_wraps_a_timed_out_ffmpeg_without_a_real_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `subprocess.TimeoutExpired` branch (`assemble()`, video_assembly.py
+    ~line 430): a wedged ffmpeg must surface as this module's own named
+    `VideoAssemblyError`, not block the caller until some outer timeout (a
+    Lambda's own) fires opaquely instead."""
+
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["ffmpeg"], timeout=video_assembly_module._FFMPEG_TIMEOUT_S
+        )
+
+    monkeypatch.setattr(video_assembly_module, "_ffmpeg_path", lambda: "ffmpeg-stub-never-run")
+    monkeypatch.setattr(video_assembly_module.subprocess, "run", _raise_timeout)
+
+    still = Image.new("RGB", (100, 100), (0, 0, 0))
+    buffer = io.BytesIO()
+    still.save(buffer, format="PNG")
+
+    with pytest.raises(VideoAssemblyError, match="did not finish"):
+        video_assembly_module.assemble([buffer.getvalue()], "feed_1x1")


### PR DESCRIPTION
## What

Covers the 19 error branches `tabsii-com/tabsii-platform#637` reported as "added with no test exercising them" (15 measured through this plugin, vendored into that instance's coverage run). This is prose context, not a closing keyword — merging this does not close that issue.

Every new test asserts the actual translated behaviour a caller sees (status code, error message, what already-committed state a caller learns survived) rather than merely reaching the line. See the commit message for the full branch-by-branch list.

## `video_assembly.py` verdict

Its `except OSError` / `except subprocess.TimeoutExpired` already had real tests and pass locally (ffmpeg is on PATH here) — the gap is that the whole test module skips on a CI runner without ffmpeg (14+ tests). Added `tests/test_marketing_video_assembly_no_ffmpeg.py`: the `OSError` case is decoupled by calling `_prepare_frame` directly (it never shells out), and the `TimeoutExpired` case by faking `_ffmpeg_path` alongside the existing `subprocess.run` mock. Both verified to pass with ffmpeg entirely absent from `PATH`.

## Fail-first discipline

Every branch's test was proven to fail without its handler (the `except`/fallback temporarily removed or replaced with a bare re-raise) before being restored — done individually for each of the 19, not just "all tests pass at the end."

## Not in scope

None of the 19 branches were judged unreachable — all were coverable with the existing fake/mock patterns already in this test suite. No production code changed; every fail-first edit was reverted.

## Gates

- `sh scripts/biffo.sh verify` — passes
- `uv run pytest` — 814 passed, 4 skipped (pre-existing, unrelated: retrieval-description skips in `test_marketing_output_tool_call.py`)
- `web-admin` lint/typecheck/test — passes (not touched, but AGENTS.md requires `pnpm install` in the worktree regardless)
