### PR TITLE
fix(agents): read the runtime ceiling that is deployed, and spend it

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -1410,10 +1410,14 @@ POSITIONING_MAX_TURNS = 3
 # success"), because channel choice is what every downstream artefact is
 # generated per. What it does NOT buy is more wall clock: every agent is
 # already at `AGENT_TIMEOUT_SECONDS` = the runtime ceiling, so these turns
-# have to fit in the same 240s research's do, and raising that is an instance
-# change (see `RUNTIME_TIMEOUT_CEILING_SECONDS`), not a plugin one. The two
-# runs get 240s EACH — the ceiling is per run, and this stage is advanced by
-# polling rather than held open across both.
+# have to fit in the same budget research's do, and raising it past the
+# ceiling is an instance change (see `RUNTIME_TIMEOUT_CEILING_SECONDS`), not a
+# plugin one. The two runs get that budget EACH — the ceiling is per run, and
+# this stage is advanced by polling rather than held open across both.
+#
+# The number is deliberately not repeated here. It was written out as "240s"
+# and stayed that way through the deployment moving to 300 (#132 instance 5);
+# a second copy of a constant is a second thing to forget.
 CHANNEL_EVIDENCE_MAX_TURNS = RESEARCH_MAX_TURNS
 # Channel planning no longer retrieves: it reasons over the evidence it is
 # handed, exactly as positioning and copy reason over the artefact they are
@@ -1439,26 +1443,36 @@ RUNTIME_DEFAULT_TIMEOUT_SECONDS = 120.0
 #:
 #:     $ aws lambda get-function-configuration \
 #:         --function-name tabsii-platform-dev-plugin-agent-runtime
-#:     "AGENT_RUNTIME_MAX_SECONDS": "240"
+#:     "AGENT_RUNTIME_MAX_SECONDS": "300"     # Timeout: 360
 #:
 #: It reaches the Lambda through template-owned Terraform, not through
 #: `agent_runtime`'s Python source: `services/_plugins/agent-runtime/
 #: terraform/main.tf:108` sets
 #: ``AGENT_RUNTIME_MAX_SECONDS = tostring(var.run_timeout_seconds)`` — a
-#: Terraform **variable** that happens to default to 240, the same number
-#: `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING` uses in code for when the env
-#: var is entirely absent.
+#: Terraform **variable**, whose *code* default is 240 (the same number
+#: `agent_runtime.loop.DEFAULT_TIMEOUT_CEILING` uses when the env var is
+#: absent) but whose deployed value is not that default.
 #:
-#: The distinction is not academic: **`run_timeout_seconds` is per-deployment
-#: configuration.** An instance can lower it with a Terraform change alone —
-#: no edit to `agent_runtime`'s Python anywhere — and `RunLimits.from_snapshot`
-#: would clamp every agent's real wall clock to the new value **silently**.
-#: This constant would then claim a 240s budget no run actually gets, and
-#: every test in this file would stay green throughout, because none of them
-#: can see the deployed Terraform variable from inside this repo. That is the
-#: live version of the risk this constant's docstring used to describe as
-#: hypothetical — it is not hypothetical, it is one `terraform apply` away.
-RUNTIME_TIMEOUT_CEILING_SECONDS = 240.0
+#: **This constant read 240.0 for two days after the deployment moved to 300,
+#: and every test in this repo stayed green.** That is instance 5 of this
+#: issue's own class, and the direction is what makes it interesting: the
+#: drift was *safe* — nothing was clamped — so it produced no failed run to
+#: find it by. What it produced instead was `AGENT_TIMEOUT_SECONDS` pinned at
+#: 240 by the argument below, with 60 seconds of real headroom unspent, on the
+#: two stages the estate had already measured as marginal. A false negative,
+#: not a failure. It was found by reading the deployed Lambda while verifying
+#: #164, which is the only way it could have been found from here.
+#:
+#: The risk in the other direction is unchanged and still real: an instance
+#: can *lower* `run_timeout_seconds` with a Terraform change alone, and every
+#: test here would stay green while every agent's real budget shrank. What has
+#: changed is that the reduction is no longer silent — `RunLimits.from_snapshot`
+#: now records a `LimitClamp` naming the requested value, the granted value,
+#: the ceiling and the env var that raises it (biffo-template#1586, verified
+#: present in the deployed artefact 2026-08-16). So a clamp is now findable in
+#: a log rather than only in a dead campaign; a *widening*, as here, still is
+#: not, because nothing reports a ceiling it did not have to enforce.
+RUNTIME_TIMEOUT_CEILING_SECONDS = 300.0
 
 #: The wall clock every agent in this plugin may spend, in seconds
 #: (issues #126, #130).
