### PR TITLE
fix(web-admin): address Core by its own origin, not this page's

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -132,12 +132,34 @@ async def fan_in_workflow() -> dict[str, Any]:
     argument as ``/config`` above, with more at stake: a hand-copied
     ``action_config`` in the UI would be a *fourth* copy of the thing whose
     copies going stale is the entire subject of #160.
+
+    ## ``core_api_url``, and why the browser cannot work it out (#171)
+
+    **Core's admin API is not same-origin with this surface.** The admin SPA is
+    served from ``dev.<domain>/api/v1/plugins/marketing/admin``, and the
+    instance's CloudFront routes only the plugin paths to the API — everything
+    else falls through to the public site. So a browser asking for
+    ``/api/v1/orchestration/workflows`` on the page's own origin gets the
+    marketing homepage under a **403**, with or without a token, which is
+    exactly how #171 presented: an auth failure that was not an auth failure.
+
+    Core's real origin is its API Gateway endpoint, which the portal reaches
+    through ``NEXT_PUBLIC_API_URL``. This Lambda already holds the same value
+    in ``BIFFO_CORE_API_URL`` (Terraform passes ``module.api_gateway.
+    api_endpoint``), so serving it here lets the panel address Core without
+    any instance-specific constant being compiled into this repo — the same
+    reason ``api.ts`` resolves its own base relatively rather than hard-coding
+    an origin.
+
+    Empty when the variable is unset. The panel must then say so rather than
+    falling back to a same-origin path, because that fallback is the bug.
     """
     declared = fan_in_definition()
     return {
         "name": WORKFLOW_NAME,
         "definition": declared,
         "fingerprint": config_fingerprint(declared["action_config"]),
+        "core_api_url": CORE_API_URL.rstrip("/"),
     }
 
 

--- a/tests/test_marketing_fan_in_workflow_route.py
+++ b/tests/test_marketing_fan_in_workflow_route.py
@@ -9,6 +9,8 @@ Restating them here would create the second copy the route exists to prevent.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 
 from marketing import admin_app as admin_app_module
@@ -68,3 +70,45 @@ def test_it_is_admin_gated_like_every_other_route_on_this_app() -> None:
     response = TestClient(admin_app_module.build_app()).get("/fan-in-workflow")
 
     assert response.status_code in (401, 403)
+
+
+def test_it_tells_the_browser_where_cores_api_actually_lives() -> None:
+    """The route carries `core_api_url`, and #171 is what happens without it.
+
+    The admin SPA is served from the instance's own domain, whose CloudFront
+    routes only `/api/v1/plugins/*` to the API. A browser asking for
+    `/api/v1/orchestration/workflows` on that origin therefore reaches the
+    public marketing site and gets a **403 with an HTML body** — the same 403
+    with a valid admin token, with an access token, and with no `Authorization`
+    header at all, which is exactly why it read as a permissions failure.
+
+    Core's real origin is its API Gateway endpoint, which this Lambda already
+    holds as `BIFFO_CORE_API_URL` (Terraform passes `module.api_gateway.
+    api_endpoint`). Serving it keeps the instance-specific value out of this
+    repo, which is the same rule `web-admin`'s own base resolution follows.
+    """
+    app = admin_app_module.build_app()
+    app.dependency_overrides[admin_app_module.require_admin] = lambda: None
+
+    with patch.object(admin_app_module, "CORE_API_URL", "https://core.example.invalid/"):
+        body = TestClient(app).get("/fan-in-workflow").json()
+
+    # Trailing slash stripped: the browser appends `/api/v1/orchestration`, and
+    # a doubled separator is a 404 nobody would think to look for.
+    assert body["core_api_url"] == "https://core.example.invalid"
+
+
+def test_an_unset_core_api_url_is_reported_as_empty_rather_than_guessed() -> None:
+    """Empty is an answer the panel can act on — it says it cannot check.
+
+    The alternative is this route inventing a plausible origin, which would put
+    the guess a layer deeper than #171 had it and make the same 403 harder to
+    trace, not easier.
+    """
+    app = admin_app_module.build_app()
+    app.dependency_overrides[admin_app_module.require_admin] = lambda: None
+
+    with patch.object(admin_app_module, "CORE_API_URL", ""):
+        body = TestClient(app).get("/fan-in-workflow").json()
+
+    assert body["core_api_url"] == ""

--- a/web-admin/src/components/FanInWorkflow.test.tsx
+++ b/web-admin/src/components/FanInWorkflow.test.tsx
@@ -11,10 +11,16 @@ afterEach(() => {
 
 const NAME = 'Marketing — synthesise research once both angles complete'
 
-function declaration(config: Record<string, unknown> = { model: 'anthropic/claude-opus-5' }) {
+const CORE_ORIGIN = 'https://api.example.invalid'
+
+function declaration(
+  config: Record<string, unknown> = { model: 'anthropic/claude-opus-5' },
+  coreApiUrl: string = CORE_ORIGIN,
+) {
   return {
     name: NAME,
     fingerprint: 'sha256:31883429cd45ebe4',
+    core_api_url: coreApiUrl,
     definition: {
       name: NAME,
       trigger_source: 'biffo.core',
@@ -69,7 +75,13 @@ describe('FanInWorkflow', () => {
     render(<FanInWorkflow />)
     await userEvent.click(await screen.findByRole('button', { name: /Re-seed it now/ }))
 
-    await waitFor(() => expect(seed).toHaveBeenCalledWith(expect.objectContaining({ name: NAME }), 'w1'))
+    await waitFor(() =>
+      expect(seed).toHaveBeenCalledWith(
+        expect.objectContaining({ name: NAME }),
+        'w1',
+        `${CORE_ORIGIN}/api/v1/orchestration`,
+      ),
+    )
   })
 
   it('offers to seed, with no id, when Core holds no workflow of this name', async () => {
@@ -80,7 +92,44 @@ describe('FanInWorkflow', () => {
 
     expect(await screen.findByText(/Not seeded/)).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: /Seed it now/ }))
-    await waitFor(() => expect(seed).toHaveBeenCalledWith(expect.anything(), null))
+    await waitFor(() =>
+      expect(seed).toHaveBeenCalledWith(
+        expect.anything(),
+        null,
+        `${CORE_ORIGIN}/api/v1/orchestration`,
+      ),
+    )
+  })
+
+
+  it('addresses Core by its own origin, never this page\'s (#171)', async () => {
+    // The whole of #171. Asked for on THIS origin, the request reaches the
+    // instance's public site — CloudFront routes only `/api/v1/plugins/*` to
+    // the API — and comes back 403 with an HTML body, identically with a valid
+    // admin token and with no token at all. So what is asserted here is the
+    // absolute base, not merely that a call was made.
+    stub(declaration(), [{ id: 'w1', name: NAME, action_config: { model: 'anthropic/claude-opus-5' } }])
+
+    render(<FanInWorkflow />)
+
+    await waitFor(() =>
+      expect(api.listCoreWorkflows).toHaveBeenCalledWith(`${CORE_ORIGIN}/api/v1/orchestration`),
+    )
+    const [base] = vi.mocked(api.listCoreWorkflows).mock.calls[0]
+    expect(base.startsWith('http')).toBe(true)
+  })
+
+  it('says so, and calls nothing, when the deployment supplies no Core origin', async () => {
+    // Falling back to a same-origin path is what produced a 403 that looked
+    // like a permissions problem for a morning. Not knowing is a reportable
+    // state, not a reason to guess.
+    stub(declaration({ model: 'm' }, ''), [])
+
+    render(<FanInWorkflow />)
+
+    expect(await screen.findByText(/BIFFO_CORE_API_URL is unset/)).toBeInTheDocument()
+    expect(api.listCoreWorkflows).not.toHaveBeenCalled()
+    expect(screen.queryByText(/In step/)).not.toBeInTheDocument()
   })
 
   it('reports a failed read as a failure, never as "in step"', async () => {

--- a/web-admin/src/components/FanInWorkflow.tsx
+++ b/web-admin/src/components/FanInWorkflow.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import {
+  coreOrchestrationBase,
   getDeclaredFanInWorkflow,
   listCoreWorkflows,
   seedFanInWorkflow,
@@ -40,6 +41,19 @@ import { configDrift, shortenValue, type ConfigDrift } from '../lib/workflowDrif
  * here, is the only credential in the system that both halves accept. The
  * plugin serves the declaration; the browser reads what is deployed, diffs,
  * and writes.
+ *
+ * ## And why it addresses Core by origin, not by path (#171)
+ *
+ * The first version of this panel asked for `/api/v1/orchestration/workflows`
+ * on its own origin, which is where an admin API on the same domain would be.
+ * It is not there. The instance's CloudFront routes only `/api/v1/plugins/*`
+ * to the API, so that request reached the public marketing site and came back
+ * **403 with an HTML body** — the same 403 with a valid admin token, with an
+ * access token, and with no `Authorization` header at all, which is precisely
+ * why it read as a permissions failure rather than a routing one.
+ *
+ * So the origin comes from the plugin, which holds it as `BIFFO_CORE_API_URL`,
+ * and when it cannot supply one this panel says so instead of guessing.
  */
 export function FanInWorkflow() {
   const [declared, setDeclared] = useState<DeclaredWorkflow | null>(null)
@@ -57,11 +71,19 @@ export function FanInWorkflow() {
     setError(null)
     setLoaded(false)
     try {
-      const [declaration, workflows] = await Promise.all([
-        getDeclaredFanInWorkflow(),
-        listCoreWorkflows(),
-      ])
+      // Sequential, not `Promise.all`: the declaration carries the origin the
+      // second call needs, so there is nothing to parallelise.
+      const declaration = await getDeclaredFanInWorkflow()
       setDeclared(declaration)
+      const base = coreOrchestrationBase(declaration)
+      if (base == null) {
+        setError(
+          'this deployment did not tell the plugin where Core’s API lives ' +
+            '(BIFFO_CORE_API_URL is unset), so the deployed workflow cannot be read',
+        )
+        return
+      }
+      const workflows = await listCoreWorkflows(base)
       setDeployed(workflows.find((w) => w.name === declaration.name) ?? null)
       setLoaded(true)
     } catch (e: unknown) {
@@ -75,10 +97,12 @@ export function FanInWorkflow() {
 
   async function reseed() {
     if (declared == null) return
+    const base = coreOrchestrationBase(declared)
+    if (base == null) return
     setSeeding(true)
     setError(null)
     try {
-      await seedFanInWorkflow(declared, deployed?.id ?? null)
+      await seedFanInWorkflow(declared, deployed?.id ?? null, base)
       setSeeded(true)
       // Re-read rather than assume. What matters is what Core now holds, and
       // a panel that congratulated itself on a write it never verified would

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -880,10 +880,32 @@ export async function getResults(): Promise<ResultsResponse> {
 // the operator's own session is the only credential in the system that can
 // both read and replace a workflow definition.
 
-/** Core's workflow-definition CRUD. NOT under `/admin` — that variant 404s,
- * indistinguishable from a route that does not exist, which is how the seed
- * script silently never seeded anything until 2026-08-11. */
-const CORE_ORCHESTRATION_BASE = '/api/v1/orchestration'
+/** Core's workflow-definition CRUD, appended to the CORE ORIGIN the plugin
+ * serves us — never to this page's own origin (#171).
+ *
+ * Two things are load-bearing in that sentence:
+ *
+ * **Not `/admin`.** That variant 404s, indistinguishable from a route that does
+ * not exist, which is how the seed script silently never seeded anything until
+ * 2026-08-11.
+ *
+ * **Not same-origin.** This SPA is served from the instance's own domain, whose
+ * CloudFront routes only `/api/v1/plugins/*` to the API; everything else falls
+ * through to the public site. A same-origin `/api/v1/orchestration/workflows`
+ * therefore returned the marketing homepage under a 403 — identically with a
+ * valid admin token, an access token, or no `Authorization` header at all,
+ * which is what made it look like a permissions problem for a whole morning.
+ * Core's real origin is its API Gateway endpoint; `getDeclaredFanInWorkflow`
+ * carries it as `core_api_url`. */
+const CORE_ORCHESTRATION_PATH = '/api/v1/orchestration'
+
+/** Where Core's orchestration API lives for this deployment, or `null` when the
+ * plugin could not tell us — in which case the caller must report that rather
+ * than guess an origin. Guessing is the bug. */
+export function coreOrchestrationBase(declared: DeclaredWorkflow): string | null {
+  const origin = declared.core_api_url?.replace(/\/+$/, '')
+  return origin ? `${origin}${CORE_ORCHESTRATION_PATH}` : null
+}
 
 /** The fan-in workflow definition this build declares. */
 export interface DeclaredWorkflow {
@@ -897,6 +919,9 @@ export interface DeclaredWorkflow {
     enabled: boolean
   }
   fingerprint: string
+  /** Core's public API origin, from the plugin Lambda's `BIFFO_CORE_API_URL`.
+   * Empty string when unset — never assume same-origin. */
+  core_api_url: string
 }
 
 /** One workflow definition as Core holds it. Only the fields this panel reads
@@ -917,12 +942,12 @@ export async function getDeclaredFanInWorkflow(): Promise<DeclaredWorkflow> {
   )
 }
 
-export async function listCoreWorkflows(): Promise<DeployedWorkflow[]> {
+export async function listCoreWorkflows(base: string): Promise<DeployedWorkflow[]> {
   const body = await request<unknown>(
     'GET',
     '/workflows',
     undefined,
-    CORE_ORCHESTRATION_BASE,
+    base,
     'list the deployed workflows',
   )
   return Array.isArray(body) ? (body as DeployedWorkflow[]) : []
@@ -938,13 +963,14 @@ export async function listCoreWorkflows(): Promise<DeployedWorkflow[]> {
 export async function seedFanInWorkflow(
   declared: DeclaredWorkflow,
   existingId: string | null,
+  base: string,
 ): Promise<void> {
   if (existingId) {
     await request<unknown>(
       'PUT',
       `/workflows/${existingId}`,
       declared.definition,
-      CORE_ORCHESTRATION_BASE,
+      base,
       're-seed the fan-in workflow',
     )
     return
@@ -953,7 +979,7 @@ export async function seedFanInWorkflow(
     'POST',
     '/workflows',
     declared.definition,
-    CORE_ORCHESTRATION_BASE,
+    base,
     'seed the fan-in workflow',
   )
 }


### PR DESCRIPTION
Closes #171.

## The panel #167 added never worked on a real deployment

It asked for `/api/v1/orchestration/workflows` on **its own origin** — which is where an admin API on the same domain would be. It is not there. The instance's CloudFront routes only `/api/v1/plugins/*` to the API; everything else falls through to the public site, so the request reached the marketing homepage and came back **403 with an HTML body**.

## Why it looked like permissions for a whole morning

Probed from the page itself:

| credential | status | body |
| --- | --- | --- |
| admin ID token | 403 | `<!DOCTYPE html>…` the public site |
| access token | 403 | same |
| **no `Authorization` header** | 403 | same |

Identical with and without a token — so it was never authentication. Two more facts that rule it out from the other end:

- The operator's token carries `cognito:groups: ["platform_admin", "admin"]`.
- Core's `list_workflows` **does not 403 a non-admin** — it filters the list by scope (`services/api/src/api/routers/orchestration.py`). Nothing in the router could have produced this.

And the portal, in the same browser and session, lists those very definitions — because it calls `https://<api-id>.execute-api.<region>.amazonaws.com/api/v1/orchestration/workflows` through `NEXT_PUBLIC_API_URL`, a different origin entirely.

## The fix

This plugin's Lambda already holds that origin as `BIFFO_CORE_API_URL` (Terraform passes `module.api_gateway.api_endpoint` — the same value the portal uses). So:

- `GET /admin/fan-in-workflow` serves it as `core_api_url`, trailing slash stripped.
- `coreOrchestrationBase()` builds the base from it; `listCoreWorkflows`/`seedFanInWorkflow` take that base rather than a module constant.
- **When the plugin cannot supply an origin, the panel says so and calls nothing.** Guessing same-origin is the bug; a fallback would bury the next instance of it a layer deeper.

No instance-specific origin is compiled into this repo — the rule `api.ts` already followed for its own base, now extended to the one API that is not same-origin.

## Guards, and proof they bite

Reinstating the same-origin base fails **four** tests: the two new ones (the base handed to Core is absolute; an unset origin is reported rather than guessed) plus the two seed assertions that now pin the base they write to. Verified by making that edit, watching them fail, and restoring.

821 python and 238 front-end tests pass.

## Still to verify

This needs vendoring into `tabsii-platform` and deploying before the panel can be confirmed working on dev — the same route the #65 fix took. **#160 stays open until then**, since its remedy is this panel functioning rather than merely shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)