### PR TITLE
fix(channel-plan): stop the positioning body being the grounding run's search

### DIFF
--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -36,9 +36,16 @@ router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 _INTERNAL_PREFIX = "/api/v1/internal/plugins/marketing"
 
 
-async def _targeting(campaign_id: str, token: str) -> tuple[str, list[str]]:
-    """This campaign's motion and selected channel keys (#67), or a 4xx
+async def _targeting(campaign_id: str, token: str) -> tuple[str, list[str], dict[str, Any]]:
+    """This campaign's motion, selected channel keys (#67) and brief, or a 4xx
     naming the decision that has not been taken yet.
+
+    The brief rides along rather than being fetched again because this is
+    already the read of the campaign row that has it. It is what the grounding
+    run's retrieval is derived from (#65) — see
+    ``pipeline.channel_evidence_input`` — and it is shaped as
+    ``{"brief": ...}`` here, matching ``start_research_route``'s payload
+    exactly, so ``definitions._brief_topic`` reads both the same way.
 
     Both are operator decisions the channel-plan stage cannot make for
     itself, and both are refused rather than defaulted. A default motion of
@@ -80,7 +87,7 @@ async def _targeting(campaign_id: str, token: str) -> tuple[str, list[str]]:
                 "should run on before planning."
             ),
         )
-    return motion, selected
+    return motion, selected, {"brief": row.get("brief") or ""}
 
 
 @router.post("/campaigns/{campaign_id}/channel-plan", status_code=status.HTTP_201_CREATED)
