### PR TITLE
fix(agents): compare drift in the runtime's terms, not this repo's

### DIFF
--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -1554,6 +1554,66 @@ CHANNEL_EVIDENCE_MAX_TURNS = RESEARCH_MAX_TURNS
 CHANNEL_PLAN_MAX_TURNS = 3
 COPY_MAX_TURNS = 3
 
+#: The `action_config`/run-definition keys Core resolves through its **prompt
+#: library** before a run ever sees them (ADR-0015 §2 — `instructions` and
+#: `goals`).
+#:
+#: This repo's belief about another repo's behaviour, in the same sense as the
+#: two timeout constants below, and it cannot be imported for the same reason.
+RUNTIME_PROMPT_FIELDS = frozenset({"instructions", "goals"})
+
+
+def as_the_runtime_stores_it(key: str, value: Any) -> Any:
+    """One config value as it will look **on the run**, not as declared here.
+
+    Core does not store a prompt field verbatim. Every write of a run
+    definition goes through `agent_runs.resolve_definition_snapshot` ->
+    `prompt_library.resolve_prompt_field` -> `prompt_parts.compose`, and
+    `compose` is:
+
+        return _PART_SEPARATOR.join(
+            stripped for text in texts if (stripped := text.strip())
+        )
+
+    A plain-string prompt is a single part, so **it comes back stripped**. Any
+    other key is returned untouched: this normalises the one transformation
+    Core actually performs, not whitespace generally.
+
+    **Why this function exists at all (issue #175).** Both of this repo's drift
+    detectors compared what they declare against what a run received, and the
+    declared `RESEARCH_SYNTHESIS_INSTRUCTIONS` ends in a newline. So every
+    synthesis run reported drift of exactly one character — 2047 declared
+    against 2046 deployed — and the remedy it printed, re-seeding, could never
+    clear it: `--replace` writes 2047 back, Core strips it to 2046 on the next
+    run, and the detector fires again. Measured on tabsii dev on 2026-08-16, in
+    a run twenty minutes after a successful `--replace`.
+
+    A permanently-red detector is worse than none: this is the ONLY one of the
+    three synthesis-drift checks that fires by itself, in the environment where
+    the drift is real, with no token and no operator. Teaching people to scroll
+    past it costs the thing #160 exists to catch.
+
+    **A drift detector must compare like with like**, so the normalisation is
+    applied to BOTH sides rather than only to the declared one — the deployed
+    side is already stripped, and `strip` is idempotent, so this is symmetric
+    by construction rather than by luck.
+
+    The fix is deliberately here and not in Core: `compose`'s stripping is
+    documented behaviour that multi-part prompts rely on, and changing it to
+    preserve a trailing newline for the single-part case would be a wide blast
+    radius for a narrow problem.
+
+    **What this does NOT normalise**: a prompt declared as a *list* of parts.
+    Core would join those with `_PART_SEPARATOR`; nothing here declares one, so
+    reproducing that join would be a second unverified belief about Core rather
+    than a fix. A list is returned unchanged and compares exactly, which fails
+    loudly rather than silently if that day comes.
+    """
+    if key in RUNTIME_PROMPT_FIELDS and isinstance(value, str):
+        return value.strip()
+    return value
+
+
 #: This repo's belief about `agent_runtime.loop.DEFAULT_TIMEOUT_SECONDS` — the
 #: wall clock a run definition inherits when it declares no `timeout_seconds`
 #: of its own. `agent_runtime` is not a dependency of this plugin (checked

--- a/src/marketing/fan_in_workflow.py
+++ b/src/marketing/fan_in_workflow.py
@@ -38,6 +38,7 @@ from .definitions import (
     RESEARCH_AGENT_NAMES,
     RESEARCH_SYNTHESIS_AGENT_NAME,
     RESEARCH_SYNTHESIS_INSTRUCTIONS,
+    as_the_runtime_stores_it,
     research_synthesis_definition,
     research_synthesis_tool_schema,
 )