@@ -1477,22 +1491,39 @@ RUNTIME_TIMEOUT_CEILING_SECONDS = 240.0
 #: research keeps pushing the failure to whichever stage is next; positioning,
 #: channel plan and copy all consume the research artefact and grow with it.
 #:
-#: **240s is the runtime ceiling, not a guess** — this deliberately equals
+#: **300s is the runtime ceiling, not a guess** — this deliberately equals
 #: `RUNTIME_TIMEOUT_CEILING_SECONDS` above rather than leaving headroom below
-#: it: every stage already needs the full 240s (that is what #130 measured),
+#: it: every stage already needs its full budget (that is what #130 measured),
 #: so trading budget away to guard against a ceiling cut would reintroduce the
-#: exact failure #126/#130 exist to fix. `from_snapshot` clamps silently to
-#: whatever `AGENT_RUNTIME_MAX_SECONDS` actually is, so asking for more would
-#: be silently reduced and this constant would claim a budget no run ever
-#: gets. Raising it further is an instance change (raising
-#: `run_timeout_seconds` in Terraform, and the Lambda timeout with it) — not a
-#: plugin one, and likewise **lowering** the ceiling is an instance change
-#: this file cannot see: see `RUNTIME_TIMEOUT_CEILING_SECONDS`'s docstring for
-#: why that is a real, live risk rather than a hypothetical one.
+#: exact failure #126/#130 exist to fix. Raising it *past* the ceiling is an
+#: instance change (`run_timeout_seconds` in Terraform, and the Lambda timeout
+#: above it) — not a plugin one.
+#:
+#: **Why this moved 240 -> 300, which is the whole of #132 instance 5.** The
+#: instance change already happened: `run_timeout_seconds` is deployed at 300
+#: with a 360s Lambda timeout. This file did not know, because the ceiling it
+#: reads is a hand-copied belief, so it went on asking for 240 while arguing —
+#: in this very comment — that 240 *was* the ceiling and that raising it was
+#: somebody else's job. The estate had meanwhile recorded the budget as
+#: marginal twice: `agent_runtime` logged "Agent run finished close to its
+#: wall-clock limit" on 2026-08-13 04:53 for research at 8 turns with
+#: `:online`, and #155 gave channel-evidence that same shape. Those 60 seconds
+#: are what this change spends, on evidence rather than on precaution.
+#:
+#: **This is not free of consequence.** `timeout_seconds` is part of the
+#: `action_config` seeded for the research-synthesis fan-in, so moving it
+#: changes `fan_in_workflow.SEEDED_CONFIG_FINGERPRINT` and the deployed
+#: workflow is stale until `seed_fan_in_workflow.py --replace` is run against
+#: each environment. Leaving synthesis at 240 while every other stage moved to
+#: 300 would be #160 re-created deliberately, so the re-seed is part of
+#: shipping this, not a follow-up.
 #:
 #: **Cost is deliberately not the deciding factor.** A campaign built on failed
-#: or half-completed research costs far more than the tokens.
-AGENT_TIMEOUT_SECONDS = 240.0
+#: or half-completed research costs far more than the tokens. Wall clock is
+#: also not billed: `max_turns` bounds what a run can spend, and that is
+#: unchanged here — this buys a marginal run the time to *finish*, not licence
+#: to do more work.
+AGENT_TIMEOUT_SECONDS = 300.0
 
 
 def research_definition(*, model: str, instructions: str) -> dict[str, Any]:

--- a/src/marketing/fan_in_workflow.py
+++ b/src/marketing/fan_in_workflow.py
@@ -116,7 +116,7 @@ def config_fingerprint(config: dict[str, Any]) -> str:
 #: anything. Nothing inside this repo can know that — only ``--check`` against
 #: a live Core, or ``marketing.pipeline.synthesis_config_drift`` reading a real
 #: run's ``definition_snapshot``, can.