@@ -98,7 +105,7 @@ async def start_channel_plan_route(
     # The operator's two pre-plan decisions (#67), read BEFORE the approval
     # gate work below so a campaign missing either is told which decision is
     # missing rather than having an agent run started for it.
-    campaign_motion, selected_keys = await _targeting(campaign_id, admin.token)
+    campaign_motion, selected_keys, brief = await _targeting(campaign_id, admin.token)
 
     positioning = await admin_app._latest_artefact(campaign_id, "positioning", admin.token)
     if positioning is None:
@@ -207,7 +214,7 @@ async def start_channel_plan_route(
     # be handed over as an enumerated set — see `pipeline.advance_channel_plan`.
     causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=positioning_body,
+        brief=brief,
         taxonomy=taxonomy,
         campaign_motion=campaign_motion,
     )

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -882,11 +882,16 @@ are what to look for in the pages you were given:
 - Where this audience demonstrably **converts** — not where it merely has
   attention. Intent expressed beats attention observed.
 
-You are also given the approved `positioning` and the `channel_taxonomy` this
-campaign may plan against. Both are context for what is worth noticing; they
-are not what you report on. The positioning was researched to establish who
-this audience is and what competitors say to them, which is a different
-question from yours.
+You are also given the campaign `brief` — who this campaign is for, in the
+operator's own words — and the `channel_taxonomy` it may plan against. Both
+are context for what is worth noticing; they are not what you report on.
+
+You are deliberately NOT given the approved positioning, and its absence is
+not an oversight you should try to work around. Everything in this run's input
+is also what its retrieval was derived from, so the message pillars and calls
+to action would have pulled the search towards the campaign's own argument and
+away from the channel question. Read on that basis: you are looking for where
+this brief's audience converts, not for pages that agree with a position.
 
 For every page worth reporting, give:
 
@@ -1230,71 +1235,60 @@ CHANNEL_PLAN_SEARCH_FRAMING = (
     "carrying the number, not a vendor home page or a listicle"
 )
 
-#: How many of the positioning's segment names, and how many channel labels,
-#: ride in the searched query. Bounded for the same reason
-#: ``SEARCH_QUERY_BRIEF_CHARS`` is: the whole positioning body still travels in
-#: the payload for the *model* to read, and a query assembled from nine
-#: segments and thirty channels is a worse query than one built from the few
-#: that lead.
-CHANNEL_PLAN_QUERY_SEGMENTS = 3
+#: How many channel labels ride in the searched query. Bounded for the same
+#: reason ``SEARCH_QUERY_BRIEF_CHARS`` is: a query naming thirty channels is a
+#: worse query than one naming the few that lead.
 CHANNEL_PLAN_QUERY_CHANNELS = 6
-
-
-def _named_items(body: Mapping[str, Any] | None, key: str, field: str, limit: int) -> list[str]:
-    """Up to ``limit`` non-empty ``field`` values from ``body[key]``.
-
-    Tolerant by construction, exactly like ``_brief_topic``: the positioning
-    body is JSON this plugin persisted but a model wrote, and a malformed or
-    partially-approved one must degrade to a thinner query rather than fail
-    the run before it starts.
-    """
-    if not isinstance(body, Mapping):
-        return []
-    items = body.get(key)
-    if not isinstance(items, list):
-        return []
-    found: list[str] = []
-    for item in items:
-        value = item.get(field) if isinstance(item, Mapping) else None
-        if isinstance(value, str) and value.strip() and value not in found:
-            found.append(" ".join(value.split()))
-        if len(found) == limit:
-            break
-    return found
 
 
 def channel_plan_search_query(
     *,
-    positioning_body: Mapping[str, Any] | None,
+    brief: Mapping[str, Any] | None,
     taxonomy: list[dict[str, Any]],
     campaign_motion: str,
 ) -> str:
     """The text the channel-plan run's retrieval is derived from (issue #65).
 
-    Sent as the FIRST key of the run's ``input_payload`` (see
-    ``marketing.pipeline.start_channel_plan``), for exactly the reason
+    Sent as the FIRST key of the grounding run's ``input_payload`` (see
+    ``marketing.pipeline.start_channel_evidence``), for exactly the reason
     ``research_search_query`` is: an ``:online`` run's provider searches
     *before* the model is invoked, from the payload, so the payload — not the
     instructions — is the only place this stage can influence what comes back.
-    Issue #101 measured what happens when that is left alone: two agents sent
-    identical payloads received 4 of 5 identical pages.
 
-    A channel-plan payload that led with the positioning body would retrieve
-    the positioning question a second time, which is precisely the defect
-    #65 reports one layer up. So the query is assembled from the three things
-    that make this campaign's channel question specific — its audience, the
-    channels actually on the table, and the motion it runs — and closed with
-    :data:`CHANNEL_PLAN_SEARCH_FRAMING`.
+    ## Why the audience half is the BRIEF, and not the positioning's segments
+
+    It was the segments, by ``name``, until a live run on tabsii dev
+    (2026-08-15) measured what that retrieves. The names a positioning agent
+    coins are written for an operator to recognise — "The Frankenstein-Stack
+    Operator (5–20 sites)", "Head Office Caught in the False Choice" — and
+    they are not phrases anyone outside this campaign has ever published. A
+    search built from them has nothing real to match.
+
+    The brief is the opposite kind of text: an operator describing a market in
+    the market's own words ("UK multi-unit franchise owners running 5-20
+    sites"). It is also the one audience half in this plugin **measured** to
+    retrieve on-topic pages — ``research_search_query`` is built the same way,
+    from the same helper, and its runs come back with franchise-specific
+    material.
+
+    Sharing the brief with research does not re-retrieve research's pages:
+    #101 established that two runs over the same topic diverge completely when
+    their framings differ, and :data:`CHANNEL_PLAN_SEARCH_FRAMING` asks a
+    different question — where this audience converts, not who it is.
     """
-    audience = _named_items(positioning_body, "segments", "name", CHANNEL_PLAN_QUERY_SEGMENTS)
+    topic_source = _brief_topic(brief)
     labels = [
         " ".join(str(entry["label"]).split())
         for entry in taxonomy
         if isinstance(entry, Mapping) and entry.get("label")
     ][:CHANNEL_PLAN_QUERY_CHANNELS]
 
-    who = ", ".join(audience) if audience else "this audience"
-    topic = f"{campaign_motion} channels for {who}"
+    # Em-dash separated rather than "channels for <who>": a brief is a
+    # sentence, not the noun phrase a segment name was, so "for" produced
+    # "channels for We are marketing Tabsii to…". The separator matches the
+    # rest of the query's own structure and costs the search nothing.
+    who = topic_source or "this audience"
+    topic = f"{campaign_motion} marketing channels — {who}"
     if labels:
         topic += f" — {', '.join(labels)}"
     return f"{topic} — {CHANNEL_PLAN_SEARCH_FRAMING}"

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -2044,17 +2044,68 @@ class ChannelPlanAdvance:
     started_plan_run_id: str | None = None
 
 
+def channel_evidence_input(
+    *,
+    brief: Mapping[str, Any] | None,
+    taxonomy: list[dict[str, Any]],
+    campaign_motion: str,
+) -> dict[str, Any]:
+    """Everything the **grounding** run is given — and nothing else (issue #65).
+
+    ## Every key here is also a search term, which is the whole point
+
+    An ``:online`` run's provider searches from the run's input payload before
+    the model is invoked. Not from its first key — from the payload. So this
+    function's return value is not "context for the model", it is *the query*,
+    and anything put here steers what comes back.
+
+    That distinction was measured rather than reasoned about. Until now this
+    run was handed :func:`channel_plan_input` — the full approved positioning,
+    thousands of tokens of segments, message pillars, calls to action and their
+    sources — behind a ``search_query`` first key. On tabsii dev (2026-08-15)
+    it retrieved five pages, and every one of them tracked the **pillars**:
+
+        default.com/post/revops-frankenstack
+        shopify.com/enterprise/blog/frankenstack
+        gtmstack.app/blog/building-unified-gtm-data-layer
+        stackswap.ai/knowledge/modern-gtm-architecture
+        kaelio.com/blog/single-source-of-truth-data-across-tools
+
+    "single source of truth" and "unified data layer" are that campaign's own
+    message pillars. They appear nowhere in the ``search_query`` — nor do any
+    of its terms appear in what came back. The query contributed nothing; the
+    body contributed everything, and the run correctly reported no evidence
+    because not one retrieved page was about where anyone converts.
+
+    So the grounding run now receives the question and not the answer-so-far:
+    the searched query, the audience as the operator described it, the channels
+    on the table, and the motion. The positioning still reaches the **planning**
+    run through :func:`channel_plan_input`, which is what needs it — that run is
+    ``opus-5`` with no ``:online``, so its payload steers no retrieval at all.
+
+    ``brief`` is the campaign's own ``{"brief": ...}`` shape, the same one
+    ``start_research`` sends, so both grounded stages describe their audience
+    from one source of words rather than two.
+    """
+    return {
+        "brief": dict(brief) if isinstance(brief, Mapping) else {},
+        "channel_taxonomy": taxonomy,
+        "campaign_motion": campaign_motion,
+    }
+
+
 async def start_channel_evidence(
     gateway: AgentGateway,
     *,
-    positioning_body: dict[str, Any],
+    brief: Mapping[str, Any] | None,
     taxonomy: list[dict[str, Any]],
     campaign_motion: str,
     channel_evidence_model: str = DEFAULT_CHANNEL_EVIDENCE_MODEL,
 ) -> tuple[str, str]:
     """Start the channel stage by starting its **grounding** run (M4, issues
-    #3/#65), given the *approved* positioning artefact's body AND the channels
-    this campaign may plan against as input.
+    #3/#65), given the campaign brief and the channels this campaign may plan
+    against as input — and deliberately NOT the approved positioning, which
+    reaches the planning run instead (see :func:`channel_evidence_input`).
 
     ## Why the stage starts with a run that recommends nothing
 
@@ -2121,18 +2172,22 @@ async def start_channel_evidence(
         # for exactly the same reason (issue #101, now #65): this is an
         # `:online` run, so the provider searches from the payload BEFORE the
         # model is invoked, and the payload is therefore the only place this
-        # stage can decide what its retrieval is about. Leading with
-        # `positioning` would retrieve the positioning question all over
-        # again — the audience/competitive evidence this stage already has
-        # too much of — instead of the conversion question it exists to ask.
+        # stage can decide what its retrieval is about.
+        #
+        # Being first is NOT sufficient, which is what #65's second live run
+        # measured — see `channel_evidence_input`. The rest of the payload is
+        # searched too, and a positioning body outweighs a one-line query by a
+        # thousand tokens. So the constraint is on the whole payload, and it is
+        # `channel_evidence_input`'s job to hold it: nothing reaches this run
+        # that its retrieval should not be about.
         input_payload={
             "search_query": channel_plan_search_query(
-                positioning_body=positioning_body,
+                brief=brief,
                 taxonomy=taxonomy,
                 campaign_motion=campaign_motion,
             ),
-            **channel_plan_input(
-                positioning_body=positioning_body,
+            **channel_evidence_input(
+                brief=brief,
                 taxonomy=taxonomy,
                 campaign_motion=campaign_motion,
             ),

--- a/tests/test_marketing_channel_plan_grounding.py
+++ b/tests/test_marketing_channel_plan_grounding.py
@@ -193,6 +193,11 @@ _TAXONOMY_ROWS = [
     }
 ]
 
+#: The campaign brief the grounding run is given, and derives its search from
+#: (#65). Shaped `{"brief": ...}` exactly as `start_research`'s payload is, so
+#: `definitions._brief_topic` reads both the same way.
+_BRIEF = {"brief": "Independent UK coffee shop chains running 3-10 sites."}
+
 
 # ── 1. The route ─────────────────────────────────────────────────────────────
 
@@ -277,14 +282,20 @@ async def test_the_run_leads_with_a_conversion_search_query() -> None:
     """An `:online` run's retrieval is derived from its input payload — the
     provider searches before the model is invoked — so the payload, not the
     instructions, is the only place this stage can affect what comes back
-    (issue #101, measured: identical payloads produced identical pages). A
-    channel-plan payload that leads with the positioning body would retrieve
-    the positioning question all over again."""
+    (issue #101, measured: identical payloads produced identical pages).
+
+    The audience half is the campaign BRIEF (#65). It was the positioning's
+    segment `name`s until a live run measured what those retrieve: the names a
+    positioning agent coins — "The Frankenstein-Stack Operator (5-20 sites)" —
+    are written for an operator to recognise and match nothing anyone has
+    published. A brief is an operator describing a market in the market's own
+    words, and it is the one audience half in this plugin measured to retrieve
+    on-topic pages."""
     gateway = _FakeGateway()
 
     await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )
@@ -296,9 +307,16 @@ async def test_the_run_leads_with_a_conversion_search_query() -> None:
     )
     query = payload["search_query"].lower()
     assert "convert" in query  # the channel question, not the audience question
