### PR TITLE
feat(copy): size each channel's copy to the platform it ships on

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -754,10 +754,18 @@ async def _advance_artefact(
         # plan's real entries this run was started against — same pattern,
         # see `pipeline.extract_copy`.
         channel_plan_channels = pending.get("channel_plan_channels") or {}
+        # `channel_budgets` is the per-channel ceiling THIS run was given in
+        # its payload (#173), stashed at start time for the same reason
+        # `channel_plan_channels` is. `None` — not `{}` — when the artefact
+        # predates #173, so `measure_copy_length` judges that copy by the
+        # single budget it was actually written under rather than by the
+        # tighter per-channel one it never saw.
+        channel_budgets = pending.get("channel_budgets")
         result = await pipeline.advance_copy(
             gateway,
             run_id=_require_run_id(),
             channel_plan_channels=channel_plan_channels,
+            channel_budgets=channel_budgets,
             allowed_source_urls=allowed_source_urls,
         )
     else:

--- a/src/marketing/copy_routes.py
+++ b/src/marketing/copy_routes.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from . import admin_app, pipeline
+from . import admin_app, definitions, pipeline
 
 router = APIRouter(dependencies=[Depends(admin_app.require_admin)])
 
@@ -157,10 +157,33 @@ async def start_copy_route(
         )
     )
 