@@ -132,6 +133,15 @@ def config_drift(
     value cannot be read back, so calling it drift would mean permanent,
     unfixable red. ``deployed`` of ``None`` — nothing seeded at all — is not
     expressible as a per-key diff and is the caller's job to report.
+
+    **Prompt fields are compared as Core stores them**, via
+    :func:`definitions.as_the_runtime_stores_it` — for the same "permanent,
+    unfixable red" reason the sentinel is skipped above, and see that function
+    for the measurement (issue #175). This one reads a *workflow definition*
+    rather than a *run*, so it did not report the drift #175 describes; it is
+    normalised anyway so that `--check` and ``pipeline.synthesis_config_drift``
+    cannot answer differently about the same config, which is exactly what made
+    #175 hard to pin down.
     """
     desired = definition()["action_config"] if desired is None else desired
     if deployed is None:
@@ -142,6 +152,8 @@ def config_drift(
         if deployed_value == REDACTED_SENTINEL:
             continue
         desired_value = desired.get(key)
-        if deployed_value != desired_value:
+        if as_the_runtime_stores_it(key, deployed_value) != as_the_runtime_stores_it(
+            key, desired_value
+        ):
             drift[key] = (deployed_value, desired_value)
     return drift

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -93,6 +93,7 @@ from .definitions import (
     ResearchFindingSet,
     ResearchSynthesis,
     Source,
+    as_the_runtime_stores_it,
     channel_evidence_definition,
     channel_evidence_tool_schema,
     channel_plan_definition,
@@ -1803,6 +1804,15 @@ def synthesis_config_drift(
     drift with a deployed value of ``None``, because absent is precisely how
     ``timeout_seconds`` produced the 120s clock #160 measured: the runtime
     silently substitutes its own default for a key nobody wrote.
+
+    **The comparison is made in the runtime's terms, not this repo's**
+    (issue #175). A snapshot is what Core *stored*, and Core resolves prompt
+    fields through its prompt library on the way in — so comparing a declared
+    prompt to a stored one raw made this detector report one character of
+    drift on **every** synthesis run, unfixably: the declared instructions end
+    in a newline and `prompt_parts.compose` strips it. See
+    :func:`definitions.as_the_runtime_stores_it`. This is the difference
+    between a guard that reports a real stale workflow and one nobody reads.
     """
     if snapshot is None:
         return {}
@@ -1814,7 +1824,9 @@ def synthesis_config_drift(
         if key in SYNTHESIS_DRIFT_IGNORED_KEYS:
             continue
         deployed_value = snapshot.get(key)
-        if deployed_value != declared_value:
+        if as_the_runtime_stores_it(key, deployed_value) != as_the_runtime_stores_it(
+            key, declared_value
+        ):
             drift[key] = (_drift_summary(deployed_value), _drift_summary(declared_value))
     return drift
 

--- a/tests/test_marketing_pipeline_orchestration.py
+++ b/tests/test_marketing_pipeline_orchestration.py
@@ -31,10 +31,36 @@ from marketing.definitions import (
 
 def _in_step_snapshot() -> dict[str, Any]:
     """The definition snapshot a *freshly re-seeded* workflow would produce —
-    what the engine ran the synthesis agent with when nothing has drifted."""
-    return research_synthesis_definition(
+    what the engine ran the synthesis agent with when nothing has drifted.
+
+    **Built through the runtime's own normalisation, not from the declaration
+    verbatim (issue #175).** This helper used to return
+    ``research_synthesis_definition(...)`` unchanged, which is a snapshot Core
+    cannot produce: a run definition passes through
+    ``prompt_library.resolve_prompt_field`` -> ``prompt_parts.compose``, which
+    strips each prompt part, and the declared instructions end in a newline.
+
+    So the negative control below asserted "no drift" against a fixture that
+    was **one character different from every real run**, and the suite stayed
+    green for as long as production reported drift on every single synthesis.
+    A fixture that invents a state the system never reaches cannot fail with
+    it — the fix belongs in what the fixture models, not in the assertion.
+
+    **Deliberately does NOT call `definitions.as_the_runtime_stores_it`**, even
+    though that function exists to describe exactly this. A fixture built from
+    the code under test agrees with that code by construction: remove the
+    normalisation and the fixture silently stops normalising too, so the
+    control goes on passing and proves nothing. Core's behaviour is restated
+    here as a literal `.strip()` of the prompt fields, so the two can
+    disagree — which is the only way this control can fail.
+    """
+    declared = research_synthesis_definition(
         model=DEFAULT_SYNTHESIS_MODEL, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
     )
+    return {
+        key: value.strip() if key in ("instructions", "goals") and isinstance(value, str) else value
+        for key, value in declared.items()
+    }
 
 
 @dataclass
@@ -1157,6 +1183,59 @@ def test_synthesis_config_drift_is_empty_for_a_freshly_seeded_workflow() -> None
     """The negative control: after a re-seed this must go quiet, or the report
     is noise and gets filtered out."""
     assert pipeline.synthesis_config_drift(_in_step_snapshot()) == {}
+
+
+def test_synthesis_config_drift_ignores_the_newline_core_itself_strips() -> None:
+    """The regression for issue #175, measured on tabsii dev.
+
+    `RESEARCH_SYNTHESIS_INSTRUCTIONS` ends in a newline. Core strips it on the
+    way in (`prompt_parts.compose`), so a run's snapshot is 2046 characters
+    where this repo declares 2047 — and the detector reported that one
+    character as drift on **every** synthesis run, twenty minutes after a
+    successful `--replace` included.
+
+    What made it worse than a false alarm: the remedy it printed could not
+    clear it. `--replace` writes the newline back, Core strips it again, and
+    the next run reports the same drift. A guard that cannot go green is one
+    people learn to scroll past, and this is the only synthesis-drift check
+    that fires by itself in the environment where the drift is real.
+    """
+    declared = research_synthesis_definition(
+        model=DEFAULT_SYNTHESIS_MODEL, instructions=RESEARCH_SYNTHESIS_INSTRUCTIONS
+    )
+    assert declared["instructions"].endswith("\n"), (
+        "this test is about the trailing newline Core strips; if the declared "
+        "prompt no longer has one, keep the case but plant it explicitly"
+    )
+    as_core_stored_it = {**_in_step_snapshot(), "instructions": declared["instructions"].strip()}
+
+    assert pipeline.synthesis_config_drift(as_core_stored_it) == {}
+
+
+def test_synthesis_config_drift_still_catches_a_prompt_that_really_changed() -> None:
+    """The other half of #175, and the one that keeps the fix honest.
+
+    Normalising whitespace must not blunt the detector: a prompt whose WORDS
+    differ is the drift #160 exists to catch, and stripping both sides must
+    leave that entirely visible.
+    """
+    drift = pipeline.synthesis_config_drift(
+        {**_in_step_snapshot(), "instructions": "Reconcile the two research angles. Be brief.\n"}
+    )
+
+    assert "instructions" in drift
+
+
+def test_synthesis_config_drift_normalises_prompts_only_not_every_string() -> None:
+    """Scope check. Core strips `instructions`/`goals` because they go through
+    the prompt library; it does not strip `agent_name` or `model`, so neither
+    does this — a trailing space in a model slug is a real difference and must
+    still be reported rather than quietly absorbed."""
+    drift = pipeline.synthesis_config_drift(
+        {**_in_step_snapshot(), "model": DEFAULT_SYNTHESIS_MODEL + " "}
+    )
+
+    assert "model" in drift
 
 
 def test_synthesis_config_drift_shortens_a_prompt_rather_than_pasting_it() -> None:

--- a/tests/test_marketing_seed_fan_in_workflow.py
+++ b/tests/test_marketing_seed_fan_in_workflow.py
@@ -385,3 +385,35 @@ def test_replace_puts_over_the_existing_definition_rather_than_creating_a_second
     assert _seed.main() == 0
     assert calls[1] == ("PUT", f"https://core.example{_seed._DEFINITIONS_PATH}/wf-1")
     assert "Replaced workflow wf-1." in capsys.readouterr().out
+
+
+def test_config_drift_agrees_with_the_run_side_detector_about_a_stripped_prompt() -> None:
+    """Issue #175's second half: the two detectors must not disagree about the
+    same config.
+
+    `--check` reads the stored *workflow definition* (unstripped) while
+    `pipeline.synthesis_config_drift` reads a *run's* snapshot (stripped by
+    Core). On 2026-08-16 they answered differently about the same workflow at
+    the same moment — `--check` said "in step", the runtime said "STALE" —
+    which is most of why the cause took a while to find.
+
+    So this side normalises too, even though it is not the side that was
+    firing: a stored config that differs only by the newline Core would strip
+    is not drift by either reading.
+    """
+    stored = definition()["action_config"]
+    assert stored["instructions"].endswith("\n"), (
+        "this test is about the trailing newline Core strips; if the declared "
+        "prompt no longer has one, keep the case but plant it explicitly"
+    )
+    as_a_run_would_hold_it = {**stored, "instructions": stored["instructions"].strip()}
+
+    assert _seed.config_drift(as_a_run_would_hold_it) == {}
+
+
+def test_config_drift_still_reports_a_prompt_whose_words_changed() -> None:
+    """The fix must not blunt the detector — whitespace is normalised, content
+    is not. This is the drift #160 exists to catch."""
+    deployed = {**definition()["action_config"], "instructions": "Summarise it. Keep it short.\n"}
+
+    assert "instructions" in _seed.config_drift(deployed)


### PR DESCRIPTION
## The bug, in one line

`RESEARCH_SYNTHESIS_INSTRUCTIONS` ends in a newline; Core strips it before a run ever sees it; the drift detector compared the two raw and reported one character of drift on **every** synthesis run, forever.

## Measured, not reasoned

On tabsii dev today, in a run **twenty minutes after a successful `--replace`**:

| | length | tail |
| --- | --- | --- |
| this repo declares | 2047 | `…discarded\nunread.\n` |
| stored in the workflow definition | **2047** | `…discarded\nunread.\n` |
| what the RUN received (`definition_snapshot`) | **2046** | `…discarded\nunread.` |

`len(declared.strip()) == 2046`. The path is `agent_runs.resolve_definition_snapshot` → `prompt_library.resolve_prompt_field` → `prompt_parts.compose`:

```python
return _PART_SEPARATOR.join(stripped for text in texts if (stripped := text.strip()))
```

A plain-string prompt is a single part, so it comes back stripped.

## Why this was worse than a false alarm

**The remedy the detector printed could not clear it.** Its message ends *"Re-seed with … `--replace`"*; re-seeding writes the newline back, Core strips it again, and the next run reports the same drift. Permanently red, by construction.

This is the only one of the three synthesis-drift checks that fires **by itself, in the environment where the drift is real** — no token, no operator, no CI. #160 exists because the other two can only report. Training people to scroll past this one costs exactly what it was built to catch.

## The fix

`definitions.as_the_runtime_stores_it` states the one transformation Core performs, beside the other beliefs-about-another-repo already in that module (the two timeout constants). Both detectors compare through it.

- **Applied to both sides**, not just the declared one — the deployed side is already stripped and `strip` is idempotent, so the comparison is symmetric by construction rather than by luck.
- **Prompt fields only** (`instructions`, `goals`). It normalises the transformation Core actually performs, not whitespace generally: a trailing space in a `model` slug is still a real difference and is still reported.
- **Not fixed in Core**, deliberately: `compose`'s stripping is documented behaviour (ADR-0015 §2) that multi-part prompts rely on, and special-casing the single-part case there is a wide blast radius for a narrow problem.
- **`config_drift` normalised too**, though it was not the side firing — it reads a stored workflow definition rather than a run, so the two detectors answered *differently about the same config at the same moment* (`--check` said "in step", the runtime said "STALE"). That disagreement is most of why this took a while to find.

## The fixture is the real story, and it is why the suite never caught this

`_in_step_snapshot()` — the "nothing has drifted" control — built its snapshot from the declaration **verbatim**. That is a snapshot Core cannot produce. So the negative control asserted "no drift" against a state one character away from every real run, and stayed green for as long as production was red.

It now models what Core stores. And it **restates the strip literally rather than calling `as_the_runtime_stores_it`**, which matters more than it looks: a fixture built from the code under test agrees with that code by construction, so removing the normalisation would silently stop the fixture normalising too and the control would go on passing.

The difference is measurable:

```
fixture calling the helper      → reverting the fix fails 2 tests (only the new ones)
fixture restating Core's strip  → reverting the fix fails 6 tests, including
                                  test_synthesis_config_drift_is_empty_for_a_freshly_seeded_workflow
                                  test_advance_research_is_quiet_when_the_engine_ran_what_this_repo_declares
```

## Tests

- `test_synthesis_config_drift_ignores_the_newline_core_itself_strips` — the regression.
- `test_synthesis_config_drift_still_catches_a_prompt_that_really_changed` — normalisation must not blunt the detector.
- `test_synthesis_config_drift_normalises_prompts_only_not_every_string` — scope: a changed `model` is still drift.
- `test_config_drift_agrees_with_the_run_side_detector_about_a_stripped_prompt` — the two detectors must not disagree.
- `test_config_drift_still_reports_a_prompt_whose_words_changed`.

845 tests pass; ruff, ruff-format, pyright and web-admin lint/typecheck/test clean.

## Not verified

**No live run has confirmed this yet** — it needs vendoring into `tabsii-platform` and a deploy, then one synthesis run that reports no drift. The claim rests on the measured lengths above and the fail-first evidence, not on a clean log line from dev.

Also unverified: whether the drift reported in #164's write-up on 2026-08-14 was this all along. The model/clock half of it was genuine; an `instructions`-only report from that period should now be re-read with suspicion.

Closes #175