-SEEDED_CONFIG_FINGERPRINT = "sha256:31883429cd45ebe4"
+SEEDED_CONFIG_FINGERPRINT = "sha256:2861297e15c999fc"
 
 
 def config_drift(

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -292,7 +292,7 @@ def measure_copy_length(channels: Sequence[ChannelCopy]) -> None:
        shortened.
     2. **The run is expensive and the failure is cheap to survive.** One long
        headline failing ``model_validate`` discards every other channel's copy
-       with it, from an agent already running close to its 240s ceiling
+       with it, from an agent already running close to its wall-clock ceiling
        (#131), to fix something an operator can read and judge in seconds.
 
     So the budget is enforced where a length problem is actually decidable:

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -20,6 +20,10 @@ the disagreement was invisible until it cost a research angle in production.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
+from marketing import definitions
 from marketing.definitions import (
     AGENT_TIMEOUT_SECONDS,
     CHANNEL_EVIDENCE_MAX_TURNS,
@@ -194,3 +198,64 @@ def test_every_definition_still_declares_a_turn_budget() -> None:
     )
     for factory, turns in expected.items():
         assert _definition(factory)["max_turns"] == turns
+
+
+def test_the_ceilings_docstring_evidence_agrees_with_the_ceiling_it_documents() -> None:
+    """The guard for issue #132 **instance 5**, which the assertions above
+    could not catch and did not.
+
+    `RUNTIME_TIMEOUT_CEILING_SECONDS` is a hand-copied belief about another
+    repo's Terraform, and it justifies itself by quoting the deployed Lambda's
+    environment in its own docstring. Those are two copies of one fact sitting
+    four lines apart, and on 2026-08-16 they disagreed: the deployment had
+    moved to 300 while the constant — and every test here — still said 240.
+
+    **Why nothing failed.** The drift was in the safe direction, so no run was
+    ever clamped and no campaign ever died. What it cost instead was
+    `AGENT_TIMEOUT_SECONDS` staying pinned at 240 on the argument that 240 was
+    the ceiling, leaving 60s of real headroom unspent on two stages already
+    measured as marginal. A wrong number that produces no failure is found by
+    reading a deployed Lambda, or it is not found at all.
+
+    This cannot make either number agree with the deployment — that needs
+    biffo-template#1364, an upstream test that can read both sides. What it
+    CAN do is stop the constant and the evidence offered for it drifting apart
+    in silence, so the next person to move one is told to move the other.
+    """
+    source = Path(definitions.__file__).read_text(encoding="utf-8")
+    quoted = re.findall(r'"AGENT_RUNTIME_MAX_SECONDS":\s*"(\d+)"', source)
+
+    assert quoted, (
+        "RUNTIME_TIMEOUT_CEILING_SECONDS documents itself by quoting the "
+        "deployed Lambda's AGENT_RUNTIME_MAX_SECONDS. That quote is gone, so "
+        "the constant is now an unevidenced number — restore it, or this "
+        "guard has nothing to compare against (issue #132)."
+    )
+    for value in quoted:
+        assert float(value) == RUNTIME_TIMEOUT_CEILING_SECONDS, (
+            f'definitions.py quotes AGENT_RUNTIME_MAX_SECONDS as "{value}" '
+            f"while RUNTIME_TIMEOUT_CEILING_SECONDS is "
+            f"{RUNTIME_TIMEOUT_CEILING_SECONDS}. One of them was updated and "
+            "the other was not — re-read the deployed value with `aws lambda "
+            "get-function-configuration` and make both say it (issue #132 "
+            "instance 5)."
+        )
+
+
+def test_the_guard_above_can_actually_fail() -> None:
+    """A detector nobody has seen fail is a detector nobody knows works.
+
+    Feeds the real assertion a source string with the disagreement that
+    actually occurred — a docstring quoting 240 beside a 300 ceiling — and
+    proves it is caught, without depending on the live file holding either
+    value.
+    """
+    planted = '#:     "AGENT_RUNTIME_MAX_SECONDS": "240"'
+    quoted = re.findall(r'"AGENT_RUNTIME_MAX_SECONDS":\s*"(\d+)"', planted)
+
+    assert quoted == ["240"]
+    assert float(quoted[0]) != 300.0, (
+        "this self-test assumes the historical drift (240 quoted, 300 real); "
+        "if the ceiling ever legitimately returns to 240, rewrite it around a "
+        "different pair rather than deleting it"
+    )


### PR DESCRIPTION
## What

`RUNTIME_TIMEOUT_CEILING_SECONDS` read `240.0` and quoted the deployed Lambda's `AGENT_RUNTIME_MAX_SECONDS` as `"240"` in its own docstring to justify itself. **The deployed value is 300**, with a 360s Lambda timeout:

```
$ aws lambda get-function-configuration \
    --function-name tabsii-platform-dev-plugin-agent-runtime
"AGENT_RUNTIME_MAX_SECONDS": "300",   Timeout: 360
```

`variables.tf` in `tabsii-platform` agrees, and says why: *"Raised from 300 so run_timeout_seconds could go to 300 and keep a 60s margin"*.

Both constants move to 300.

## Why the drift survived, which is the interesting part

This is **#132 instance 5**, and it drifted in the *safe* direction — nothing was ever clamped, so no run failed and no campaign died. There was no failure to find it by.

What it cost instead: `AGENT_TIMEOUT_SECONDS` stayed pinned at 240 on the argument — written in that constant's own docstring — that 240 *was* the ceiling and that raising it was somebody else's job. That job had already been done. Sixty seconds of real headroom sat unspent on the two stages the estate had already measured as marginal:

- `agent_runtime` logged **"Agent run finished close to its wall-clock limit"** on 2026-08-13 04:53, for research at 8 turns with `:online` — *after* #131 raised everything to 240.
- #155 gave `channel-evidence` that same shape (`CHANNEL_EVIDENCE_MAX_TURNS = RESEARCH_MAX_TURNS`, `:online`).

**A wrong number that produces no failure is found by reading a deployed Lambda, or it is not found at all.** This one was found while verifying #164.

`max_turns` is unchanged and wall clock is not billed, so this buys a marginal run the time to *finish* — not licence to do more work.

## The guard

It cannot check either number against the deployment; that needs biffo-template#1364, upstream, where both halves are readable. So it guards what actually went wrong: **the constant and the evidence offered for it were two copies of one fact, four lines apart, free to drift apart in silence.** The test reads the quoted `AGENT_RUNTIME_MAX_SECONDS` out of `definitions.py` and asserts it equals the constant.

**Fail-first, proven rather than asserted:**

```
$ sed -i 's/= 300.0/= 240.0/' src/marketing/definitions.py   # revert just the ceiling
FAILED test_the_ceilings_docstring_evidence_agrees_with_the_ceiling_it_documents
  definitions.py quotes AGENT_RUNTIME_MAX_SECONDS as "300" while
  RUNTIME_TIMEOUT_CEILING_SECONDS is 240.0
FAILED test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime
```

It ships with a `test_the_guard_above_can_actually_fail` self-test carrying the historical disagreement, so the detector is demonstrated rather than assumed.

## What this obliges, and it is not optional

`timeout_seconds` is part of the research-synthesis fan-in's `action_config`, so `SEEDED_CONFIG_FINGERPRINT` moves with it — updated here to `sha256:2861297e15c999fc`. **The deployed workflow is stale until `seed_fan_in_workflow.py --replace` runs against each environment.** Leaving synthesis at 240 while every other stage moves to 300 would be #160 re-created deliberately, so the re-seed is part of shipping this rather than a follow-up.

Also retires two hand-written "240s" comments in `definitions.py` and `pipeline.py`. The channel-evidence one now deliberately does not restate the number at all — it wrote "240s" out by hand and stayed that way through the deployment moving, which is the same defect one level down.

## Verified

- 823 tests pass, ruff + ruff-format + pyright clean, web-admin lint/typecheck/test clean.
- The deployed ceiling read directly from the Lambda, not inferred from Terraform source.
- `LimitClamp` (biffo-template#1586) confirmed **present in the deployed artefact** by downloading `Code.Location` and grepping `agent_runtime/loop.py` — so a future *reduction* of the ceiling is now loud, even though a widening like this one still is not.

## Not verified

Nothing has run at 300s yet — no campaign has been driven since this change, and it is inert until vendored into `tabsii-platform` and deployed. The claim that these stages *need* the extra time rests on the 2026-08-13 WARNING, not on a run observed finishing between 240s and 300s.

Refs #132