+    # The per-field ceiling each channel's copy must actually fit (#173).
+    #
+    # `COPY_LENGTH_BUDGET` alone is one number for every channel, and the paid
+    # platforms are tighter than it on some fields — so copy could satisfy the
+    # budget in full and still be trimmed by the paid pack on export. Measured
+    # on dev: 3 of 6 paid fields truncated, every one inside budget.
+    #
+    # The taxonomy already carries the shape needed to resolve this: #76
+    # increment 2 added `marketing_channel.ad_platform` and the seed populates
+    # it for every paid channel. Nothing has to be inferred from the channel
+    # key here — which is the guess `paid_pack_routes._platform_for_channel`
+    # deleted, and the reason #173 was recorded as blocked.
+    #
+    # Read at start time and stashed below for the same reason
+    # `channel_plan_channels` is: it must be what THIS run was shown, so the
+    # length check at advance time measures the copy against the number the
+    # model was actually given, not against a taxonomy that has moved since.
+    channels_resp = await admin_app._core("GET", f"{_INTERNAL_PREFIX}/channels", admin.token)
+    channels_resp.raise_for_status()
+    ad_platforms = {row["key"]: row.get("ad_platform") for row in (channels_resp.json() or [])}
+    channel_budgets = definitions.channel_copy_budgets(channel_plan_channels, ad_platforms)
+
     causation_id, run_id = await pipeline.start_copy(
         gateway,
         positioning_body=positioning_body,
         channel_plan_body=channel_plan_body,
+        channel_budgets=channel_budgets,
     )
 
     created = await admin_app._core(
@@ -179,6 +202,7 @@ async def start_copy_route(
                 pipeline.with_element_ids(
                     {
                         "channel_plan_channels": channel_plan_channels,
+                        "channel_budgets": channel_budgets,
                         "allowed_source_urls": allowed_source_urls,
                     }
                 )

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -489,6 +489,118 @@ CopyField = Literal["headline", "body", "cta"]
 
 COPY_LENGTH_BUDGET: Mapping[CopyField, int] = {"headline": 60, "body": 200, "cta": 40}
 
+#: Character limits by ad platform, per field (#76 increment 2, moved here for
+#: #173). Deliberately conservative, published numbers (Meta/Google/TikTok/
+#: LinkedIn ad-copy guidance), not fetched from anywhere — this plugin calls no
+#: platform API, so these are static data, the same way :data:`PLACEMENTS`'s
+#: aspect ratios are.
+#:
+#: ``"generic"`` is the fallback for a channel with no (or an unrecognised)
+#: ``ad_platform``, sized to the narrowest of the known platforms so a gap
+#: never overstates how much room the operator actually has.
+#:
+#: **This lives in ``definitions`` rather than in ``paid_pack_routes`` because
+#: two stages now read it** (#173): the pack trims to it at export, and the copy
+#: stage writes to it. While the pack owned it privately, the writing stage had
+#: no way to see it, and copy could satisfy its budget in full and still be
+#: truncated on the way out — which is the whole of #173. A second copy of these
+#: numbers beside the copy stage would have made the two drift apart silently,
+#: which is the failure mode this estate spends most of its time removing.
+#:
+#: Keyed by ``marketing_channel.ad_platform`` — "google" covers both Google
+#: Search ads and YouTube ads, which is coarser than ideal (search and video ad
+#: copy specs genuinely differ), but the taxonomy does not carry a finer-grained
+#: platform today and these limits are already declared conservative guidance
+#: rather than authoritative ones. Splitting it further is a taxonomy change,
+#: not a lookup-table one.
+AD_PLATFORM_LIMITS: Mapping[str, Mapping[CopyField, int]] = {
+    "meta": {"headline": 40, "body": 125, "cta": 20},
+    "google": {"headline": 30, "body": 90, "cta": 30},
+    "tiktok": {"headline": 100, "body": 100, "cta": 20},
+    "linkedin": {"headline": 70, "body": 150, "cta": 20},
+    "generic": {"headline": 30, "body": 90, "cta": 20},
+}
+
+#: The key :data:`AD_PLATFORM_LIMITS` falls back to. Named rather than written
+#: as a literal in three modules, for the same reason :data:`CopyField` is.
+AD_PLATFORM_GENERIC = "generic"
+
+
+def ad_platform_limits(ad_platform: str | None) -> Mapping[CopyField, int]:
+    """The per-field character limits for this channel's ad platform, falling
+    back to ``generic``'s narrower ones.
+
+    A channel with no ``ad_platform``, or one naming a platform this table does
+    not (yet) carry, still deserves a pack — just a more conservative one. The
+    fallback is deliberately the *narrowest* set, so an unknown platform can
+    never overstate the room an operator has.
+    """
+    return AD_PLATFORM_LIMITS.get(ad_platform or "", AD_PLATFORM_LIMITS[AD_PLATFORM_GENERIC])
+
+
+def copy_length_budget(*, motion: str, ad_platform: str | None) -> dict[CopyField, int]:
+    """What a channel's copy may actually be, per field (issue #173).
+
+    ## Why one ceiling was not enough
+
+    :data:`COPY_LENGTH_BUDGET` is a *writing* constraint — #128's "brevity as a
+    constraint, not a preference" — and it applies to every channel. The ad
+    platforms are a *fitting* constraint, and on some fields they are tighter
+    than the budget: Google's headline field holds 30 characters against the
+    budget's 60, and LinkedIn's CTA 20 against 40.
+
+    While those two never met, copy could satisfy the budget in full and still
+    be trimmed on export. Measured on dev, 2026-08-16 (campaign ``b6724387``):
+    a 46-character Google headline, a 132-character Google body and a
+    37-character LinkedIn CTA — every one inside budget, every one truncated by
+    the paid pack. Three of six paid fields.
+
+    So a paid channel's ceiling is the **tighter of the two**, per field, and
+    the model is told that number rather than the budget. Nothing here relaxes
+    the budget: ``min`` can only lower it.
+
+    ## Why organic is left alone
+
+    An organic channel has no ad form to fit, so there is no second constraint
+    to take the minimum with — and applying ``generic``'s 30/90/20 to a blog
+    post or a LinkedIn organic update would impose an ad's limits on something
+    that is not an ad. Organic keeps :data:`COPY_LENGTH_BUDGET` exactly as it
+    was, which is also what makes this change safe for every channel #173 did
+    not measure.
+
+    Note the asymmetry with :func:`ad_platform_limits`, which falls back to
+    ``generic`` for *anything* it does not recognise: that function answers "how
+    much will the pack trim to", and the pack only ever runs for paid channels.
+    This one answers "what may be written", and for an organic channel the
+    answer is not an ad platform's at all.
+    """
+    if motion != "paid":
+        return dict(COPY_LENGTH_BUDGET)
+    limits = ad_platform_limits(ad_platform)
+    return {field: min(budget, limits[field]) for field, budget in COPY_LENGTH_BUDGET.items()}
+
+
+def channel_copy_budgets(
+    channel_motions: Mapping[str, str],
+    ad_platforms: Mapping[str, str | None],
+) -> dict[str, dict[CopyField, int]]:
+    """``{channel_key: {field: ceiling}}`` for every channel the copy run will
+    write for (issue #173).
+
+    ``channel_motions`` is the approved plan's ``{channel_key: motion}`` — the
+    set the copy stage already validates against — and ``ad_platforms`` is
+    ``{channel_key: ad_platform}`` from the tenant's taxonomy. A channel absent
+    from the taxonomy resolves its platform to ``None``, which for a paid
+    channel means ``generic``'s conservative limits rather than an error: the
+    plan was approved against a taxonomy snapshot, and a channel retired since
+    should still get copy that fits.
+    """
+    return {
+        channel_key: copy_length_budget(motion=motion, ad_platform=ad_platforms.get(channel_key))
+        for channel_key, motion in channel_motions.items()
+    }
+
+
 #: How far past its budget a field has to be before the copy set is rejected
 #: outright rather than flagged (``pipeline.CopyTooLongError``).
 #:
@@ -559,22 +671,26 @@ class ChannelCopy(BaseModel):
     headline: str = Field(
         description=(
             f"The lead line, sized for this channel. At most "
-            f"{COPY_LENGTH_BUDGET['headline']} characters — a ceiling, not a target to "
-            "fill. One idea, scanned in a glance, strongest claim first."
+            f"{COPY_LENGTH_BUDGET['headline']} characters, and less where this channel "
+            "appears in the `channel_limits` map in your input — that number replaces "
+            "this one. A ceiling, not a target to fill. One idea, scanned in a glance, "
+            "strongest claim first."
         )
     )
     body: str = Field(
         description=(
             f"The body copy, sized for this channel. At most {COPY_LENGTH_BUDGET['body']} "
-            "characters — a ceiling, not a target to fill. One sentence; write a second "
-            "only if it carries a fact the first does not."
+            "characters, and less where this channel appears in the `channel_limits` map "
+            "in your input — that number replaces this one. A ceiling, not a target to "
+            "fill. One sentence; write a second only if it carries a fact the first does not."
         )
     )
     cta: str = Field(
         description=(
             "The call to action, drawn from the approved positioning. At most "
-            f"{COPY_LENGTH_BUDGET['cta']} characters — a ceiling, not a target to fill. "
-            "Ask for the action; do not restate the headline."
+            f"{COPY_LENGTH_BUDGET['cta']} characters, and less where this channel appears "
+            "in the `channel_limits` map in your input — that number replaces this one. "
+            "A ceiling, not a target to fill. Ask for the action; do not restate the headline."
         )
     )
     sources: list[Source] = Field(
@@ -1065,7 +1181,20 @@ one is usually still too long:
 - **Body: at most {_BODY_BUDGET} characters.**
 - **CTA: at most {_CTA_BUDGET} characters.**
 
-Your output is measured against these numbers after you return it. Every
+**Several channels are tighter than that, and your input says which.** Your
+input carries `channel_limits`: a `channel_key` to `{{headline, body, cta}}`
+map giving the real ceiling for each channel you are writing for. Where a
+channel appears there, **its numbers replace the ones above for that channel**
+— they are never higher, and they are what your output is measured against.
+
+Those tighter numbers are the ad platform's own field sizes, not a stricter
+opinion about brevity. A paid search headline lives in a box roughly half the
+width of the ceiling above: a headline written to the wider number is not
+slightly long there, it is a headline the platform cuts off, and an operator
+pastes the wreckage into an ads form. Write to the number given for the
+channel in front of you.
+
+Your output is measured against those numbers after you return it. Every
 field over its ceiling is recorded on the artefact and shown to the operator
 who has to approve it, right next to the line that broke it. Copy more than
 {_CEILING_MULTIPLE}x over is rejected outright and the whole set is thrown away with it.

--- a/src/marketing/paid_pack_routes.py
+++ b/src/marketing/paid_pack_routes.py
@@ -60,7 +60,15 @@ from typing import Any
 from biffo_plugin_sdk import BiffoAPIClient, create_core_client
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from . import admin_app, config, pack_routes, pipeline, principal_client, spend_routes
+from . import (
+    admin_app,
+    config,
+    definitions,
+    pack_routes,
+    pipeline,
+    principal_client,
+    spend_routes,
+)
 
 require_admin = admin_app.require_admin
 
@@ -101,28 +109,16 @@ async def _channel_ad_platforms(admin_token: str) -> dict[str, str | None]:
 
 # ── Ad copy at real platform character limits ───────────────────────────────
 
-#: Character limits by ad platform, per field. Deliberately conservative,
-#: published numbers (Meta/Google/TikTok/LinkedIn ad-copy guidance), not
-#: fetched from anywhere — this milestone calls no platform API, so these are
-#: static data, the same way `definitions.PLACEMENTS`'s aspect ratios are.
-#: `"generic"` is the fallback for a channel with no (or an unrecognised)
-#: `ad_platform`, sized to the narrowest of the known platforms so a gap
-#: never overstates how much room the operator actually has.
+#: The character limits this pack trims to, now owned by `definitions` because
+#: the COPY STAGE reads the same table (#173). It used to live here, privately,
+#: which is precisely why copy could satisfy its length budget in full and still
+#: be truncated on the way out: the stage that writes the copy could not see the
+#: numbers the stage that exports it would enforce.
 #:
-#: Keyed by `marketing_channel.ad_platform` (#76 increment 2) — "google"
-#: covers both Google Search ads and YouTube ads, which is coarser than
-#: ideal (search and video ad copy specs genuinely differ), but the taxonomy
-#: does not carry a finer-grained platform today and these limits are already
-#: declared conservative, static guidance rather than authoritative ones —
-#: see the module docstring. Splitting it further is a taxonomy change, not
-#: a lookup-table one.
-_PLATFORM_LIMITS: dict[str, dict[str, int]] = {
-    "meta": {"headline": 40, "body": 125, "cta": 20},
-    "google": {"headline": 30, "body": 90, "cta": 30},
-    "tiktok": {"headline": 100, "body": 100, "cta": 20},
-    "linkedin": {"headline": 70, "body": 150, "cta": 20},
-    "generic": {"headline": 30, "body": 90, "cta": 20},
-}
+#: Aliased rather than re-exported under the old name so that every reader is
+#: pointed at the one definition — see `definitions.AD_PLATFORM_LIMITS` for the
+#: numbers themselves and why they are static.
+_PLATFORM_LIMITS = definitions.AD_PLATFORM_LIMITS
 
 _ELLIPSIS = "…"
 
@@ -141,7 +137,12 @@ def _platform_for_channel(channel_key: str, ad_platforms: dict[str, str | None])
     unrecognised platform still deserves a pack, just a more conservative
     one."""
     platform = ad_platforms.get(channel_key)
-    return platform if platform in _PLATFORM_LIMITS else "generic"
+    # `is not None` before the membership test, rather than relying on the
+    # test alone to exclude it: `_PLATFORM_LIMITS` is now a `Mapping` from
+    # `definitions`, and `in` on a Mapping does not narrow `str | None` away.
+    if platform is not None and platform in _PLATFORM_LIMITS:
+        return platform
+    return definitions.AD_PLATFORM_GENERIC
 
 
 def _fit_to_limit(text: str, limit: int) -> tuple[str, bool]:

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -86,6 +86,7 @@ from .definitions import (
     ChannelCopy,
     ChannelEvidenceSet,
     ChannelPlan,
+    CopyField,
     CopySet,
     LengthOverage,
     Positioning,
@@ -271,11 +272,23 @@ class CopyTooLongError(PipelineError):
 # ── Length: measured, recorded, and only fatal at the far end (issue #128) ───
 
 
-def measure_copy_length(channels: Sequence[ChannelCopy]) -> None:
-    """Record every field over :data:`COPY_LENGTH_BUDGET` on its own
+def measure_copy_length(
+    channels: Sequence[ChannelCopy],
+    channel_budgets: Mapping[str, Mapping[CopyField, int]] | None = None,
+) -> None:
+    """Record every field over its channel's budget on its own
     :class:`ChannelCopy`, and raise :class:`CopyTooLongError` for anything
     past :data:`COPY_LENGTH_CEILING_MULTIPLE` times that budget. Mutates in
     place, exactly as :func:`extract_copy`'s ``motion`` carry-over does.
+
+    ``channel_budgets`` is ``{channel_key: {field: ceiling}}`` from
+    :func:`~marketing.definitions.channel_copy_budgets` — the *same* mapping
+    the run was given in its input payload (#173), so what is measured here is
+    what the model was asked for. A channel missing from it falls back to
+    :data:`COPY_LENGTH_BUDGET`, which is also what ``None`` means: an older
+    pending artefact, stashed before per-channel budgets existed, must keep
+    being judged by the rule it was written under rather than by a tighter one
+    it never saw.
 
     ## Why over-budget is recorded rather than rejected
 
@@ -315,9 +328,16 @@ def measure_copy_length(channels: Sequence[ChannelCopy]) -> None:
     (``admin_app._pipeline_error_to_http``, which maps the BASE class so a new
     error type cannot fall through as a bare 500).
     """
+    budgets = channel_budgets or {}
     for channel_copy in channels:
+        # Per channel, defaulting to the shared budget. `.get` rather than a
+        # membership test: an unknown channel is already a hard error one
+        # function up (`UnknownChannelError`), so the only way to reach this
+        # with a missing key is the pre-#173 artefact case above.
+        budget_for_channel = budgets.get(channel_copy.channel_key, COPY_LENGTH_BUDGET)
         overages: list[LengthOverage] = []
-        for field_name, budget in COPY_LENGTH_BUDGET.items():
+        for field_name in COPY_LENGTH_BUDGET:
+            budget = budget_for_channel.get(field_name, COPY_LENGTH_BUDGET[field_name])
             length = len(getattr(channel_copy, field_name))
             if length > budget:
                 overages.append(LengthOverage(field=field_name, length=length, budget=budget))
@@ -972,6 +992,7 @@ def extract_copy(
     messages: list[dict[str, Any]],
     *,
     channel_plan_channels: dict[str, Literal["organic", "paid"]],
+    channel_budgets: Mapping[str, Mapping[CopyField, int]] | None = None,
     allowed_source_urls: Collection[str] | None = None,
     annotations: list[dict[str, Any]] | None = None,
 ) -> CopySet:
@@ -1025,7 +1046,7 @@ def extract_copy(
     # fabricated a source should be reported as having fabricated a source, not
     # as having written a long headline. See :func:`measure_copy_length` for why
     # only the far end of this is fatal (issue #128).
-    measure_copy_length(result.channels)
+    measure_copy_length(result.channels, channel_budgets)
     return result
 
 
@@ -2313,6 +2334,7 @@ async def start_copy(
     *,
     positioning_body: dict[str, Any],
     channel_plan_body: dict[str, Any],
+    channel_budgets: Mapping[str, Mapping[CopyField, int]] | None = None,
     copy_model: str = DEFAULT_COPY_MODEL,
 ) -> tuple[str, str]:
     """Request the single copy agent (M5, issue #4), given the *approved*
@@ -2328,7 +2350,20 @@ async def start_copy(
         agent_name=COPY_AGENT_NAME,
         definition=copy_definition(model=copy_model, instructions=COPY_INSTRUCTIONS),
         output_tool=copy_tool_schema(),
-        input_payload={"positioning": positioning_body, "channel_plan": channel_plan_body},
+        # `channel_limits` is the per-channel ceiling the model must write to
+        # (#173). It rides in the payload rather than in the tool schema
+        # because the schema is built once per run and covers every channel,
+        # so a field description cannot say "30 for Google, 70 for LinkedIn" —
+        # while the payload can, and `measure_copy_length` then measures the
+        # output against this same mapping.
+        #
+        # Not an `:online` run, so nothing here steers retrieval — the ordering
+        # constraint that governs the grounded stages (#65) does not apply.
+        input_payload={
+            "positioning": positioning_body,
+            "channel_plan": channel_plan_body,
+            "channel_limits": dict(channel_budgets or {}),
+        },
         causation_id=causation_id,
     )
     return causation_id, run_id
@@ -2339,13 +2374,15 @@ async def advance_copy(
     *,
     run_id: str,
     channel_plan_channels: dict[str, Literal["organic", "paid"]],
+    channel_budgets: Mapping[str, Mapping[CopyField, int]] | None = None,
     allowed_source_urls: Collection[str] | None = None,
 ) -> CopySet | None:
     """Read the copy run, advancing nothing else — mirrors
     :func:`advance_channel_plan`: a single run, not a chain, so there is no
     fan-in to discover. ``channel_plan_channels`` is ``{channel_key: motion}``
     for exactly the approved channel plan's real (non-proposal) entries — see
-    :func:`extract_copy` for how it and ``allowed_source_urls`` are used."""
+    :func:`extract_copy` for how it, ``channel_budgets`` (#173) and
+    ``allowed_source_urls`` are used."""
     view = await gateway.get_agent_run(run_id=run_id)
     if view is None or not view.is_terminal:
         return None
@@ -2354,6 +2391,7 @@ async def advance_copy(
     return extract_copy(
         view.messages,
         channel_plan_channels=channel_plan_channels,
+        channel_budgets=channel_budgets,
         allowed_source_urls=allowed_source_urls,
         annotations=view.annotations,
     )

--- a/tests/test_marketing_per_channel_copy_budget.py
+++ b/tests/test_marketing_per_channel_copy_budget.py
@@ -1,0 +1,285 @@
+"""Per-channel copy ceilings, so paid copy inside budget is not truncated (#173).
+
+The defect this file holds shut: `COPY_LENGTH_BUDGET` was one ceiling for every
+channel, and several ad platforms are tighter than it on some fields. Copy could
+satisfy the budget in full and still be trimmed by the paid pack on export —
+measured on dev 2026-08-16, campaign `b6724387`, 3 of 6 paid fields.
+
+The numbers in `_MEASURED` below are that live run's, kept verbatim rather than
+rounded into a fixture: they are the evidence the issue was opened on, and a
+test that drifts off them stops proving the thing it was written for.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from marketing.definitions import (
+    AD_PLATFORM_LIMITS,
+    COPY_LENGTH_BUDGET,
+    CopyField,
+    ad_platform_limits,
+    channel_copy_budgets,
+    copy_length_budget,
+)
+
+#: `(channel_key, ad_platform, field, generated_length)` from the live run in
+#: #173. Every one of these was inside `COPY_LENGTH_BUDGET` and truncated anyway.
+_MEASURED: list[tuple[str, str, CopyField, int]] = [
+    ("google_search_paid", "google", "headline", 46),
+    ("google_search_paid", "google", "body", 132),
+    ("linkedin_paid", "linkedin", "cta", 37),
+]
+
+
+@pytest.mark.parametrize(("channel_key", "platform", "field", "generated"), _MEASURED)
+def test_the_field_that_was_truncated_is_now_over_its_ceiling(
+    channel_key: str, platform: str, field: CopyField, generated: int
+) -> None:
+    """The whole point, stated as the three fields that actually failed.
+
+    Each was inside the old budget — which is why nothing flagged it — and each
+    exceeds the platform limit the pack then trimmed it to. Under the new
+    ceiling the same copy is over budget, so it is recorded on the artefact and
+    shown to the operator instead of silently losing its end.
+    """
+    budget = copy_length_budget(motion="paid", ad_platform=platform)
+
+    assert generated <= COPY_LENGTH_BUDGET[field], "premise: it was inside the old budget"
+    assert generated > budget[field], "it must now be over the ceiling it is measured against"
+
+
+def test_a_paid_ceiling_is_never_wider_than_the_platform_will_hold() -> None:
+    """The invariant that makes truncation impossible for in-budget copy.
+
+    Asserted across every known platform and field rather than for the three
+    that happened to fail, because a future platform added to the table with a
+    generous limit must not be able to raise a ceiling above what the pack
+    trims to.
+    """
+    for platform, limits in AD_PLATFORM_LIMITS.items():
+        budget = copy_length_budget(motion="paid", ad_platform=platform)
+        for field, limit in limits.items():
+            assert budget[field] <= limit, f"{platform}.{field} would still be truncated"
+
+
+def test_a_paid_ceiling_is_never_wider_than_the_brevity_budget_either() -> None:
+    """#128's constraint is not relaxed by #173. `min` can only lower it, and
+    TikTok's 100-character headline is the case that proves the direction
+    matters: it is above the 60-character budget, and must not raise it."""
+    for platform in AD_PLATFORM_LIMITS:
+        budget = copy_length_budget(motion="paid", ad_platform=platform)
+        for field, brevity in COPY_LENGTH_BUDGET.items():
+            assert budget[field] <= brevity
+
+    assert AD_PLATFORM_LIMITS["tiktok"]["headline"] > COPY_LENGTH_BUDGET["headline"]
+    assert (
+        copy_length_budget(motion="paid", ad_platform="tiktok")["headline"]
+        == (COPY_LENGTH_BUDGET["headline"])
+    )
+
+
+def test_organic_keeps_exactly_the_budget_it_had() -> None:
+    """ "The organic default stays as-is where no platform limit applies" —
+    #173's own fourth acceptance line, and the reason this change is safe for
+    every channel the issue did not measure.
+
+    An organic channel has no ad form to fit, so there is no second constraint
+    to take a minimum with. Applying `generic`'s 30/90/20 to a blog post would
+    impose an ad's limits on something that is not an ad.
+    """
+    assert copy_length_budget(motion="organic", ad_platform=None) == dict(COPY_LENGTH_BUDGET)
+
+
+def test_an_organic_channel_carrying_an_ad_platform_is_still_organic() -> None:
+    """Motion decides, not the presence of a platform string. A LinkedIn
+    organic post is not a LinkedIn ad, and the taxonomy could carry a platform
+    on a channel of either motion."""
+    assert copy_length_budget(motion="organic", ad_platform="google") == dict(COPY_LENGTH_BUDGET)
+
+
+def test_an_unknown_paid_platform_gets_the_narrowest_ceiling_not_the_widest() -> None:
+    """A gap must never overstate the room an operator has.
+
+    `generic` is the narrowest row in the table, and it is what the paid pack
+    trims an unrecognised platform to — so the ceiling has to agree with it, or
+    the promise this issue makes ("in-budget copy is not truncated") holds only
+    for platforms someone remembered to add.
+    """
+    unknown = copy_length_budget(motion="paid", ad_platform="pinterest")
+    generic = copy_length_budget(motion="paid", ad_platform="generic")
+
+    assert unknown == generic
+    assert ad_platform_limits("pinterest") == AD_PLATFORM_LIMITS["generic"]
+    assert ad_platform_limits(None) == AD_PLATFORM_LIMITS["generic"]
+
+
+def test_a_paid_channel_missing_from_the_taxonomy_still_gets_a_fitting_ceiling() -> None:
+    """The plan was approved against a taxonomy snapshot; a channel retired
+    since must still get copy that fits, not an exception. It resolves to
+    `generic` — conservative — rather than to the unconstrained budget."""
+    budgets = channel_copy_budgets({"retired_channel": "paid"}, {})
+
+    assert budgets["retired_channel"] == copy_length_budget(motion="paid", ad_platform=None)
+
+
+def test_budgets_are_built_for_exactly_the_channels_the_run_writes_for() -> None:
+    """Keyed by the approved plan's channels, not by the taxonomy: the map is
+    what the copy agent is handed and what its output is measured against, so a
+    channel it was never asked to write for has no business in it."""
+    budgets = channel_copy_budgets(
+        {"google_search_paid": "paid", "blog": "organic"},
+        {"google_search_paid": "google", "blog": None, "linkedin_paid": "linkedin"},
+    )
+
+    assert set(budgets) == {"google_search_paid", "blog"}
+    assert budgets["google_search_paid"]["headline"] == AD_PLATFORM_LIMITS["google"]["headline"]
+    assert budgets["blog"] == dict(COPY_LENGTH_BUDGET)
+
+
+# ── The wiring: told to the agent, and measured against on the way back ──────
+
+
+def _copy(channel_key: str, *, headline: str = "h", body: str = "b", cta: str = "c"):
+    from marketing.definitions import ChannelCopy, Source
+
+    return ChannelCopy(
+        channel_key=channel_key,
+        headline=headline,
+        body=body,
+        cta=cta,
+        sources=[Source(url="https://example.com/x", note="n")],
+    )
+
+
+def test_measure_uses_the_channels_own_ceiling_not_the_shared_one() -> None:
+    """A 46-character Google headline is over its 30-character ceiling and must
+    be recorded as such — with the ceiling it actually broke, since that number
+    is rendered beside the line in the approval gate."""
+    from marketing import pipeline
+
+    channels = [_copy("google_search_paid", headline="x" * 46)]
+
+    pipeline.measure_copy_length(
+        channels, {"google_search_paid": copy_length_budget(motion="paid", ad_platform="google")}
+    )
+
+    (overage,) = channels[0].over_budget
+    assert (overage.field, overage.length, overage.budget) == ("headline", 46, 30)
+
+
+def test_the_same_copy_on_an_organic_channel_is_not_flagged() -> None:
+    """The identical 46 characters are fine on a channel with no ad form —
+    which is what makes this a per-channel ceiling rather than a tightening."""
+    from marketing import pipeline
+
+    channels = [_copy("blog", headline="x" * 46)]
+
+    pipeline.measure_copy_length(
+        channels, {"blog": copy_length_budget(motion="organic", ad_platform=None)}
+    )
+
+    assert channels[0].over_budget == []
+
+
+def test_copy_written_before_this_change_is_judged_by_the_rule_it_was_written_under() -> None:
+    """A pending artefact stashed before #173 has no `channel_budgets`. Judging
+    its copy by the tighter per-channel ceiling would flag fields the model was
+    never asked to fit, on a run nobody can go back and redo."""
+    from marketing import pipeline
+
+    channels = [_copy("google_search_paid", headline="x" * 46)]
+
+    pipeline.measure_copy_length(channels, None)
+
+    assert channels[0].over_budget == []
+
+
+def test_the_fatal_ceiling_scales_with_the_channels_own_budget() -> None:
+    """`COPY_LENGTH_CEILING_MULTIPLE` is a multiple of the budget that applies,
+    so a Google headline is thrown out past 3x30 rather than 3x60. Otherwise the
+    tighter ceiling would be advisory exactly where it matters most."""
+    from marketing import pipeline
+
+    budgets = {"google_search_paid": copy_length_budget(motion="paid", ad_platform="google")}
+
+    with pytest.raises(pipeline.CopyTooLongError) as excinfo:
+        pipeline.measure_copy_length([_copy("google_search_paid", headline="x" * 91)], budgets)
+
+    assert "google_search_paid headline is 91 characters (budget 30)" in str(excinfo.value)
+
+    # 89 is over the 30-char budget but inside 3x, so it is recorded, not fatal.
+    survivable = [_copy("google_search_paid", headline="x" * 89)]
+    pipeline.measure_copy_length(survivable, budgets)
+    assert survivable[0].over_budget[0].length == 89
+
+
+@pytest.mark.asyncio
+async def test_the_agent_is_told_each_channels_ceiling_in_its_payload() -> None:
+    """The half a prompt cannot do on its own (#128's lesson).
+
+    The tool schema is built once per run and covers every channel, so a field
+    description cannot say "30 for Google, 70 for LinkedIn". The numbers travel
+    in the payload instead, and this asserts they arrive — a model told a
+    ceiling above the real one writes to the ceiling it is given.
+    """
+    from marketing import pipeline
+
+    class _Gateway:
+        def __init__(self) -> None:
+            self.payloads: list[dict] = []
+
+        async def request_agent_run(self, *, input_payload, **_kw):
+            self.payloads.append(input_payload)
+            return "run-1"
+
+    gateway = _Gateway()
+    budgets = channel_copy_budgets(
+        {"google_search_paid": "paid", "blog": "organic"},
+        {"google_search_paid": "google", "blog": None},
+    )
+
+    await pipeline.start_copy(
+        gateway,  # type: ignore[arg-type]
+        positioning_body={},
+        channel_plan_body={},
+        channel_budgets=budgets,
+    )
+
+    limits = gateway.payloads[0]["channel_limits"]
+    assert limits["google_search_paid"] == {"headline": 30, "body": 90, "cta": 30}
+    assert limits["blog"] == dict(COPY_LENGTH_BUDGET)
+
+
+def test_the_prompt_points_at_the_map_rather_than_restating_numbers() -> None:
+    """The prompt must not carry a second copy of the per-channel ceilings —
+    they are per run, and a hard-coded set in the instructions would be the
+    stale-copy failure this estate keeps paying for. It has to name the key the
+    payload actually uses, or the model cannot find them."""
+    from marketing.definitions import COPY_INSTRUCTIONS
+
+    assert "channel_limits" in COPY_INSTRUCTIONS
+
+    # No platform-specific ceiling is written out in prose. A number quoted
+    # here is a second copy of `AD_PLATFORM_LIMITS`, and it is the copy that
+    # goes stale: change Google's limit and the payload says one thing while a
+    # sentence three paragraphs up says another.
+    #
+    # It caught its author immediately — the first draft of this prompt
+    # illustrated the point with "a 30-character box", which is Google's
+    # headline limit transcribed by hand.
+    #
+    # Only values unique to the platform table are checked. The budget's own
+    # numbers are quoted deliberately, and platform NAMES are not checked at
+    # all: `COPY_INSTRUCTIONS` names LinkedIn as a tone example ("a LinkedIn
+    # post and an Instagram caption should not read the same"), which is about
+    # voice and carries no number to go stale.
+    prompt_numbers = set(re.findall(r"\b\d+\b", COPY_INSTRUCTIONS))
+    platform_only = {
+        value for limits in AD_PLATFORM_LIMITS.values() for value in limits.values()
+    } - set(COPY_LENGTH_BUDGET.values())
+
+    transcribed = sorted(value for value in platform_only if str(value) in prompt_numbers)
+    assert not transcribed, f"platform limits written into the prompt: {transcribed}"

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -998,6 +998,10 @@ async def test_start_copy_requests_one_run_carrying_both_upstream_bodies() -> No
     assert requested.input_payload == {
         "positioning": positioning_body,
         "channel_plan": channel_plan_body,
+        # #173: the per-channel ceilings ride in the payload, because the tool
+        # schema is one schema for every channel and cannot say "30 for Google,
+        # 70 for LinkedIn". Empty here because this run was given no channels.
+        "channel_limits": {},
     }
     assert run_id  # a real id was returned
 

--- a/tests/test_marketing_pipeline_routes.py
+++ b/tests/test_marketing_pipeline_routes.py
@@ -16,7 +16,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
-from marketing import admin_app, pipeline
+from marketing import admin_app, definitions, pipeline
 from marketing.definitions import RESEARCH_SYNTHESIS_AGENT_NAME
 
 _CAMPAIGN = "b3f1c0de-0000-4000-8000-0000000000cd"
@@ -1016,6 +1016,37 @@ def test_start_copy_stashes_the_union_of_both_approved_inputs_citation_urls(ctx)
 
     pending = json.loads(started["body"])
     assert pending["allowed_source_urls"] == ["https://example.com/thread"]
+    assert pending["channel_plan_channels"], "the channel stash must survive the new key"
+
+
+def test_start_copy_resolves_each_channels_ceiling_from_the_taxonomy(ctx) -> None:
+    """#173, at the seam where it was said to be blocked.
+
+    The issue recorded this as needing a taxonomy change, because at
+    `extract_copy` the only channel fact available is `{channel_key: motion}`
+    and deriving a channel's shape from its key means substring-matching it —
+    the guess `paid_pack_routes._platform_for_channel` deleted in #76
+    increment 2.
+
+    That premise was already stale: #76 increment 2 also added
+    `marketing_channel.ad_platform`, and the route reads it. Nothing here is
+    inferred from a channel key.
+    """
+    client, core, gateway = ctx
+    _propose_and_approve_channel_plan(client, core, gateway)
+
+    started = client.post(f"/campaigns/{_CAMPAIGN}/copy").json()
+
+    # Paid Google search: tighter than the shared budget on headline and body.
+    limits = gateway.requested[-1]["input_payload"]["channel_limits"]
+    assert limits["google_search_paid"] == {"headline": 30, "body": 90, "cta": 30}
+    # Organic: untouched, which is #173's fourth acceptance line.
+    assert limits["instagram_organic"] == dict(definitions.COPY_LENGTH_BUDGET)
+
+    # Stashed, so the length check at advance time measures the copy against
+    # the number the model was given rather than a taxonomy that has moved.
+    pending = json.loads(started["body"])
+    assert pending["channel_budgets"] == limits
     assert pending["channel_plan_channels"], "the channel stash must survive the new key"
 
 


### PR DESCRIPTION
Closes #173.

## The defect

`COPY_LENGTH_BUDGET` was one ceiling for every channel — headline 60, body 200, cta 40 — and the ad platforms are tighter than it on some fields. So copy could satisfy the budget in full and still be trimmed by the paid pack on export:

| field | generated | budget | platform limit | outcome |
| --- | --- | --- | --- | --- |
| `google_search_paid` headline | 46 | 60 ✅ | 30 | truncated |
| `google_search_paid` body | 132 | 200 ✅ | 90 | truncated |
| `linkedin_paid` cta | 37 | 40 ✅ | 20 | truncated |

Three of six paid fields, every one inside budget, so nothing flagged them.

A paid channel's ceiling is now the **tighter of the two, per field**, and the model is told that number instead of the budget. `min` can only lower it, so #128's brevity constraint is untouched — TikTok's 100-character headline is the case that proves the direction matters, and it does not raise the 60.

Organic keeps the budget exactly as it was. There is no ad form to fit, and applying `generic`'s 30/90/20 to a blog post would impose an ad's limits on something that is not an ad — #173's own fourth acceptance line, and what makes this safe for every channel the issue did not measure.

## The stated blocker was already gone

#173 recorded this as blocked on a taxonomy change — *"a table change plus a seed change plus a migration"* — because at `extract_copy` the only channel fact available is `{channel_key: motion}`, and deriving a channel's shape from its key means substring-matching it, which #76 increment 2 deleted.

**But #76 increment 2 also added `marketing_channel.ad_platform`**, and `seed_marketing_channels.py` populates it for every paid channel. The shape was already on the taxonomy; nothing was reading it on this path. `paid_pack_routes` had been looking it up since that increment. So: no table change, no seed change, no migration — the route reads `/channels` and resolves each channel's platform by lookup, exactly as the pack does.

## Where the numbers live now

`AD_PLATFORM_LIMITS` moves from `paid_pack_routes` into `definitions`, because two stages read it: the pack trims to it, the copy stage writes to it. While the pack owned it privately, the stage that writes the copy could not see the numbers the stage that exports it would enforce — which is the whole defect. A second copy beside the copy stage would have let the two drift apart silently.

The per-channel ceilings travel in the run's input payload as `channel_limits`, not in the tool schema: the schema is built once per run and covers every channel, so a field description cannot say "30 for Google, 70 for LinkedIn". `measure_copy_length` measures the output against that same mapping, so what is judged is what the model was asked for.

A pending artefact stashed before this change carries no budgets and is still judged by the single budget it was written under — `None` rather than `{}` is load-bearing there.

## Guards

Reinstating the single ceiling fails **nine** tests, including one per field from the live run. Verified by making that edit, watching them fail, and restoring.

One guard caught its own author: the first draft of the prompt illustrated the point with *"a 30-character box"* — Google's limit transcribed by hand — and the test that forbids restating the table rejected it. The prose now makes the point without a number.

840 tests pass; ruff, format and pyright clean.

## Not verified

The fourth acceptance line — *"a paid-pack export of copy generated under those ceilings truncates no field, proven on a live run"* — needs a deploy and a copy run. Everything here is the mechanism; the live proof is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)