### PR TITLE
feat(channel-plan): let the agent propose a channel the operator deselected

### DIFF
--- a/src/marketing/admin_app.py
+++ b/src/marketing/admin_app.py
@@ -699,6 +699,15 @@ async def _advance_artefact(
         # increment 2). See `pipeline.extract_channel_plan` for why it must
         # be what the run was shown, not a fresh fetch.
         taxonomy = pending.get("channel_taxonomy") or {}
+        # `proposable_taxonomy` is the same snapshot for the rows the operator
+        # DESELECTED — what this run was allowed to argue for but not to plan
+        # (#67). Carried the same way and read back here for the same reason:
+        # an operator re-selecting a channel mid-flight must not turn this
+        # run's proposal of it into a plan entry. Absent — a run started
+        # before this shipped — reads as `{}`, i.e. "this run was shown
+        # nothing proposable", so an unrecognised key is still an
+        # `UnknownChannelError` exactly as it was.
+        proposable = pending.get("proposable_taxonomy") or {}
         # `allowed_motions` is the campaign's motion as it stood when this run
         # started (#67), carried the same way and for the same reason.
         # Absent — a run started before #67 shipped — reads as `None`, i.e.
@@ -724,6 +733,7 @@ async def _advance_artefact(
             # the stage share one chain.
             causation_id=artefact.get("causation_id"),
             taxonomy=taxonomy,
+            proposable=proposable,
             allowed_motions=allowed_motions,
             allowed_source_urls=allowed_source_urls,
         )

--- a/src/marketing/channel_plan_routes.py
+++ b/src/marketing/channel_plan_routes.py
@@ -161,11 +161,12 @@ async def start_channel_plan_route(
     #
     # This is what makes them constraints rather than requests. A channel the
     # operator did not select, or whose motion this campaign does not run, is
-    # simply not in the list the agent is given — and `extract_channel_plan`
-    # rejects any `channel_key` outside exactly this snapshot (#76 increment
-    # 2), so there is no path by which one reaches the plan. Nothing here
-    # relies on the model choosing to comply; #128 is this estate's evidence
-    # that a constraint the model is merely asked to respect is not one.
+    # simply not in the list the agent may plan from — and
+    # `extract_channel_plan` rejects any `channel_key` outside exactly this
+    # snapshot as a plan entry (#76 increment 2), so there is no path by which
+    # one reaches the plan. Nothing here relies on the model choosing to
+    # comply; #128 is this estate's evidence that a constraint the model is
+    # merely asked to respect is not one.
     #
     # A selected key that is no longer in the taxonomy is skipped rather than
     # rejected: the selection is a filter over the taxonomy, never a source of
@@ -173,6 +174,25 @@ async def start_channel_plan_route(
     # every campaign that had selected it.
     allowed_motions = definitions.motions_allowed_by(campaign_motion)
     selected = set(selected_keys)
+    # The MOTION filter is applied to both blocks; only the SELECTION filter
+    # tells them apart (#67, third increment). #67's section 2 is headed
+    # "shortlist, with the agent able to add", and the deselected rows below
+    # are what makes the "able to add" half reach a taxonomy channel at all —
+    # until now the agent could not name `online_communities` to argue for it,
+    # because it had never been told the key exists.
+    #
+    # Motion is NOT relaxed with the selection, and the asymmetry is
+    # deliberate. #67 settles motion as a campaign-strategy property that copy
+    # and both packs read; an organic campaign has no use for an argument to
+    # run a paid channel, and showing it one would spend a proposal slot on
+    # something the operator would have to change the campaign's strategy to
+    # accept. A deselected channel, by contrast, is a decision about THIS
+    # campaign's reach that new evidence can legitimately reopen.
+    proposable_rows = [
+        row
+        for row in channel_rows
+        if row["key"] not in selected and row["motion"] in allowed_motions
+    ]
     channel_rows = [
         row for row in channel_rows if row["key"] in selected and row["motion"] in allowed_motions
     ]
@@ -196,16 +216,27 @@ async def start_channel_plan_route(
     # operator widening a campaign from organic to both while a run is in
     # flight must not retroactively legalise a paid channel that run was
     # never allowed to pick.
-    taxonomy = [
-        {
-            "channel_key": row["key"],
-            "label": row["label"],
-            "motion": row["motion"],
-            "category": row["category"],
-        }
-        for row in channel_rows
-    ]
+    def _shown(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "channel_key": row["key"],
+                "label": row["label"],
+                "motion": row["motion"],
+                "category": row["category"],
+            }
+            for row in rows
+        ]
+
+    taxonomy = _shown(channel_rows)
     taxonomy_motions = {row["key"]: row["motion"] for row in channel_rows}
+    # Stashed beside `channel_taxonomy` and for the identical reason: an
+    # operator selecting a channel while a run is in flight must not
+    # retroactively promote that run's PROPOSAL of it into a plan entry, any
+    # more than widening the motion may retroactively legalise a paid channel.
+    # `extract_channel_plan` partitions the answer against exactly these two
+    # snapshots — see its docstring for why the model gets no vote in that.
+    proposable_taxonomy = _shown(proposable_rows)
+    proposable_motions = {row["key"]: row["motion"] for row in proposable_rows}
 
     # The stage starts with its GROUNDING run (#65): one `:online` run whose
     # job is to retrieve and to read. The planning run that turns what it
@@ -236,6 +267,7 @@ async def start_channel_plan_route(
                 pipeline.with_element_ids(
                     {
                         "channel_taxonomy": taxonomy_motions,
+                        "proposable_taxonomy": proposable_motions,
                         "allowed_motions": sorted(allowed_motions),
                         "allowed_source_urls": allowed_source_urls,
                         # What the PLANNING run will be started with, one or
@@ -250,6 +282,7 @@ async def start_channel_plan_route(
                         "plan_input": pipeline.channel_plan_input(
                             positioning_body=positioning_body,
                             taxonomy=taxonomy,
+                            proposable_taxonomy=proposable_taxonomy,
                             campaign_motion=campaign_motion,
                         ),
                     }

--- a/src/marketing/copy_routes.py
+++ b/src/marketing/copy_routes.py
@@ -102,9 +102,21 @@ async def start_copy_route(
         admin_app._parse_artefact_body(approved_positioning.get("body")),
         admin_app._artefact_selection(approved_positioning),
     )
-    channel_plan_body = pipeline.selected_body(
-        admin_app._parse_artefact_body(approved_channel_plan.get("body")),
-        admin_app._artefact_selection(approved_channel_plan),
+    # `without_proposals` (#67) narrows the same way `selected_body` does, and
+    # for the same reason: this body is BOTH the copy run's input and the basis
+    # of its citation check, so an outside-the-selection proposal must neither
+    # reach the model nor stay cite-able. See that function for why leaving it
+    # in kills the whole copy artefact rather than merely wasting output.
+    #
+    # Applied here, at the one place the approved plan is read for this stage,
+    # rather than inside `start_copy`: the citation set below is derived from
+    # this same value, and narrowing in only one of the two places is how the
+    # allowed set and the shown set drift apart.
+    channel_plan_body = pipeline.without_proposals(
+        pipeline.selected_body(
+            admin_app._parse_artefact_body(approved_channel_plan.get("body")),
+            admin_app._artefact_selection(approved_channel_plan),
+        )
     )
     # `{channel_key: motion}` for the plan's real, APPROVED entries (#76
     # increment 2, narrowed per #145) — excludes any suggested_label-only

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -346,27 +346,39 @@ class ChannelRecommendation(BaseModel):
     agent-generated name once overflowed `marketing_link.channel` (#75).
     Exactly one of `channel_key`/`suggested_label` is set — enforced below,
     not left to convention — mirroring #67's settled design: the agent picks
-    from the taxonomy it is given (`channel_key`, a real
-    `marketing_channel.key`) where it can, and may still propose a channel
-    outside that taxonomy (`suggested_label`, free text) where its evidence is
-    strong. A proposal is promoted to a real `channel_key` only on operator
-    acceptance — out of scope here, since that promotion is a UI/workflow
-    action, not a schema one.
+    from a taxonomy it is given (`channel_key`, a real `marketing_channel.key`)
+    where it can, and may still propose a channel outside every taxonomy it
+    was shown (`suggested_label`, free text) where its evidence is strong. A
+    `suggested_label` proposal is promoted to a real `channel_key` only on
+    operator acceptance — out of scope here, since that promotion is a
+    UI/workflow action, not a schema one.
+
+    ## This class does NOT say whether an entry is a plan entry or a proposal
+
+    Deliberately. Since #67's third increment the agent is shown **two**
+    taxonomies — `channel_taxonomy` (the operator's selection, which it may
+    PLAN from) and `proposable_taxonomy` (the rows the operator left out,
+    which it may only PROPOSE from) — so a `channel_key` on its own no longer
+    tells you which it is. That distinction lives in **which list of
+    :class:`ChannelPlan` the entry ends up in**, and it is decided by
+    `pipeline.extract_channel_plan` from the two stashed snapshots, never by
+    the model. See :class:`ChannelPlan` for why the answer is a position in
+    the body rather than a flag on this object.
     """
 
     channel_key: str | None = Field(
         default=None,
         description=(
-            "A `key` from the channel taxonomy you were given, when this recommendation "
-            "matches one of the available channels. Leave unset ONLY when proposing a "
-            "channel outside that taxonomy — set `suggested_label` instead, never both."
+            "A `key` copied exactly from `channel_taxonomy` or `proposable_taxonomy`, when "
+            "one of their entries fits. Leave unset ONLY when proposing a channel that is "
+            "in neither list — set `suggested_label` instead, never both."
         ),
     )
     suggested_label: str | None = Field(
         default=None,
         description=(
-            "Free-text name for a channel NOT in the taxonomy you were given, used only "
-            "when your evidence strongly supports a channel that taxonomy does not offer. "
+            "Free-text name for a channel in NEITHER list you were given, used only "
+            "when your evidence strongly supports a channel that no taxonomy entry offers. "
             "Requires operator acceptance before it becomes a real channel. Leave unset "
             "when `channel_key` is set."
         ),
@@ -413,9 +425,58 @@ class ChannelPlan(BaseModel):
     the third approval gate (M4). Organic and paid recommendations share one
     list, distinguished by `ChannelRecommendation.motion`, rather than two
     separate lists: ranking is only meaningful within a motion, and a single
-    list keeps that scoped to the field the rank is relative to."""
+    list keeps that scoped to the field the rank is relative to.
 
-    channels: list[ChannelRecommendation] = Field(default_factory=list)
+    ## Two lists, because plan-vs-proposal has to be structural (#67)
+
+    `channels` is the plan. `proposals` is what the agent argues FOR without
+    being able to put it in the plan — a channel the operator deselected, or
+    one no taxonomy entry covers at all — and an operator must accept a
+    proposal before it becomes a real channel.
+
+    Until #67's third increment the two were told apart by a field: a
+    proposal was `channel_key: null` plus a `suggested_label`, so every
+    downstream reader could ask "does it carry a `channel_key`?" and get the
+    right answer. That increment lets the agent propose a **taxonomy** channel
+    the operator deselected, which carries a perfectly real `channel_key` — so
+    that question silently starts answering "yes, an approved channel" for
+    something the operator never selected. The copy stage would then write
+    publish-ready copy for it and the packs would carry it.
+
+    Separate lists rather than a `is_proposal` flag alongside the existing
+    field, because the two fail in opposite directions. A flag fails **open**:
+    every reader that forgets it — including one written next year by someone
+    who never read this docstring — treats a proposal as an approved channel.
+    A separate list fails **closed**: a reader that only knows about
+    `channels`, which is every reader that exists today, cannot see a proposal
+    at all. `pipeline.channel_key_motions` is the chokepoint every downstream
+    stage goes through and it reads `channels`; it needed no change, and that
+    is the property being bought.
+
+    The model does not decide which list an entry lands in — see
+    `pipeline.extract_channel_plan`, which re-partitions both lists from the
+    taxonomy snapshots this run was actually shown. Putting `proposals` in the
+    output schema is how the model is *told* the distinction exists; it is not
+    how the distinction is enforced (#128: a constraint the model is merely
+    asked to respect is not a constraint).
+    """
+
+    channels: list[ChannelRecommendation] = Field(
+        default_factory=list,
+        description=(
+            "Recommendations drawn from `channel_taxonomy` — the channels the operator "
+            "selected. This is the plan."
+        ),
+    )
+    proposals: list[ChannelRecommendation] = Field(
+        default_factory=list,
+        description=(
+            "Channels you are arguing FOR but cannot plan: an entry from "
+            "`proposable_taxonomy` (a channel the operator did not select), or a "
+            "`suggested_label` for a channel in neither list. Each needs the operator's "
+            "acceptance before it becomes part of the campaign."
+        ),
+    )
 
 
 # ── How long a piece of copy is allowed to be (issue #128) ───────────────────
@@ -1031,8 +1092,13 @@ You are the campaign studio's channel strategist. You are given
 `retrieved_evidence` — the conversion evidence gathered for this campaign — one
 **approved** positioning artefact (audience segments, message pillars and calls
 to action, each carrying the sources that support it), a `campaign_motion`
-(`organic`, `paid` or `both`), and one **channel taxonomy**: a list of
-`{{channel_key, label, motion, category}}` entries.
+(`organic`, `paid` or `both`), and **two channel lists**, each a list of
+`{{channel_key, label, motion, category}}` entries:
+
+- `channel_taxonomy` — the channels the operator SELECTED for this campaign.
+  You may plan from these.
+- `proposable_taxonomy` — channels this platform offers that the operator did
+  NOT select. You may not plan from these; you may only propose them.
 
 ## `retrieved_evidence` is the list you decide from, and cite from
 
@@ -1051,11 +1117,12 @@ Among the entries you were given, prefer the specific one carrying the number �
 a benchmark report, a results write-up, a case study — over a vendor home page
 or an agency's "top 10 channels" listicle.
 
-**The taxonomy you are given is not the whole taxonomy.** It is the set of
-channels the operator selected for this campaign, already narrowed to the
-campaign's motion. Channels the operator did not select, and channels whose
-motion this campaign does not run, are simply absent from it — that is a
-decision already taken, not an omission for you to correct.
+**Neither list is the whole taxonomy.** Both are already narrowed to the
+campaign's motion, so a channel whose motion this campaign does not run is
+absent from both — that is a decision already taken, not an omission for you
+to correct. What separates the two lists is the operator's selection, and that
+separation is the whole point: `channel_taxonomy` is what this campaign will
+actually run, and `proposable_taxonomy` is what it decided against.
 
 Recommend channels for this campaign, covering the motion(s) it runs:
 1. **Organic** channels — where this audience already spends attention,
@@ -1068,23 +1135,39 @@ paid only; `both` wants both. This is enforced when your answer comes back,
 not merely requested here: a recommendation outside the campaign's motion is
 rejected and the whole plan fails with it.
 
-For EVERY recommendation, set exactly one of:
-- `channel_key` — copy it EXACTLY from the taxonomy you were given, when one
-  of its entries fits. Do not invent a key, alter one, or guess at a key that
-  looks plausible but was not in the list — an unrecognised key is rejected,
-  not silently accepted. When you set `channel_key`, leave `motion` unset:
-  it is derived from the taxonomy entry, not asserted by you.
+For EVERY recommendation, in either list, set exactly one of:
+- `channel_key` — copy it EXACTLY from `channel_taxonomy` or
+  `proposable_taxonomy`, when one of their entries fits. Do not invent a key,
+  alter one, or guess at a key that looks plausible but was in neither list —
+  an unrecognised key is rejected, not silently accepted. When you set
+  `channel_key`, leave `motion` unset: it is derived from the taxonomy entry,
+  not asserted by you.
 - `suggested_label` — free text, ONLY when the evidence strongly supports a
-  channel that genuinely is not in the taxonomy you were given. This is a
-  proposal, not a plan entry: an operator must accept it before it becomes a
-  real channel. When you use `suggested_label`, you MUST also set `motion`
-  yourself, since there is no taxonomy entry to derive it from — and that
-  motion must be one the campaign runs, or the plan is rejected.
+  channel that is in neither list. When you use `suggested_label`, you MUST
+  also set `motion` yourself, since there is no taxonomy entry to derive it
+  from — and that motion must be one the campaign runs, or the plan is
+  rejected.
 
-Prefer the taxonomy. Reach for `suggested_label` only when nothing in the
-taxonomy is a genuine fit for what the evidence supports — not as a shortcut
-around checking the list first, and never to re-propose a channel the
-operator has already left out for a reason you cannot see.
+Then put each recommendation in the right list:
+
+- `channels` — the plan. Only `channel_taxonomy` entries belong here.
+- `proposals` — things the operator has to accept before they are real: a
+  `proposable_taxonomy` entry, or a `suggested_label`. Nothing here is
+  planned, no copy is written for it, and it appears in no pack until an
+  operator accepts it.
+
+Which list an entry belongs in is worked out from the two taxonomies when your
+answer comes back, not taken from where you put it — so putting a
+`proposable_taxonomy` channel in `channels` does not get it planned, it simply
+makes your answer harder to read. Sort them correctly.
+
+**Propose sparingly, and only on the evidence.** A `proposable_taxonomy`
+channel is one the operator decided against, for reasons you cannot see;
+proposing it is worth an operator's attention only when `retrieved_evidence`
+says something specific and strong about it that they may not have known. A
+list of everything they left out is worth nothing. Prefer planning well within
+the selection over arguing to widen it, and reach for `suggested_label` last —
+only when nothing in EITHER list is a genuine fit.
 
 Rank the channels within each motion (1 = highest priority) and give each a
 rationale an operator can disagree with: name the conversion evidence from
@@ -1123,6 +1206,11 @@ question, and is rejected along with the whole plan. If nothing in
 `retrieved_evidence` speaks to a channel's performance for this audience, do
 not recommend that channel — leave it out rather than reach for the
 positioning to dress it up.
+
+This applies to `proposals` exactly as it does to `channels`, and the whole
+plan fails on either. Asking an operator to reconsider a channel they already
+decided against, with nothing retrieved behind it, is the least defensible
+thing this run can produce.
 
 For `note`, do not paste the positioning item's note verbatim — your
 `rationale` already says why this channel follows from the evidence, so repeat

--- a/src/marketing/pipeline.py
+++ b/src/marketing/pipeline.py
@@ -86,6 +86,7 @@ from .definitions import (
     ChannelCopy,
     ChannelEvidenceSet,
     ChannelPlan,
+    ChannelRecommendation,
     CopyField,
     CopySet,
     LengthOverage,
@@ -781,6 +782,24 @@ def retrieved_evidence(
     return handed
 
 
+def all_recommendations(plan: ChannelPlan) -> list[ChannelRecommendation]:
+    """Every recommendation the run produced, planned or proposed (#67).
+
+    The one place this module flattens :class:`~marketing.definitions.ChannelPlan`'s
+    two lists, and it exists so that the flattening is a deliberate act with a
+    name rather than a `[*plan.channels, *plan.proposals]` someone writes from
+    memory. The lists are separate precisely so that a reader who wants only
+    the plan gets only the plan by default (see :class:`ChannelPlan`); the
+    questions that legitimately span both are the ones asked of the run rather
+    than of the campaign — is every recommendation grounded, and what did this
+    artefact cite — and they are asked here.
+
+    Order is plan-then-proposals, so an error naming the first offender names a
+    real plan entry before a proposal when both are wrong.
+    """
+    return [*plan.channels, *plan.proposals]
+
+
 def _require_retrieved_evidence(
     plan: ChannelPlan, *, retrieved_source_urls: Collection[str]
 ) -> None:
@@ -804,7 +823,7 @@ def _require_retrieved_evidence(
     allowed = {_url_key(url) for url in retrieved_source_urls}
     ungrounded = [
         recommendation.channel_key or recommendation.suggested_label or "(unnamed channel)"
-        for recommendation in plan.channels
+        for recommendation in all_recommendations(plan)
         if not any(_url_key(source.url) in allowed for source in recommendation.sources)
     ]
     if not ungrounded:
@@ -832,6 +851,7 @@ def extract_channel_plan(
     messages: list[dict[str, Any]],
     *,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    proposable: Mapping[str, Literal["organic", "paid"]] | None = None,
     allowed_motions: Collection[str] | None = None,
     allowed_source_urls: Collection[str] | None = None,
     annotations: list[dict[str, Any]] | None = None,
@@ -904,6 +924,51 @@ def extract_channel_plan(
     the agent stops asserting motion independently for a real channel, full
     stop, regardless of what it put in the field.
 
+    ## Where this function decides plan-versus-proposal (#67, third increment)
+
+    ``proposable`` is the second ``{channel_key: motion}`` snapshot — the
+    taxonomy rows the operator **deselected**, which this run was shown in a
+    separate block it may only propose from. It is stashed at start time for
+    the identical reason ``taxonomy`` is, and an operator re-selecting a
+    channel mid-flight must no more retroactively promote a proposal than a
+    widened motion may retroactively legalise a paid channel.
+
+    Every recommendation, from **either** of the model's two lists, is then
+    re-partitioned here, by which snapshot its key is in:
+
+    - key in ``taxonomy`` — a plan entry, in ``plan.channels``.
+    - key in ``proposable`` — a **proposal**, in ``plan.proposals``, whatever
+      list the model put it in and whatever it wrote in ``motion``.
+    - key in neither — :class:`UnknownChannelError`, unchanged.
+    - no key at all (``suggested_label``) — a proposal, unchanged.
+
+    **The model does not get a vote on which list an entry lands in**, and
+    that is the point. #128 is this estate's evidence that a constraint the
+    model is merely asked to respect is not one, and this is the same lever
+    ``motion`` already uses one paragraph up: derived from the snapshot, never
+    read back from what the model asserted. A model that puts a deselected
+    channel in ``channels`` gets it moved, not honoured — so the operator's
+    selection remains an enforcement even though the deselected rows are now
+    visible to the run.
+
+    Why this partition is what makes showing the deselected rows safe at all:
+    before it, "carries a ``channel_key``" meant "is an approved channel", and
+    every downstream reader was written on that basis
+    (:func:`channel_key_motions` and everything through it). A proposal
+    carrying a real key would have flowed straight into the copy stage and the
+    packs — publish-ready copy for a channel the operator never selected. The
+    two lists move that distinction out of a field's nullness and into the
+    shape of the body, where a reader cannot fail to observe it by forgetting
+    to look. See :class:`~marketing.definitions.ChannelPlan` for why a flag
+    was rejected.
+
+    ``proposable=None`` — a run started before this increment — means "this
+    run was shown no proposable rows", so nothing can be in that set and every
+    unrecognised key is still an :class:`UnknownChannelError`. Unlike
+    ``allowed_motions``, there is no tri-state to preserve: an empty proposable
+    set is not a rule being skipped, it is the honest description of a run that
+    was only ever shown one list.
+
     ``allowed_motions`` is the campaign's own motion widened to channel
     motions (#67) — ``{"organic"}``, ``{"paid"}`` or both, from
     :func:`~marketing.definitions.motions_allowed_by`, stashed on the pending
@@ -950,7 +1015,7 @@ def extract_channel_plan(
         ),
         tool_name=CHANNEL_PLAN_TOOL_NAME,
         model_cls=ChannelPlan,
-        citation_groups=lambda r: [c.sources for c in r.channels],
+        citation_groups=lambda r: [c.sources for c in all_recommendations(r)],
         malformed_message=f"the channel-plan run produced no {CHANNEL_PLAN_TOOL_NAME} tool call",
         no_citations_message=(
             "The channel-plan run cited nothing at all — neither its own search results "
@@ -962,30 +1027,54 @@ def extract_channel_plan(
     if retrieved is not None:
         _require_retrieved_evidence(plan, retrieved_source_urls=retrieved)
     permitted = None if allowed_motions is None else frozenset(allowed_motions)
-    for recommendation in plan.channels:
+    proposable_motions: dict[str, Literal["organic", "paid"]] = dict(proposable or {})
+    planned: list[ChannelRecommendation] = []
+    proposed: list[ChannelRecommendation] = []
+    # Read off the model's two lists and thrown away immediately — the
+    # partition below is rebuilt from the snapshots, so where the model filed
+    # an entry never survives this function.
+    for recommendation in all_recommendations(plan):
         if recommendation.channel_key is None:
-            # A `suggested_label` proposal. `motion` is the agent's own — the
-            # model validator already requires it — so this is where the
-            # campaign's motion has to be enforced against the model.
+            # A `suggested_label` proposal for something in neither snapshot.
+            # `motion` is the agent's own — the model validator already
+            # requires it — so this is where the campaign's motion has to be
+            # enforced against the model.
             if permitted is not None and recommendation.motion not in permitted:
                 raise MotionNotAllowedError(
                     f"The channel-plan run proposed {recommendation.suggested_label!r} as a "
                     f"{recommendation.motion} channel, but this campaign runs "
                     f"{'/'.join(sorted(permitted))} channels only."
                 )
+            proposed.append(recommendation)
             continue
-        if recommendation.channel_key not in taxonomy:
+        is_proposal = recommendation.channel_key not in taxonomy
+        if is_proposal and recommendation.channel_key not in proposable_motions:
             raise UnknownChannelError(
                 f"The channel-plan run referenced channel_key {recommendation.channel_key!r}, "
-                "which was not in the taxonomy it was given."
+                "which was in neither the taxonomy nor the proposable channels it was given."
             )
-        motion = taxonomy[recommendation.channel_key]
+        motion = (
+            proposable_motions[recommendation.channel_key]
+            if is_proposal
+            else taxonomy[recommendation.channel_key]
+        )
         if permitted is not None and motion not in permitted:
+            # Defence in depth against a caller that filtered its snapshots
+            # wrongly, not against the model — and it applies to the proposable
+            # snapshot exactly as to the selected one. The motion is #67's
+            # OTHER operator decision, and relaxing the selection into
+            # "proposable" must not quietly relax the motion with it: an
+            # organic campaign is never shown a paid row in either block, so
+            # one reaching here means the route built the wrong set.
             raise MotionNotAllowedError(
-                f"The channel-plan run recommended {recommendation.channel_key!r}, a {motion} "
-                f"channel, but this campaign runs {'/'.join(sorted(permitted))} channels only."
+                f"The channel-plan run {'proposed' if is_proposal else 'recommended'} "
+                f"{recommendation.channel_key!r}, a {motion} channel, but this campaign runs "
+                f"{'/'.join(sorted(permitted))} channels only."
             )
         recommendation.motion = motion  # derived, not asserted
+        (proposed if is_proposal else planned).append(recommendation)
+    plan.channels = planned
+    plan.proposals = proposed
     return plan
 
 
@@ -1072,7 +1161,12 @@ def flatten_citations(
             *(c.sources for c in output.ctas),
         ]
     elif isinstance(output, ChannelPlan):
-        groups = [c.sources for c in output.channels]
+        # Both lists (#67). This column answers "what did this artefact cite",
+        # a question about the run rather than about the campaign, and a
+        # proposal an operator has yet to accept was still argued from sources
+        # — omitting them would make the citation count disagree with the
+        # artefact an operator is looking at.
+        groups = [c.sources for c in all_recommendations(output)]
     elif isinstance(output, CopySet):
         groups = [c.sources for c in output.channels]
     else:
@@ -1122,7 +1216,24 @@ def flatten_citations(
 #: has none of these keys, so every function below is a no-op on it, and a
 #: stage added later that carries a new list of selectable things needs only
 #: to be named here — not to teach every call site about a new `kind`.
-ELEMENT_LIST_KEYS: tuple[str, ...] = ("findings", "segments", "pillars", "ctas", "channels")
+#:
+#: `proposals` (#67) is a channel plan's second list, and it is here for the
+#: same reason `channels` is: its entries carry `sources`, so they must be in
+#: `source_urls_from_body`'s union or a selection would silently narrow the
+#: next stage's citable set by a source a kept element still relies on — the
+#: exact failure that function's docstring warns about. That the two lists are
+#: BOTH selectable is not the same as their being interchangeable: everything
+#: downstream of the approval gate reads `channels` alone (see
+#: `channel_key_motions`), so selecting a proposal keeps it visible on the
+#: approved artefact without making it a channel.
+ELEMENT_LIST_KEYS: tuple[str, ...] = (
+    "findings",
+    "segments",
+    "pillars",
+    "ctas",
+    "channels",
+    "proposals",
+)
 
 
 def with_element_ids(body: Mapping[str, Any]) -> dict[str, Any]:
@@ -1192,6 +1303,29 @@ def selected_body(body: Mapping[str, Any], element_ids: Collection[str] | None) 
             item for item in items if isinstance(item, dict) and item.get("id") in wanted
         ]
     return narrowed
+
+
+def without_proposals(body: Mapping[str, Any]) -> dict[str, Any]:
+    """``body`` with a channel plan's ``proposals`` list removed (#67) — what
+    a DOWNSTREAM stage is handed, as opposed to what an operator reviews.
+
+    The separate list makes a proposal invisible to every reader that asks for
+    ``channels``, but the copy run is handed the plan artefact's body *whole*,
+    so without this it would see the proposals as prose and could write copy
+    for one. That copy is then rejected by :func:`extract_copy`'s
+    ``channel_plan_channels`` check — fatally, taking the whole artefact with
+    it, because this pipeline's outputs are all-or-nothing. So the failure mode
+    here is not "a proposal sneaks into a pack" but "a campaign's copy stage
+    dies on a channel the operator was only being asked about", which is worse
+    than it sounds: nothing in the resulting error points at the proposal.
+
+    Narrowing the input is also the same lever #67 uses everywhere else — the
+    channel-plan run cannot pick an unselected channel because it is not shown
+    one — rather than a fifth thing the prompt asks a model to remember.
+
+    A no-op on every other body: nothing but a channel plan has this key.
+    """
+    return {key: value for key, value in body.items() if key != "proposals"}
 
 
 def source_urls_from_body(body: Mapping[str, Any]) -> list[str]:
@@ -2037,6 +2171,7 @@ def channel_plan_input(
     *,
     positioning_body: dict[str, Any],
     taxonomy: list[dict[str, Any]],
+    proposable_taxonomy: list[dict[str, Any]] | None = None,
     campaign_motion: str,
 ) -> dict[str, Any]:
     """Everything the planning run needs beyond the evidence itself.
@@ -2048,10 +2183,26 @@ def channel_plan_input(
     ``channel_taxonomy`` already is — it must be what THIS stage was started
     against, not whatever the positioning or the taxonomy has been changed to
     by the time the grounding run finishes.
+
+    ``proposable_taxonomy`` (#67) is the deselected rows, in their own
+    clearly-labelled block. Two lists rather than one flagged list, because
+    what the run may PLAN from and what it may only PROPOSE from are different
+    permissions, and the block boundary is the only part of that the model can
+    see. Which one an answer actually lands in is decided afterwards from these
+    same two sets — :func:`extract_channel_plan` — so this block is how the run
+    is told the option exists, never how the operator's selection is enforced.
+
+    It rides in the PLANNING run's payload only, never the grounding run's:
+    #65 measured that everything in an ``:online`` payload steers retrieval,
+    and #67 is explicit that search budget should not be spent on channels the
+    operator has already ruled out. A proposal therefore has to be grounded in
+    what a search aimed at the *selected* channels happened to turn up, which
+    is the right bar for asking an operator to reconsider.
     """
     return {
         "positioning": positioning_body,
         "channel_taxonomy": taxonomy,
+        "proposable_taxonomy": list(proposable_taxonomy or []),
         "campaign_motion": campaign_motion,
     }
 
@@ -2235,6 +2386,7 @@ async def advance_channel_plan(
     *,
     evidence_run_id: str,
     taxonomy: dict[str, Literal["organic", "paid"]],
+    proposable: Mapping[str, Literal["organic", "paid"]] | None = None,
     plan_run_id: str | None = None,
     plan_input: Mapping[str, Any] | None = None,
     causation_id: str | None = None,
@@ -2254,8 +2406,9 @@ async def advance_channel_plan(
     ``plan_input`` is :func:`channel_plan_input`'s dict, stashed at start time
     for the reason that function's docstring gives. ``taxonomy`` is
     ``{channel_key: motion}`` for exactly the taxonomy the stage was started
-    against, and ``allowed_motions`` the campaign motion it was started under
-    (#67) — see :func:`extract_channel_plan` for how they and
+    against, ``proposable`` the same for the deselected rows it was allowed to
+    propose from, and ``allowed_motions`` the campaign motion it was started
+    under (#67) — see :func:`extract_channel_plan` for how they and
     ``allowed_source_urls`` are used.
 
     ## The guard's subject is the run that RETRIEVED
@@ -2334,6 +2487,7 @@ async def advance_channel_plan(
         plan=extract_channel_plan(
             plan_view.messages,
             taxonomy=taxonomy,
+            proposable=proposable,
             allowed_motions=allowed_motions,
             allowed_source_urls=allowed_source_urls,
             annotations=evidence_view.annotations,
@@ -2412,7 +2566,24 @@ async def advance_copy(
 def channel_key_motions(
     channel_plan_body: dict[str, Any],
 ) -> dict[str, Literal["organic", "paid"]]:
-    """``{channel_key: motion}`` for the entries that carry a key. Never raises.
+    """``{channel_key: motion}`` for the plan entries that carry a key. Never
+    raises.
+
+    **Reads ``channels`` only, never ``proposals`` (#67).** This is the
+    chokepoint every downstream stage goes through — copy, and through copy the
+    distribution and paid packs — so it is the one place "an approved channel"
+    is turned back into a set of keys, and a proposal must not be in it.
+
+    That exclusion is structural rather than filtered. Since #67's third
+    increment a proposal can carry a perfectly real ``channel_key`` (a taxonomy
+    row the operator deselected), so the ``if c.get("channel_key")`` below is
+    no longer what excludes it — the key it reads from is. A reader that knows
+    nothing about proposals gets the plan, which is the failure direction to
+    be in: forgetting `proposals` exists costs a proposal being invisible,
+    where a forgotten ``is_proposal`` filter would have cost publish-ready copy
+    for a channel the operator never selected. The remaining
+    ``if c.get("channel_key")`` guard is for the legacy shape, where a
+    proposal did live in ``channels`` with no key.
 
     Split out of :func:`channel_plan_channel_map` for issue #152. That function
     answers TWO questions at once — "is this plan stale?" and "what are its
@@ -2442,13 +2613,21 @@ def channel_plan_channel_map(
     channel_plan_body: dict[str, Any],
 ) -> dict[str, Literal["organic", "paid"]]:
     """``{channel_key: motion}`` for an approved channel plan's real entries
-    (#76 increment 2) — those carrying a ``channel_key``. A
-    ``suggested_label``-only proposal is excluded: it is not a real channel
-    until an operator accepts it, so copy must not be written for it yet.
+    (#76 increment 2) — those in ``channels`` carrying a ``channel_key``.
+    Every proposal is excluded, whether it names a taxonomy channel the
+    operator deselected or only a ``suggested_label``: it is not a channel of
+    this campaign's until an operator accepts it, so copy must not be written
+    for it yet. See :func:`channel_key_motions` for why that exclusion is a
+    matter of which list is read rather than which field is set.
 
-    Raises :class:`StaleChannelPlanError` when the plan has entries but NONE
-    of them carry a ``channel_key`` — every entry is the pre-#76 free-text
-    shape (``{"channel": ..., "motion": ...}``, no id at all). This is the
+    Raises :class:`StaleChannelPlanError` when the plan has ``channels``
+    entries but NONE of them carry a ``channel_key`` — every entry is the
+    pre-#76 free-text shape (``{"channel": ..., "motion": ...}``, no id at
+    all). Since #67's third increment that signal is sharper than it was: a
+    keyless entry can no longer legitimately appear in ``channels`` at all, so
+    one that does really is a pre-taxonomy plan rather than a current plan
+    whose only surviving entry is a proposal — which is the mis-diagnosis #152
+    had to work around. This is the
     explicit answer to "what happens to dev's existing approved plans/copy":
     rather than silently building a copy run with nothing to reference, or a
     bare ``KeyError``, this campaign needs channel planning re-run before

--- a/tests/test_marketing_campaign_targeting.py
+++ b/tests/test_marketing_campaign_targeting.py
@@ -236,13 +236,20 @@ def _approve_positioning(client: TestClient, gateway: _FakeGateway, core: _FakeC
     }
 
 
-def _plan_call(channels: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _plan_call(
+    channels: list[dict[str, Any]], proposals: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
+    """The planning run's answer. `proposals` is the model's own filing of what
+    it thinks is a proposal — which `extract_channel_plan` re-derives rather
+    than believes, so several tests below pass entries in the WRONG list
+    deliberately."""
+    arguments: dict[str, Any] = {"channels": channels}
+    if proposals is not None:
+        arguments["proposals"] = proposals
     return [
         {
             "role": "assistant",
-            "tool_calls": [
-                {"function": {"name": "submit_channel_plan", "arguments": {"channels": channels}}}
-            ],
+            "tool_calls": [{"function": {"name": "submit_channel_plan", "arguments": arguments}}],
         }
     ]
 
@@ -497,7 +504,11 @@ def test_a_proposal_within_the_campaign_motion_is_kept(
 ) -> None:
     """#67 keeps the agent able to propose outside the operator's selection —
     the constraint is the motion and the taxonomy, not the ability to
-    suggest."""
+    suggest.
+
+    It lands in `proposals`, not `channels`, even though the model put it in
+    `channels`: the plan is what the campaign will run, and a proposal is not
+    part of it until an operator accepts it."""
     core = _FakeCore(motion="organic")
     gateway = _FakeGateway()
     client = _client(core, gateway, monkeypatch)
@@ -519,9 +530,11 @@ def test_a_proposal_within_the_campaign_motion_is_kept(
     )
 
     assert resp.status_code == 200
-    (channel,) = json.loads(resp.json()["body"])["channels"]
-    assert channel["suggested_label"] == "Regional franchise forum"
-    assert channel["channel_key"] is None
+    body = json.loads(resp.json()["body"])
+    assert body["channels"] == []
+    (proposal,) = body["proposals"]
+    assert proposal["suggested_label"] == "Regional franchise forum"
+    assert proposal["channel_key"] is None
 
 
 def test_extract_channel_plan_rejects_a_taxonomy_row_outside_the_allowed_motions() -> None:
@@ -572,6 +585,289 @@ def test_a_legacy_pending_artefact_still_advances(monkeypatch: pytest.MonkeyPatc
     )
 
     assert resp.status_code == 200
+
+
+# ── The agent may PROPOSE from what the operator deselected (#67) ────────────
+#
+# #67's section 2 is headed "shortlist, with the agent able to add", and until
+# now the "able to add" half could not reach a taxonomy channel at all: the run
+# is shown only the selected rows, so it had no way to name `linkedin_organic`
+# to argue for it, and the only outside route left was free text for a channel
+# the taxonomy did not cover.
+#
+# The middle option #67's last comment describes is what these tests pin. The
+# deselected rows are shown in a SEPARATE block the run may only propose from,
+# so:
+#
+# - the selection is still an enforcement, not a request — the plan-from set is
+#   unchanged, and nothing here relaxes it;
+# - "is this a plan entry or a proposal?" is answered by which LIST the entry
+#   comes back in, never by whether it carries a `channel_key`. That inversion
+#   is the whole risk of this change: a proposal now carries a perfectly real
+#   key, and every downstream reader was written when "carries a key" meant
+#   "approved channel".
+
+
+def _selected_only(*keys: str) -> _FakeCore:
+    return _FakeCore(target_channel_keys=",".join(keys))
+
+
+def _payload_of(gateway: _FakeGateway, agent_name: str) -> dict[str, Any]:
+    """The one run of `agent_name` this gateway was asked for, by name.
+
+    By name rather than by "which payload has a `channel_taxonomy` key", which
+    is what the older tests in this module filter on: BOTH runs of the channel
+    stage carry that key, and so — for `brief` — does every research run.
+    """
+    (run,) = [r for r in gateway.requested if r["agent_name"] == agent_name]
+    return run["input_payload"]
+
+
+def test_the_planning_run_is_shown_the_deselected_rows_in_their_own_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two blocks, disjoint, and the plan-from block is still exactly the
+    selection. A single flagged list would have put the deselected rows where
+    the run reads its plan-from set."""
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    # The planning run is started by the FIRST advance, not by the route (#65),
+    # so drive the grounding run to done before reading its payload.
+    gateway.complete(started["agent_run_id"], messages=_evidence_call())
+    client.get(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan")
+
+    payload = _payload_of(gateway, definitions.CHANNEL_PLAN_AGENT_NAME)
+    assert [c["channel_key"] for c in payload["channel_taxonomy"]] == ["instagram_organic"]
+    assert [c["channel_key"] for c in payload["proposable_taxonomy"]] == [
+        "linkedin_organic",
+        "google_search_paid",
+    ]
+    # Stashed on the pending artefact at START time, not re-fetched when the
+    # run comes back — an operator selecting `linkedin_organic` while this run
+    # is in flight must not turn its PROPOSAL of that channel into a plan
+    # entry, exactly as widening the motion must not legalise a paid one.
+    stashed = json.loads(started["body"])
+    assert stashed["channel_taxonomy"] == {"instagram_organic": "organic"}
+    assert stashed["proposable_taxonomy"] == {
+        "linkedin_organic": "organic",
+        "google_search_paid": "paid",
+    }
+
+
+def test_the_grounding_run_is_not_shown_the_deselected_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#65 measured that everything in an `:online` run's payload steers what
+    comes back, and #67 is explicit that search budget must not be spent on
+    channels that were never available. So the proposable block rides in the
+    PLANNING run's payload only."""
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    client.post(f"/campaigns/{_CAMPAIGN}/channel-plan")
+
+    payload = _payload_of(gateway, definitions.CHANNEL_EVIDENCE_AGENT_NAME)
+    assert "proposable_taxonomy" not in payload
+    assert [c["channel_key"] for c in payload["channel_taxonomy"]] == ["instagram_organic"]
+
+
+def test_a_deselected_channel_comes_back_as_a_proposal_not_a_plan_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clause #67 was held open for, and the sharp edge of building it.
+
+    The run names a real `channel_key` the operator deselected. Before this
+    increment that was an `UnknownChannelError`; it must now be a proposal —
+    and it must NOT be in `channels`, because everything downstream of the
+    approval gate reads that list as the campaign's approved channels.
+    """
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call(
+            [_recommendation()],
+            [_recommendation(channel_key="linkedin_organic", rank=2)],
+        ),
+    )
+
+    assert resp.status_code == 200
+    body = json.loads(resp.json()["body"])
+    assert [c["channel_key"] for c in body["channels"]] == ["instagram_organic"]
+    (proposal,) = body["proposals"]
+    assert proposal["channel_key"] == "linkedin_organic"
+    # Motion is derived from the proposable snapshot, exactly as a plan entry's
+    # is from the selected one — the model asserts neither.
+    assert proposal["motion"] == "organic"
+
+
+def test_the_snapshot_decides_which_list_an_entry_lands_in_not_the_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#128: a constraint the model is merely asked to respect is not one. So
+    the model's own filing is thrown away and both lists are rebuilt from the
+    two snapshots — here from an answer that got both entries backwards."""
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call(
+            # A DESELECTED channel filed as a plan entry...
+            [_recommendation(channel_key="linkedin_organic")],
+            # ...and a SELECTED one filed as a proposal.
+            [_recommendation(channel_key="instagram_organic", rank=2)],
+        ),
+    )
+
+    assert resp.status_code == 200
+    body = json.loads(resp.json()["body"])
+    assert [c["channel_key"] for c in body["channels"]] == ["instagram_organic"]
+    assert [c["channel_key"] for c in body["proposals"]] == ["linkedin_organic"]
+
+
+def test_a_key_in_neither_block_is_still_an_unknown_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The third case, unchanged. Widening what the run may name must not
+    become "the run may name anything" — an invented or mangled key is still
+    fatal to the whole plan."""
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call([_recommendation()], [_recommendation(channel_key="tiktok_organic", rank=2)]),
+    )
+
+    assert resp.status_code == 502
+    assert "tiktok_organic" in resp.json()["detail"]
+    assert core.artefacts[started["id"]]["status"] == "pending"
+
+
+def test_a_deselected_row_outside_the_campaign_motion_is_not_proposable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The selection is relaxed into "proposable"; the MOTION is not.
+
+    #67 settles motion as a campaign-strategy property that copy and both packs
+    read, so an organic campaign has no use for an argument to run a paid
+    channel — accepting it would mean changing the campaign's strategy, not its
+    channel list. A deselected channel of the RIGHT motion is a decision new
+    evidence can legitimately reopen, and it is proposable.
+    """
+    core = _FakeCore(motion="organic", target_channel_keys="instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+
+    assert json.loads(started["body"])["proposable_taxonomy"] == {"linkedin_organic": "organic"}
+
+
+def test_a_proposal_never_becomes_a_channel_the_copy_stage_writes_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """**The guard this whole change turns on.**
+
+    A proposal carries a real `channel_key` now, and `pipeline.channel_key_motions`
+    — the chokepoint copy and, through copy, both packs go through — used to
+    mean "every entry with a key". If a proposal stayed in `channels`, the copy
+    stage would write publish-ready copy for a channel the operator never
+    selected and the packs would carry it.
+
+    Driven through the real approval and copy routes rather than asserted on
+    the helper, because the helper being right is not the claim — the claim is
+    that nothing between the plan and the copy run puts it back.
+    """
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    plan = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call(
+            [_recommendation()],
+            [_recommendation(channel_key="linkedin_organic", rank=2)],
+        ),
+    ).json()
+    assert plan["status"] == "proposed"
+    client.post(f"/campaigns/{_CAMPAIGN}/artefacts/channel_plan/approve")
+
+    copy_started = client.post(f"/campaigns/{_CAMPAIGN}/copy")
+
+    assert copy_started.status_code == 201
+    # What `extract_copy` will validate the copy run's answer against.
+    stashed = json.loads(copy_started.json()["body"])
+    assert stashed["channel_plan_channels"] == {"instagram_organic": "organic"}
+    # And the copy run is not shown the proposal at all — #67's own lever,
+    # applied one stage down: a model that cannot see a channel cannot write
+    # for it, so nothing here rests on the prompt asking it not to.
+    shown = _payload_of(gateway, definitions.COPY_AGENT_NAME)["channel_plan"]
+    assert [c["channel_key"] for c in shown["channels"]] == ["instagram_organic"]
+    assert "proposals" not in shown
+
+
+def test_a_pending_artefact_from_before_proposals_still_advances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run started before this increment stashed no `proposable_taxonomy`,
+    and was genuinely shown nothing proposable — so an unrecognised key stays
+    an `UnknownChannelError` rather than becoming a proposal by default.
+
+    Unlike `allowed_motions`, absence here is not a rule being skipped: there
+    is no tri-state to preserve, because an empty proposable set is the honest
+    description of that run.
+    """
+    core = _selected_only("instagram_organic")
+    gateway = _FakeGateway()
+    client = _client(core, gateway, monkeypatch)
+    _approve_positioning(client, gateway, core)
+    started = client.post(f"/campaigns/{_CAMPAIGN}/channel-plan").json()
+    legacy = json.loads(core.artefacts[started["id"]]["body"])
+    legacy.pop("proposable_taxonomy", None)
+    core.artefacts[started["id"]]["body"] = json.dumps(legacy)
+
+    resp = _plan_through_both_runs(
+        client,
+        core,
+        gateway,
+        started,
+        _plan_call([_recommendation(), _recommendation(channel_key="linkedin_organic", rank=2)]),
+    )
+
+    assert resp.status_code == 502
+    assert "linkedin_organic" in resp.json()["detail"]
 
 
 def test_channel_plan_still_404s_an_unknown_campaign(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_marketing_channel_plan_grounding.py
+++ b/tests/test_marketing_channel_plan_grounding.py
@@ -472,6 +472,56 @@ def test_the_grounding_check_is_skipped_when_retrieval_is_not_known() -> None:
     assert plan.channels[0].channel_key == "google_search_paid"
 
 
+def test_an_ungrounded_proposal_fails_the_plan_exactly_as_a_channel_does() -> None:
+    """#67's third increment gave the run a second list to answer in, and a
+    guard that only walked the first would have exempted it.
+
+    A proposal is where an ungrounded recommendation costs most, not least:
+    the operator already decided against this channel, so the ONLY thing that
+    justifies putting it back in front of them is evidence they have not seen.
+    `all_recommendations` is what makes the guard span both lists.
+    """
+    messages = _tool_call(
+        {
+            "channels": [_channel("google_search_paid", _RETRIEVED_URL)],
+            "proposals": [_channel("linkedin_organic", _PARENT_URL)],
+        }
+    )
+
+    with pytest.raises(pipeline.UngroundedRecommendationError) as excinfo:
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy={"google_search_paid": "paid"},
+            proposable={"linkedin_organic": "organic"},
+            allowed_source_urls=[_PARENT_URL],
+            annotations=_ANNOTATIONS,
+        )
+
+    assert "linkedin_organic" in str(excinfo.value)
+
+
+def test_a_proposals_fabricated_source_is_refused_like_any_other() -> None:
+    """The provenance half of the same point. A URL in neither the parent nor
+    the runtime's retrieval record was read by nothing, and that sentence does
+    not become less true because the recommendation carrying it is only a
+    proposal."""
+    messages = _tool_call(
+        {
+            "channels": [_channel("google_search_paid", _RETRIEVED_URL)],
+            "proposals": [_channel("linkedin_organic", _FABRICATED_URL)],
+        }
+    )
+
+    with pytest.raises(pipeline.UncitedSourceError):
+        pipeline.extract_channel_plan(
+            messages,
+            taxonomy={"google_search_paid": "paid"},
+            proposable={"linkedin_organic": "organic"},
+            allowed_source_urls=[_PARENT_URL],
+            annotations=_ANNOTATIONS,
+        )
+
+
 def test_an_ungrounded_recommendation_is_a_pipeline_error() -> None:
     """`admin_app._pipeline_error_to_http` maps the BASE class, so a new error
     type that missed it would fall through as a bare 500 rather than the 502

--- a/tests/test_marketing_element_ids.py
+++ b/tests/test_marketing_element_ids.py
@@ -32,9 +32,13 @@ def _source(url: str) -> dict[str, str]:
 
 def test_with_element_ids_stamps_every_known_list() -> None:
     """One id per element, across every list this plugin's artefact kinds
-    actually use — proven for all five at once rather than one at a time, so
+    actually use — proven for all six at once rather than one at a time, so
     a future kind added to `ELEMENT_LIST_KEYS` without a matching branch here
-    is caught the moment this test is extended, not silently skipped."""
+    is caught the moment this test is extended, not silently skipped.
+
+    It did exactly that when `proposals` was added (#67): this test failed with
+    `KeyError: 'proposals'` before a line of it was touched, which is the
+    behaviour the docstring above promises."""
     body = {
         "summary": "irrelevant to ids",
         "findings": [{"signal": "s", "sources": [_source("https://a.example")]}],
@@ -42,6 +46,7 @@ def test_with_element_ids_stamps_every_known_list() -> None:
         "pillars": [{"pillar": "p", "sources": [_source("https://c.example")]}],
         "ctas": [{"text": "cta", "sources": [_source("https://d.example")]}],
         "channels": [{"channel_key": "x", "sources": [_source("https://e.example")]}],
+        "proposals": [{"channel_key": "y", "sources": [_source("https://f.example")]}],
     }
 
     stamped = with_element_ids(body)
@@ -163,6 +168,44 @@ def test_selected_body_leaves_non_element_keys_untouched() -> None:
 
     assert narrowed["summary"] == "kept verbatim"
     assert narrowed["findings"] == []
+
+
+def test_a_channel_plan_proposal_is_a_first_class_selectable_element() -> None:
+    """`proposals` (#67) has to be in `ELEMENT_LIST_KEYS`, and this is the
+    test that says so — the two guards it would otherwise fall between both
+    pass without it.
+
+    `test_with_element_ids_stamps_every_known_list` iterates
+    `ELEMENT_LIST_KEYS` itself, so a key missing from that tuple is a key it
+    never checks. And `selected_body` only filters the lists it knows about,
+    so an unlisted `proposals` is not "not selectable" — it is passed through
+    WHOLE on every narrowed body, surviving a selection that dropped it, while
+    `approve_artefact_route` rejects its id as unknown. The operator's
+    selection and what the artefact carries then disagree, silently.
+
+    Asserted end to end over the three functions rather than on the tuple's
+    contents, because the tuple being right is not the claim.
+    """
+    body = with_element_ids(
+        {
+            "channels": [{"channel_key": "instagram_organic", "sources": [_source("https://a")]}],
+            "proposals": [{"channel_key": "linkedin_organic", "sources": [_source("https://b")]}],
+        }
+    )
+    planned = body["channels"][0]["id"]
+    proposed = body["proposals"][0]["id"]
+
+    # Stamped, so there is something to select it by...
+    assert isinstance(proposed, str) and proposed
+    # ...offered to the approval route's unknown-id check...
+    assert known_element_ids(body) == {planned, proposed}
+    # ...and actually dropped when the operator does not keep it.
+    assert selected_body(body, [planned])["proposals"] == []
+    # Its sources go with it, so the next stage cannot cite a dropped
+    # proposal's evidence — see `source_urls_from_body` on why this is a fresh
+    # union rather than a subtraction.
+    assert source_urls_from_body(selected_body(body, [planned])) == ["https://a"]
+    assert source_urls_from_body(body) == ["https://a", "https://b"]
 
 
 # ── source_urls_from_body ────────────────────────────────────────────────────

--- a/tests/test_marketing_pipeline.py
+++ b/tests/test_marketing_pipeline.py
@@ -805,6 +805,44 @@ def test_flatten_citations_of_a_channel_plan_dedupes_by_url() -> None:
     assert citations == [{"url": "https://example.com/dup", "note": "a"}]
 
 
+def test_flatten_citations_of_a_channel_plan_covers_proposals_too() -> None:
+    """`marketing_artefact.citations` exists so "this artefact cites nothing"
+    is a question a query can ask rather than a paragraph someone has to read.
+    That is a question about the RUN, not about the campaign — so it spans both
+    lists (#67), or the count disagrees with the artefact on screen and a plan
+    whose only sourced work was a proposal reads as uncited."""
+    plan = extract_channel_plan(
+        _tool_call(
+            "submit_channel_plan",
+            {
+                "channels": [
+                    {
+                        "channel_key": "instagram_organic",
+                        "rank": 1,
+                        "rationale": "r",
+                        "sources": [{"url": "https://example.com/planned", "note": "a"}],
+                    }
+                ],
+                "proposals": [
+                    {
+                        "channel_key": "linkedin_organic",
+                        "rank": 2,
+                        "rationale": "r",
+                        "sources": [{"url": "https://example.com/proposed", "note": "b"}],
+                    }
+                ],
+            },
+        ),
+        taxonomy={"instagram_organic": "organic"},
+        proposable={"linkedin_organic": "organic"},
+    )
+
+    assert flatten_citations(plan) == [
+        {"url": "https://example.com/planned", "note": "a"},
+        {"url": "https://example.com/proposed", "note": "b"},
+    ]
+
+
 def test_flatten_citations_of_copy_dedupes_by_url() -> None:
     copy = extract_copy(
         _tool_call(
@@ -1003,6 +1041,71 @@ def test_channel_plan_channel_map_excludes_proposals_and_derives_from_real_entri
     }
 
     assert channel_plan_channel_map(plan_body) == {"instagram_organic": "organic"}
+
+
+def test_channel_key_motions_ignores_the_proposals_list_entirely() -> None:
+    """#67's third increment inverted what "carries a `channel_key`" means.
+
+    A proposal can now name a real taxonomy channel — one the operator
+    DESELECTED — so the old test ("has a key" ⇒ "is an approved channel")
+    silently starts admitting a channel nobody chose. This is the chokepoint
+    every downstream stage reads (copy, and through copy both packs), so a
+    `linkedin_organic` leaking through here is publish-ready copy and a pack
+    entry for a channel the operator excluded.
+
+    It is excluded structurally rather than filtered: the function reads
+    `channels`, and the proposal is not in it. A reader written next year that
+    knows nothing about proposals gets the same right answer.
+    """
+    from marketing.pipeline import channel_key_motions, channel_plan_channel_map
+
+    plan_body = {
+        "channels": [{"channel_key": "instagram_organic", "motion": "organic"}],
+        "proposals": [
+            {"channel_key": "linkedin_organic", "motion": "organic"},
+            {"channel_key": None, "suggested_label": "Reddit r/franchise", "motion": "organic"},
+        ],
+    }
+
+    assert channel_key_motions(plan_body) == {"instagram_organic": "organic"}
+    assert channel_plan_channel_map(plan_body) == {"instagram_organic": "organic"}
+
+
+def test_a_plan_of_nothing_but_proposals_is_not_a_stale_plan() -> None:
+    """`channels: []` with proposals present is a current plan that recommends
+    nothing within the selection — not the pre-#76 free-text shape. Raising
+    here would tell an operator to re-run a plan that is fine, which is the
+    mis-diagnosis #152 had to work around; the new shape makes it impossible
+    rather than worked around, because a keyless entry can no longer be in
+    `channels` at all."""
+    from marketing.pipeline import channel_plan_channel_map
+
+    plan_body = {
+        "channels": [],
+        "proposals": [{"channel_key": "linkedin_organic", "motion": "organic"}],
+    }
+
+    assert channel_plan_channel_map(plan_body) == {}
+
+
+def test_without_proposals_strips_only_that_key() -> None:
+    """What the copy run is handed (#67). Everything else about the approved
+    plan passes through byte for byte — this narrows the input, it does not
+    reshape it — and it is a no-op on a body that has no proposals, which is
+    every other artefact kind and every plan written before this shipped."""
+    from marketing.pipeline import without_proposals
+
+    body = {
+        "channels": [{"channel_key": "instagram_organic"}],
+        "proposals": [{"channel_key": "linkedin_organic"}],
+        "summary": "kept",
+    }
+
+    assert without_proposals(body) == {
+        "channels": [{"channel_key": "instagram_organic"}],
+        "summary": "kept",
+    }
+    assert without_proposals({"channels": []}) == {"channels": []}
 
 
 def test_channel_plan_channel_map_raises_on_a_pre_migration_plan() -> None:

--- a/web-admin/src/components/ArtefactBody.test.tsx
+++ b/web-admin/src/components/ArtefactBody.test.tsx
@@ -362,6 +362,81 @@ describe('ChannelPlanArtefact', () => {
     // channel_key with no taxonomy row", a different failure entirely.
     expect(heading.textContent).not.toMatch(/unrecognised channel/i)
   })
+
+  /** #67's third increment: the agent may now propose a channel that IS in
+   * the taxonomy — one the operator deselected — so a proposal arrives with a
+   * real `channel_key` and a real label, in `proposals` rather than
+   * `channels`.
+   *
+   * Without the separate block this renders as an ordinary ranked channel and
+   * an operator reading the plan has no way to tell it apart from one they
+   * selected. That is the failure #67 names ("visually and structurally
+   * distinct — a separate field or flag, not merely a note in the rationale"),
+   * and it is the half a reader actually acts on. */
+  it('renders a proposed TAXONOMY channel in its own block, badged, outside the plan (#67)', () => {
+    render(
+      <ChannelPlanArtefact
+        body={{
+          channels: [
+            {
+              channel_key: 'linkedin_organic',
+              suggested_label: null,
+              motion: 'organic',
+              rank: 1,
+              rationale: 'Selected, planned',
+              sources: [{ url: 'https://example.com/linkedin', note: 'n' }],
+            },
+          ],
+          proposals: [
+            {
+              channel_key: 'google_search_paid',
+              suggested_label: null,
+              motion: 'paid',
+              rank: 1,
+              rationale: 'Deselected, but the evidence is strong',
+              sources: [{ url: 'https://example.com/google', note: 'n' }],
+            },
+          ],
+        }}
+        channelLookup={makeLookup([LINKEDIN, GOOGLE])}
+      />,
+    )
+
+    const headings = screen.getAllByRole('heading', { level: 4 }).map((h) => h.textContent ?? '')
+    const planned = headings.find((h) => h.includes('LinkedIn — organic')) ?? ''
+    const proposed = headings.find((h) => h.includes('Google Search ads')) ?? ''
+    // The planned channel is unbadged; the proposed one is badged — the two
+    // must not read the same, which is the entire point.
+    expect(planned).not.toMatch(/proposed/i)
+    expect(proposed).toMatch(/outside selection/i)
+    // ...and the proposals sit under their own heading, after the plan,
+    // rather than being interleaved with it by rank.
+    expect(screen.getByRole('heading', { name: /outside your selection/i })).toBeInTheDocument()
+  })
+
+  it('renders exactly as before for a plan with no proposals key at all', () => {
+    render(
+      <ChannelPlanArtefact
+        body={{
+          channels: [
+            {
+              channel_key: 'linkedin_organic',
+              suggested_label: null,
+              motion: 'organic',
+              rank: 1,
+              rationale: 'Planned',
+              sources: [{ url: 'https://example.com/linkedin', note: 'n' }],
+            },
+          ],
+        }}
+        channelLookup={makeLookup([LINKEDIN, GOOGLE])}
+      />,
+    )
+
+    // Every channel-plan artefact proposed before #67's third increment has no
+    // `proposals` key. The block must not appear empty for them.
+    expect(screen.queryByRole('heading', { name: /outside your selection/i })).not.toBeInTheDocument()
+  })
 })
 
 describe('CopyArtefact', () => {

--- a/web-admin/src/components/ArtefactBody.tsx
+++ b/web-admin/src/components/ArtefactBody.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import type {
   ChannelPlanBody as ChannelPlanBodyT,
+  ChannelRecommendation,
   CopySetBody,
   LengthOverage,
   PositioningBody as PositioningBodyT,
@@ -337,26 +338,57 @@ export function ChannelPlanArtefact({
   selection?: ElementSelection
 }) {
   const byRank = [...body.channels].sort((a, b) => a.rank - b.rank)
+  const proposals = [...(body.proposals ?? [])].sort((a, b) => a.rank - b.rank)
+  const items = (channels: ChannelRecommendation[], proposed: boolean) =>
+    channels.map((c, i) => ({
+      key: `${proposed ? 'proposal' : 'plan'}-${c.channel_key ?? c.suggested_label ?? ''}-${i}`,
+      id: c.id,
+      label: c.channel_key ?? c.suggested_label ?? 'this channel',
+      heading: (
+        <h4>
+          #{c.rank}{' '}
+          <ChannelName
+            channelKey={c.channel_key}
+            suggestedLabel={c.suggested_label}
+            proposed={proposed}
+            lookup={channelLookup}
+          />{' '}
+          <span className={`motion motion-${c.motion}`}>{c.motion}</span>
+        </h4>
+      ),
+      body: <p>{c.rationale}</p>,
+      sources: c.sources,
+    }))
+
   return (
     <div className="artefact-body">
       <FindingGroup
-        items={byRank.map((c, i) => ({
-          key: `${c.channel_key ?? c.suggested_label ?? 'proposal'}-${i}`,
-          id: c.id,
-          label: c.channel_key ?? c.suggested_label ?? 'this channel',
-          heading: (
-            <h4>
-              #{c.rank}{' '}
-              <ChannelName channelKey={c.channel_key} suggestedLabel={c.suggested_label} lookup={channelLookup} />{' '}
-              <span className={`motion motion-${c.motion}`}>{c.motion}</span>
-            </h4>
-          ),
-          body: <p>{c.rationale}</p>,
-          sources: c.sources,
-        }))}
+        items={items(byRank, false)}
         renderSources={(sources) => <SourceRefs sources={sources} />}
         selection={selection}
       />
+      {/* #67 asks that an outside-selection proposal be "visually and
+          structurally distinct — a separate field or flag, not merely a note
+          in the rationale". It is now structurally separate server-side
+          (`ChannelPlanBody.proposals`), and this is the visual half: its own
+          heading, its own block, and a sentence saying what an operator is
+          being asked. Rendered only when there are proposals, so a plan with
+          none looks exactly as it did. */}
+      {proposals.length > 0 && (
+        <section className="channel-proposals">
+          <h4>Outside your selection — proposed</h4>
+          <p className="channel-proposals-note">
+            Not part of this plan. The channel-plan agent found evidence for {proposals.length} channel
+            {proposals.length === 1 ? '' : 's'} you did not select. Nothing is written for {proposals.length === 1 ? 'it' : 'them'} unless you add{' '}
+            {proposals.length === 1 ? 'it' : 'them'} to this campaign’s target channels and plan again.
+          </p>
+          <FindingGroup
+            items={items(proposals, true)}
+            renderSources={(sources) => <SourceRefs sources={sources} />}
+            selection={selection}
+          />
+        </section>
+      )}
     </div>
   )
 }

--- a/web-admin/src/components/ChannelName.test.tsx
+++ b/web-admin/src/components/ChannelName.test.tsx
@@ -41,6 +41,35 @@ describe('ChannelName', () => {
     expect(screen.getByText(/outside selection/i)).toBeInTheDocument()
   })
 
+  /** The #67 regression this component would otherwise have shipped.
+   *
+   * "Is this a proposal?" used to be derivable here from `channelKey ===
+   * null`, and that was sound while a proposal could only ever be free text.
+   * Since the agent may propose a TAXONOMY channel the operator deselected, a
+   * proposal carries a perfectly real key — so inferring from the key renders
+   * it as an ordinary planned channel: proper label, no badge, indistinguishable
+   * from something the operator actually chose. #67 requires the opposite in
+   * as many words ("nothing downstream can mistake a proposal for an approved
+   * channel"), and this is the one place an operator would see it.
+   */
+  it('badges a proposed taxonomy channel while still showing its real label (#67)', () => {
+    render(
+      <ChannelName channelKey="linkedin_paid" suggestedLabel={null} proposed lookup={fakeLookup([LINKEDIN_PAID])} />,
+    )
+
+    expect(screen.getByText(/outside selection/i)).toBeInTheDocument()
+    // The label, not the key — a proposal is a real taxonomy row, so #77's
+    // "never pass a machine key off as a label" applies to it too.
+    expect(screen.getByText('LinkedIn ads')).toBeInTheDocument()
+    expect(screen.queryByText('linkedin_paid')).not.toBeInTheDocument()
+  })
+
+  it('does not badge a planned channel', () => {
+    render(<ChannelName channelKey="linkedin_paid" suggestedLabel={null} lookup={fakeLookup([LINKEDIN_PAID])} />)
+
+    expect(screen.queryByText(/outside selection/i)).not.toBeInTheDocument()
+  })
+
   /** #84/#85's decision on existing free-text rows: minted before the
    * picker existed (e.g. `"totally made up channel"`, minted on dev during
    * #84's own repro), these have no taxonomy row and are NOT migrated or

--- a/web-admin/src/components/ChannelName.tsx
+++ b/web-admin/src/components/ChannelName.tsx
@@ -9,13 +9,9 @@ import type { ChannelLookup } from '../lib/useChannelTaxonomy'
  * Three distinct states, each visually marked so none can be mistaken for
  * another:
  *
- * - **Proposal** (`channelKey` is `null`, `suggestedLabel` is set) — a
- *   channel outside the operator's selection the channel-plan agent found
- *   strong evidence for (#67). `ChannelRecommendation` carries exactly one
- *   of `channel_key`/`suggested_label`, enforced server-side, so this is
- *   already structurally distinct from an approved-taxonomy channel — this
- *   badge makes that structural fact visible rather than inventing a new
- *   convention (#67 requires this be structural, not a rationale note).
+ * - **Proposal** — a channel outside the operator's selection the
+ *   channel-plan agent found strong evidence for (#67), badged so it cannot
+ *   be read as part of the plan.
  * - **Still loading** — the taxonomy fetch hasn't resolved yet. Shown as a
  *   neutral placeholder, not the bare key (which would look like a label
  *   for an instant) and not blank (which reads as broken).
@@ -23,14 +19,36 @@ import type { ChannelLookup } from '../lib/useChannelTaxonomy'
  *   (deleted, or from an instance whose seed diverged). Shown as the key,
  *   clearly marked unrecognised — never blank, and never silently treated
  *   as if it were the label.
+ *
+ * ## `proposed` is told, not inferred — and that is the #67 fix
+ *
+ * This component used to derive "is a proposal" from `channelKey === null`,
+ * which was sound while a proposal could only ever be free text. Since #67's
+ * third increment the agent may propose a **taxonomy** channel the operator
+ * deselected, and that carries a perfectly real `channel_key` — so inferring
+ * from the key would render it as an ordinary planned channel, with its
+ * proper taxonomy label and no badge, which is precisely the
+ * "nothing downstream can mistake a proposal for an approved channel"
+ * requirement being broken in the one place an operator would actually see
+ * it. The caller knows which list the entry came out of; it says so.
+ *
+ * A null `channelKey` is still treated as a proposal regardless of the flag:
+ * every channel-plan body written before that increment carries its proposals
+ * inside `channels` with no key, and those must keep their badge.
  */
 export function ChannelName({
   channelKey,
   suggestedLabel,
+  proposed = false,
   lookup,
 }: {
   channelKey: string | null
   suggestedLabel: string | null
+  /** True when this entry came out of `ChannelPlanBody.proposals`. Defaults
+   * to `false` for the render sites that have no proposals to show at all —
+   * copy and the distribution pack, whose entries are approved channels by
+   * construction. */
+  proposed?: boolean
   lookup: ChannelLookup
 }) {
   if (channelKey === null) {
@@ -38,6 +56,18 @@ export function ChannelName({
       <span className="channel-name channel-proposed">
         <span className="badge badge-proposed">Proposed — outside selection</span>{' '}
         {suggestedLabel !== null && suggestedLabel !== '' ? suggestedLabel : '(no label given)'}
+      </span>
+    )
+  }
+
+  if (proposed) {
+    // A real taxonomy row, so it gets its real label — the badge is what
+    // says it is not in the plan. Rendering the key instead would be the
+    // #77 mistake (a machine key passed off as a label) reintroduced.
+    return (
+      <span className="channel-name channel-proposed">
+        <span className="badge badge-proposed">Proposed — outside selection</span>{' '}
+        {lookup.loading ? 'Loading channel…' : (lookup.get(channelKey)?.label ?? channelKey)}
       </span>
     )
   }

--- a/web-admin/src/index.css
+++ b/web-admin/src/index.css
@@ -704,6 +704,36 @@ details.mint-toggle[open] > .mint {
   color: var(--text-muted);
 }
 
+/* ── Outside-the-selection proposals (issue #67) ──────────────────────────
+ *
+ * #67 requires an outside-selection proposal be "visually and structurally
+ * distinct — a separate field or flag, not merely a note in the rationale".
+ * The structural half is `ChannelPlanBody.proposals`, a list of its own; this
+ * is the visual half, and it deliberately does more than the per-item
+ * `.badge-proposed` alone. A badge on each heading is easy to skim past in a
+ * list of eight ranked channels that otherwise look identical, and the cost
+ * of skimming past it is an operator believing a channel they never selected
+ * is in the plan.
+ *
+ * So the whole block is set apart: indented behind a warning-coloured rule,
+ * under its own heading, after every planned channel. The plan reads first
+ * and unchanged; this reads as an appendix to it, which is what it is.
+ */
+.channel-proposals {
+  margin-top: 1.25rem;
+  padding-left: 0.9rem;
+  border-left: 3px solid var(--warning-bg);
+}
+
+.channel-proposals > h4 {
+  margin-bottom: 0.25rem;
+}
+
+.channel-proposals-note {
+  margin-top: 0;
+  color: var(--text-muted);
+}
+
 .stage-actions {
   display: flex;
   gap: 0.5rem;

--- a/web-admin/src/lib/api.ts
+++ b/web-admin/src/lib/api.ts
@@ -449,9 +449,13 @@ export interface PositioningBody {
 }
 
 /** #76 increment 2: exactly one of `channel_key`/`suggested_label` is set —
- * a `channel_key` from the taxonomy, or a free-text proposal for a channel
- * outside it (#67). Never both, never neither — enforced server-side by
- * `definitions.ChannelRecommendation`'s own validator, not re-checked here. */
+ * a `channel_key` from a taxonomy the run was shown, or a free-text proposal
+ * for a channel in neither of them (#67). Never both, never neither —
+ * enforced server-side by `definitions.ChannelRecommendation`'s own
+ * validator, not re-checked here.
+ *
+ * Nothing on this object says whether it is a plan entry or a proposal, and
+ * that is deliberate — see {@link ChannelPlanBody}. */
 export interface ChannelRecommendation {
   id?: string
   channel_key: string | null
@@ -462,8 +466,24 @@ export interface ChannelRecommendation {
   sources: Source[]
 }
 
+/** Two lists, because "plan entry or proposal?" is answered by which one an
+ * entry is in (#67) — never by a field on the entry.
+ *
+ * A proposal may now carry a real `channel_key`: the agent is shown the
+ * taxonomy rows the operator DESELECTED, in their own block, and may argue
+ * for one of them. So `channel_key !== null` no longer means "an approved
+ * channel", and every reader that used to ask that question has to read
+ * `channels` instead. `pipeline.extract_channel_plan` partitions the two
+ * server-side, from the snapshots the run was shown, so the model has no say
+ * in which list its answer lands in.
+ *
+ * `proposals` is optional because every channel-plan artefact proposed before
+ * this shipped has no such key — those bodies put a `suggested_label`
+ * proposal in `channels` with a null `channel_key`, which is why
+ * `ChannelName` still treats a null key as a proposal in its own right. */
 export interface ChannelPlanBody {
   channels: ChannelRecommendation[]
+  proposals?: ChannelRecommendation[]
 }
 
 /** #76 increment 2: `channel` → `channel_key`, always a real taxonomy key —

--- a/web-admin/src/lib/elementSelection.test.ts
+++ b/web-admin/src/lib/elementSelection.test.ts
@@ -85,6 +85,45 @@ describe('elementsOf', () => {
     ])
   })
 
+  it('offers a proposal a checkbox too, so a partial approval can keep one (#67)', () => {
+    const result = elementsOf(
+      artefact({
+        channels: [
+          {
+            id: 'ch1',
+            channel_key: 'linkedin_organic',
+            suggested_label: null,
+            motion: 'organic',
+            rank: 1,
+            rationale: 'x',
+            sources: [],
+          },
+        ],
+        proposals: [
+          {
+            id: 'pr1',
+            channel_key: 'google_search_paid',
+            suggested_label: null,
+            motion: 'paid',
+            rank: 1,
+            rationale: 'x',
+            sources: [],
+          },
+        ],
+      }),
+    )
+    // Mirrors `pipeline.ELEMENT_LIST_KEYS`, which gained `proposals` for the
+    // same reason: an id-less element is dropped by `selected_body` the
+    // moment ANY selection is submitted, so a proposal outside this list
+    // would silently vanish from an artefact the operator narrowed. Being
+    // selectable does not make it a channel — everything downstream of the
+    // gate reads `channels` alone.
+    expect(result).toEqual([
+      { id: 'ch1', label: 'linkedin_organic' },
+      { id: 'pr1', label: 'google_search_paid' },
+    ])
+  })
+
   it('labels a piece of copy with its channel and headline together, distinct from a channel-plan entry', () => {
     const result = elementsOf(
       artefact({

--- a/web-admin/src/lib/elementSelection.ts
+++ b/web-admin/src/lib/elementSelection.ts
@@ -13,11 +13,18 @@
 import type { Artefact } from './api'
 import { parseArtefactBody } from './api'
 
-/** Same four field names `pipeline.ELEMENT_LIST_KEYS` (Python) lists —
+/** Same field names `pipeline.ELEMENT_LIST_KEYS` (Python) lists —
  * `findings` (research), `segments`/`pillars`/`ctas` (positioning),
  * `channels` (channel_plan AND copy, which share the field name but not the
- * item shape; nothing here needs to tell them apart). */
-const ELEMENT_LIST_KEYS = ['findings', 'segments', 'pillars', 'ctas', 'channels'] as const
+ * item shape; nothing here needs to tell them apart), and `proposals`
+ * (channel_plan's outside-the-selection entries, #67).
+ *
+ * A proposal is selectable for the same reason a channel is — an operator
+ * approving a stage says which of its elements carry forward, and a proposal
+ * they want to keep on the record should survive that. It carrying forward
+ * still does not make it a channel: everything downstream of the gate reads
+ * `channels` alone (`pipeline.channel_key_motions`). */
+const ELEMENT_LIST_KEYS = ['findings', 'segments', 'pillars', 'ctas', 'channels', 'proposals'] as const
 
 /** One operator-selectable element, generic across every artefact kind — an
  * `id` to select/deselect by, and a short human-readable `label` for the


### PR DESCRIPTION
Refs #67 — deliberately not `Closes`.

#67's own "Done when" includes driving the flow in a browser on a live
deployment, and its last comment records that gap still standing from #154.
Everything here is unit- and route-level. The issue stays open until the
operator-facing half — how a proposed taxonomy channel renders for accept or
dismiss — has been seen on dev.

The last third of #67. Sections 1 and 3 are done and verified live; section 2 was done for the shortlist and unbuilt for the **"agent able to add"** clause. This builds it, taking the middle option that issue's last comment describes.

## The problem

#67's section 2 is headed *"shortlist, with the agent able to add"*, and the "able to add" half could not reach a taxonomy channel **by construction**. The run is shown only the operator's selected rows — which is exactly what makes the selection an enforcement rather than a request (#128: a constraint a model is merely *asked* to respect is not one) — so it had no way to name `online_communities` in order to argue for it. It did not know the key existed. The only outside route left was a free-text `suggested_label`, which cannot express the case #67's own mock-up illustrates.

## What changed

The run is now **additionally** shown the deselected taxonomy rows, in a separate `proposable_taxonomy` block it may only PROPOSE from. `channel_taxonomy` — the set it may PLAN from — is untouched. Nothing here weakens the input-narrowing.

`extract_channel_plan` resolves the three cases the issue names:

| the run returns | result |
| --- | --- |
| `channel_key` in the selected set | a plan entry (unchanged) |
| `channel_key` in the proposable set | a **proposal**, never a plan entry |
| `channel_key` in neither | `UnknownChannelError` (unchanged) |
| `suggested_label`, no key | a proposal (unchanged) |

## The sharp edge, and why the design is what it is

A proposal now carries a **real** `channel_key`, so `carries a key ⇒ is an approved channel` — the assumption every downstream reader was written on — stops holding. Left alone, the copy stage would write publish-ready copy for a channel the operator never selected and both packs would carry it.

`ChannelPlan` therefore gains a **second list**: `channels` is the plan, `proposals` is what needs an operator's acceptance.

**Two lists rather than an `is_proposal` flag, because they fail in opposite directions.** A flag fails **open** — every reader that forgets it, including one written next year by someone who never read the docstring, treats a proposal as approved. A separate list fails **closed** — a reader that only knows about `channels`, which is every reader that exists today, cannot see a proposal at all. `pipeline.channel_key_motions`, the chokepoint copy and (through copy) both packs go through, needed **no change**. That is the property being bought.

**The model gets no vote on which list an entry lands in.** `extract_channel_plan` re-partitions *both* of the model's lists from the two stashed snapshots, so where it filed an entry never survives: a deselected channel put in `channels` is moved, not honoured. Same lever `motion` already uses — derived from the snapshot, never read back from what the model asserted.

## Downstream readers updated

- **`channel_key_motions` / `channel_plan_channel_map`** — read `channels` only. The staleness signal gets *sharper*: a keyless entry can no longer legitimately appear there, so #152's mis-diagnosis becomes unreachable rather than worked around.
- **`copy_routes`** — new `pipeline.without_proposals` narrows the plan body handed to the copy run **and** the citation set derived from it. Not cosmetic: a proposal the copy agent could see would be written for and then killed by `extract_copy`'s own check, taking the whole artefact with it, with nothing in the error pointing at the proposal.
- **`flatten_citations`, `_require_retrieved_evidence`, `_extract_cited_artefact`** — span both lists via a new `all_recommendations` helper. A proposal must be grounded in retrieved evidence exactly as a plan entry is; asking an operator to reopen a decision with nothing behind it is the least defensible thing this run can produce.
- **`ELEMENT_LIST_KEYS`** gains `proposals`, so a proposal is id-stamped, selectable, and *dropped* by a narrowing selection rather than passed through whole while its id reads as unknown.
- **`admin_app._advance_artefact`** reads the second snapshot back, absent ⇒ `{}`.
- **web-admin** — `ChannelName` is now **told** it is rendering a proposal instead of inferring it from a null key (inferring would render a proposed taxonomy channel as an ordinary planned one, badge-less, in the one place an operator would see it); `ChannelPlanArtefact` renders proposals in their own block after the plan. #67 requires visual as well as structural distinctness, and this is the half a reader acts on.
- Swept `pack_routes`, `paid_pack_routes`, `user_app`, `results_routes`, `render` — all read the **copy** artefact, whose channels are validated against `channel_plan_channels`, so a proposal cannot reach them.

## Two deliberate asymmetries

- **The grounding run is not shown the deselected rows.** #65 measured that everything in an `:online` payload steers retrieval, and #67 is explicit that search budget must not be spent on channels that were never available. A proposal must be grounded in what a search aimed at the *selected* channels turned up — the right bar for asking an operator to reconsider.
- **Motion is not relaxed with the selection.** A deselected row whose motion this campaign does not run is in **neither** block. Accepting it would mean changing the campaign's strategy, not its channel list.

## Constraint honoured

No substring inference from channel keys anywhere — motion for a proposed channel comes from the `proposable_taxonomy` snapshot, exactly as a plan entry's comes from `channel_taxonomy`. `paid_pack_routes._platform_for_channel` is untouched.

## Every guard proven against the unfixed behaviour

Each change reverted in turn (file copy, restored after) and the suite re-run:

| revert | tests that failed |
| --- | --- |
| partition puts proposable keys in `channels` | `test_a_deselected_channel_comes_back_as_a_proposal_not_a_plan_entry`, `test_the_snapshot_decides_which_list_an_entry_lands_in_not_the_model`, `test_a_proposal_never_becomes_a_channel_the_copy_stage_writes_for` |
| `suggested_label` proposals into `channels` | `test_a_proposal_within_the_campaign_motion_is_kept` |
| grounding guard walks `plan.channels` only | `test_an_ungrounded_proposal_fails_the_plan_exactly_as_a_channel_does` |
| citation groups exclude proposals | `test_a_proposals_fabricated_source_is_refused_like_any_other`, `test_flatten_citations_of_a_channel_plan_covers_proposals_too` |
| route builds no proposable block | 5 tests, incl. `test_the_planning_run_is_shown_the_deselected_rows_in_their_own_block` and `test_a_deselected_row_outside_the_campaign_motion_is_not_proposable` |
| `without_proposals` becomes identity | `test_a_proposal_never_becomes_a_channel_the_copy_stage_writes_for`, `test_without_proposals_strips_only_that_key` |
| `ELEMENT_LIST_KEYS` without `proposals` | `test_a_channel_plan_proposal_is_a_first_class_selectable_element` |
| `ChannelName` infers from the key alone | `ChannelName > badges a proposed taxonomy channel…`, `ChannelPlanArtefact > renders a proposed TAXONOMY channel in its own block…` |
| `elementSelection` without `proposals` | `elementsOf > offers a proposal a checkbox too` |

The first pass of `ELEMENT_LIST_KEYS` revert broke **nothing**, which is why `test_a_channel_plan_proposal_is_a_first_class_selectable_element` exists — the two neighbouring guards both pass without it.

Gates: `pytest` 860 passed, `ruff check`, `ruff format --check`, `pyright` 0 errors; web-admin `vitest` 243 passed, `tsc --noEmit`, `eslint --max-warnings=0`.

## Not verified

- **Not driven in a browser on a live deployment.** #67's last "Done when" box asks for that, and it is the same gap #154 and the 0816 verification comment both left open. Everything above is unit- and route-level.
- **Not exercised against a real model.** No test asserts on prompt prose (deliberately, per this module's convention), so whether the run actually *uses* the proposable block well — proposes sparingly, on evidence — is unmeasured. The mechanism is enforced; the judgement is not.
- The accept/dismiss workflow that **promotes** a proposal into the campaign's selection is still out of scope (#154's deliberately-left item 1). The UI says so in as many words: an operator adds the channel to the campaign's targets and plans again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