-    assert "multi-location operators" in query  # this campaign's audience, not any audience
+    assert "coffee shop chains" in query  # this campaign's market, in the market's own words
     assert "google search ads" in query  # the channels actually on the table
     assert gateway.requested[0]["agent_name"] == CHANNEL_EVIDENCE_AGENT_NAME
+
+    # The guard, not a restatement: a coined persona name must never reach the
+    # query, because a search built from one has nothing real to match. Held
+    # against the positioning fixture's OWN segment name, so renaming that
+    # fixture cannot quietly make this pass.
+    coined = _POSITIONING_BODY["segments"][0]["name"].lower()
+    assert coined not in query, f"{coined!r} is a coined label, not something the web has published"
 
 
 # ── 4. Provenance, for a stage that retrieves (issue #113/#22 re-derived) ────
@@ -481,7 +499,7 @@ async def test_channel_plan_retrieval_breadth_is_measured_like_researchs(
     gateway = _FakeGateway()
     causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )
@@ -518,7 +536,7 @@ async def test_channel_plan_breadth_is_logged_when_the_run_failed(
     gateway = _FakeGateway()
     causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )
@@ -542,7 +560,7 @@ async def test_channel_plan_breadth_says_unmeasured_rather_than_a_false_zero(
     gateway = _FakeGateway()
     causation_id, run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -8,6 +8,7 @@ that directly.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -757,15 +758,25 @@ def _plan_call(channels: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 @pytest.mark.asyncio
-async def test_start_channel_evidence_requests_one_grounded_run_carrying_the_positioning_body() -> (
+async def test_start_channel_evidence_requests_one_grounded_run_carrying_only_the_question() -> (
     None
 ):
+    """The grounding run is given the question, not the answer-so-far (#65).
+
+    This test used to assert the opposite — that the grounding run's payload
+    was exactly the planning run's, "so the two runs cannot be shown different
+    things". That symmetry read well and was wrong: everything in an
+    ``:online`` run's payload is also its search, so handing it the positioning
+    made the campaign's own message pillars the query. Measured on tabsii dev,
+    2026-08-15: five pages retrieved, every one tracking a pillar, none about
+    conversion.
+    """
     gateway = _FakeGateway()
-    positioning_body = {"segments": [], "pillars": [], "ctas": []}
+    brief = {"brief": "Independent UK coffee shop chains running 3-10 sites."}
     taxonomy = [{"channel_key": "instagram_organic", "label": "Instagram", "motion": "organic"}]
 
     causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
+        gateway, brief=brief, taxonomy=taxonomy, campaign_motion="both"
     )
 
     assert len(gateway.requested) == 1
@@ -775,29 +786,64 @@ async def test_start_channel_evidence_requests_one_grounded_run_carrying_the_pos
     assert requested.agent_name == CHANNEL_EVIDENCE_AGENT_NAME
     assert requested.causation_id == causation_id
     assert requested.input_payload == {
-        # #65: an `:online` run's provider searches from the payload before the
-        # model is invoked — so the searched query leads, exactly as research's
-        # does (#101). Its CONTENT is asserted in
-        # `test_marketing_channel_plan_grounding.py`; what matters here is that
-        # the payload's other keys are unchanged and this one is present.
+        # The searched query leads, exactly as research's does (#101). Its
+        # CONTENT is asserted in `test_marketing_channel_plan_grounding.py`.
         "search_query": pipeline.channel_plan_search_query(
-            positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
+            brief=brief, taxonomy=taxonomy, campaign_motion="both"
         ),
-        # Exactly what the planning run will be started with, so the two runs
-        # cannot be shown different things.
-        **pipeline.channel_plan_input(
-            positioning_body=positioning_body, taxonomy=taxonomy, campaign_motion="both"
-        ),
+        **pipeline.channel_evidence_input(brief=brief, taxonomy=taxonomy, campaign_motion="both"),
     }
     assert next(iter(requested.input_payload)) == "search_query"
     assert run_id  # a real id was returned
 
 
 @pytest.mark.asyncio
+async def test_the_grounding_run_is_never_shown_the_positioning() -> None:
+    """The guard on the above, stated as its own claim so it cannot be lost in
+    a payload-equality assertion someone later relaxes.
+
+    Every key of an ``:online`` payload is a search term. The positioning's
+    pillars and CTAs are this campaign's argument, and searching them retrieves
+    pages that agree with the argument rather than pages about where anyone
+    converts — which is the whole of #65.
+    """
+    gateway = _FakeGateway()
+    positioning = {
+        "segments": [{"name": "The Frankenstein-Stack Operator", "description": "d"}],
+        "pillars": [{"pillar": "One source of truth, not two systems"}],
+        "ctas": [{"text": "Book a stack review"}],
+    }
+
+    await pipeline.start_channel_evidence(
+        gateway,
+        brief={"brief": "UK multi-unit franchise owners running 5-20 sites."},
+        taxonomy=[{"channel_key": "linkedin_paid", "label": "LinkedIn ads", "motion": "paid"}],
+        campaign_motion="paid",
+    )
+
+    serialised = json.dumps(gateway.requested[0].input_payload)
+    assert "positioning" not in gateway.requested[0].input_payload
+    # Asserted on the SERIALISED payload, not on its keys: what the provider
+    # searches is the text, so a pillar nested three levels down under some
+    # other key would steer retrieval exactly as one at the top level does.
+    #
+    # The terms are read off the positioning above rather than retyped, so a
+    # future edit to that fixture cannot leave this checking for wording the
+    # test no longer supplies.
+    coined = [
+        positioning["segments"][0]["name"],
+        positioning["pillars"][0]["pillar"],
+        positioning["ctas"][0]["text"],
+    ]
+    for term in coined:
+        assert term not in serialised, f"{term!r} reached the run whose payload is its query"
+
+
+@pytest.mark.asyncio
 async def test_advance_channel_plan_returns_nothing_while_the_grounding_run_is_running() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
 
     advance = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
@@ -811,7 +857,7 @@ async def test_advance_channel_plan_returns_nothing_while_the_grounding_run_is_r
 async def test_advance_channel_plan_starts_the_planning_run_on_the_same_chain() -> None:
     gateway = _FakeGateway()
     causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, messages=_evidence_call("https://example.com/y"))
 
@@ -838,7 +884,7 @@ async def test_advance_channel_plan_starts_the_planning_run_on_the_same_chain() 
 async def test_advance_channel_plan_returns_the_plan_once_the_planning_run_succeeds() -> None:
     gateway = _FakeGateway()
     causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(
         run_id,
@@ -879,7 +925,7 @@ async def test_advance_channel_plan_returns_the_plan_once_the_planning_run_succe
 async def test_advance_channel_plan_raises_when_the_grounding_run_failed() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, status="failed")
 
@@ -891,7 +937,7 @@ async def test_advance_channel_plan_raises_when_the_grounding_run_failed() -> No
 async def test_advance_channel_plan_raises_when_the_planning_run_failed() -> None:
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, messages=_evidence_call("https://example.com/y"))
     started = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})
@@ -915,7 +961,7 @@ async def test_advance_channel_plan_propagates_null_annotations_into_the_error()
     the run this leaves without them."""
     gateway = _FakeGateway()
     _causation_id, run_id = await pipeline.start_channel_evidence(
-        gateway, positioning_body={}, taxonomy=[], campaign_motion="both"
+        gateway, brief={}, taxonomy=[], campaign_motion="both"
     )
     gateway.complete(run_id, messages=_evidence_call(), annotations=None)
     started = await pipeline.advance_channel_plan(gateway, evidence_run_id=run_id, taxonomy={})

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -656,12 +656,18 @@ def test_start_channel_plan_runs_once_positioning_is_approved(ctx) -> None:
         r for r in gateway.requested if r["agent_name"] == "marketing-channel-evidence"
     ]
     assert len(channel_plan_requests) == 1
-    assert channel_plan_requests[0]["input_payload"]["positioning"]["segments"][0]["name"] == (
-        "Segment"
-    )
+    payload = channel_plan_requests[0]["input_payload"]
+    # The route reads the campaign's brief and hands it to the grounding run
+    # (#65) — its retrieval is derived from this payload, so the audience has
+    # to be described here in the market's own words.
+    assert payload["brief"]["brief"] == "Reach multi-location operators."
+    # And the positioning does NOT travel with it: every key here is a search
+    # term, and this campaign's own message pillars are not what the run is
+    # meant to go and look for.
+    assert "positioning" not in payload
     # The taxonomy fetched from `GET /channels` (#76 increment 2) rides along
     # as the agent's own input, not something it has to be told separately.
-    taxonomy = channel_plan_requests[0]["input_payload"]["channel_taxonomy"]
+    taxonomy = payload["channel_taxonomy"]
     assert {c["channel_key"] for c in taxonomy} == {"instagram_organic", "google_search_paid"}
 
 

--- a/tests/test_marketing_two_step_channel_plan.py
+++ b/tests/test_marketing_two_step_channel_plan.py
@@ -88,6 +88,11 @@ _TAXONOMY_ROWS = [
     }
 ]
 
+#: The campaign brief the grounding run is given, and derives its search from
+#: (#65). Shaped `{"brief": ...}` exactly as `start_research`'s payload is, so
+#: `definitions._brief_topic` reads both the same way.
+_BRIEF = {"brief": "Independent UK coffee shop chains running 3-10 sites."}
+
 _POSITIONING_BODY = {
     "segments": [
         {
@@ -194,7 +199,7 @@ async def _start_and_ground(
     """Start the stage and complete its grounding run."""
     causation_id, evidence_run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )
@@ -488,7 +493,7 @@ async def test_a_grounding_run_that_never_called_its_tool_is_a_malformed_run() -
     gateway = _FakeGateway()
     causation_id, evidence_run_id = await pipeline.start_channel_evidence(
         gateway,
-        positioning_body=_POSITIONING_BODY,
+        brief=_BRIEF,
         taxonomy=_TAXONOMY_ROWS,
         campaign_motion="paid",
     )


### PR DESCRIPTION
Closes #65.

## What the live run actually measured

#163 split this stage into a grounding run and a planning run, and put `search_query` first in the grounding run's payload on the understanding that leading the payload decides what gets retrieved. A run on tabsii dev (2026-08-15, `a18a4dc5`) says otherwise. The five pages it retrieved:

| url | title |
| --- | --- |
| `www.default.com/post/revops-frankenstack` | Frankenstack: How A Techstack Can Kill Your Pipeline |
| `www.shopify.com/enterprise/blog/frankenstack` | Frankenstack: What It Is and How To Fix It (2026) |
| `gtmstack.app/blog/building-unified-gtm-data-layer` | Building a Unified GTM Data Layer |
| `stackswap.ai/knowledge/modern-gtm-architecture` | Modern GTM Architecture |
| `www.kaelio.com/blog/single-source-of-truth-data-across-tools` | How to Build a Single Source of Truth… |

**"single source of truth" and "unified data layer" are that campaign's own message pillars.** They appear nowhere in the `search_query` — and going the other way, not one term from the query (`conversion rates`, `cost per acquisition`, `LinkedIn ads`, `trade press`) appears in anything that came back.

The query contributed nothing. The positioning body — a thousand times its size, in the same payload — contributed everything. The evidence agent then correctly returned `{"evidence": []}`, because not one retrieved page was about where anybody converts.

## The fix

**The constraint is on the whole payload, not its first key.** The grounding run now receives `channel_evidence_input`: the searched query, the campaign brief, the channel taxonomy and the motion. The positioning reaches the **planning** run only, through the unchanged `channel_plan_input` — that run is `opus-5` with no `:online`, so its payload steers no retrieval at all.

**The query's audience half is now the brief, not the positioning's segment names.** Same failure one layer down: a name a positioning agent coins is written for an operator to recognise, and "The Frankenstein-Stack Operator (5–20 sites)" is not a phrase anyone outside this campaign has published. A brief is an operator describing a market in the market's own words — and it is the one audience half in this plugin *measured* to retrieve on-topic pages, since `research_search_query` is built from the same helper and its runs come back with franchise-specific material.

Sharing the brief with research does not re-fetch research's pages: #101 established that two runs over one topic diverge completely when their framings differ, and `CHANNEL_PLAN_SEARCH_FRAMING` asks where the audience converts rather than who it is.

What the same campaign would now search on:

```
both marketing channels — We are marketing Tabsii to UK multi-unit franchise
owners running 5-20 sites who want to scale. They are hands-on operators, not
corporate executives. Tabsii is an AI-first franchise operating system covering
CRM, supply chain, POS and — Trade press — earned coverage, Online communities
(forums, groups), LinkedIn ads, … — where this audience actually converts —
reported conversion rates, cost per acquisition, lead cost …
```

## Guards, and proof they bite

- **The grounding run is never shown the positioning** — asserted on the *serialised* payload, so a pillar nested under some other key counts too, with the terms read off the fixture rather than retyped.
- **No coined segment name reaches the query** — held against the positioning fixture's own `name`, so renaming the fixture cannot quietly make it pass.

Both were verified by reinstating the defect (handing the grounding run a positioning again) and watching them fail, then restoring the fix. 819 python tests pass.

## Not verified

**This is not yet confirmed on a live run.** The previous attempt's planning step died on `OpenRouter returned 402` before producing a plan, and the credit has not been topped up. What is measured here is the payload and the query; what the new query actually retrieves is the thing to check once a run can complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)