### PR TITLE
fix(agents): ask the deployment for its run ceilings instead of asserting them

### DIFF
--- a/scripts/check_runtime_ceiling.py
+++ b/scripts/check_runtime_ceiling.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Read the ceilings this plugin's run budgets are enforced against, from the
+deployment that enforces them — instead of asserting them from a copy.
+
+Issue #132. Every agent definition in `marketing.definitions` declares a
+`timeout_seconds` and a `max_turns`. Neither is enforced here: the
+`agent_runtime` Lambda clamps both into the deployment's own ceilings
+(`AGENT_RUNTIME_MAX_SECONDS`, `AGENT_RUNTIME_MAX_TURNS`), and `agent_runtime`
+is not a dependency of this plugin, so nothing in this repo can import either
+number. `RUNTIME_TIMEOUT_CEILING_SECONDS` is therefore a hand-copied belief
+about another repo's Terraform, and every test in this repo asserts against
+that copy rather than against the deployment.
+
+**That copy went stale for two days and nothing failed.** On 2026-08-16 the
+deployed `AGENT_RUNTIME_MAX_SECONDS` read `"300"` while the constant — and
+every test here — still said 240. `AGENT_TIMEOUT_SECONDS` stayed pinned at 240
+by a comment arguing that 240 *was* the ceiling, so 60 seconds of granted
+headroom sat unspent on the two stages the estate had already measured as
+marginal (`agent_runtime` logged "Agent run finished close to its wall-clock
+limit" on 2026-08-13 04:53). That is instance 5 of #132, and it was found by a
+human reading a deployed Lambda for an unrelated reason.
+
+**Why no existing detector could have found it, in either repo.** The runtime
+was taught to say when it *clamps* (biffo-template#1586: `RunLimits.
+from_snapshot` records a `LimitClamp` naming requested, granted, ceiling and
+the env var that raises it). But `clamp_report()` is deliberately empty when
+nothing was reduced — "a line on every run is noise, noise gets filtered, and a
+filtered line reports nothing". So the runtime tells you when the deployment
+grants **less** than you asked for, and never when it grants **more**. Instance
+5 was the widening direction: no clamp, no failed run, no log line, nothing to
+investigate.
+
+This script is the widening direction's detector, and it is the one form of it
+this repo can build. It cannot be a pytest — reaching AWS is not a hermetic CI
+gate, and the answer differs per environment — so it is an operator command in
+the same shape as `seed_fan_in_workflow.py --check`, which already exists here
+for the same reason (a snapshot in this checkout, a deployment that can move
+under it, and no way to compare the two without asking the deployment).
+
+    uv run python scripts/check_runtime_ceiling.py \
+        --function-name tabsii-platform-dev-plugin-agent-runtime
+
+    0  in step   · the deployment grants exactly what this checkout believes
+    1  drifted   · a number here disagrees with the deployment, in either
+                   direction — see the report for which and what it costs
+    2  cannot tell · the deployment could not be read, or it does not set the
+                   ceiling at all (see `_ceiling_from` for why that is a
+                   refusal to answer rather than a pass)
+
+**The function name is an argument and has no default, deliberately.** It is
+`<project>-<environment>-plugin-agent-runtime` on the deployments this plugin
+runs on, but a default would be a *fourth* copy of another repo's fact — the
+exact defect this script exists to remove — and it would be a copy that reads
+as authoritative while being wrong on every environment but one. `--profile`
+and `--region` are passed to boto3 unchanged so an operator can point this at
+whichever account holds the deployment.
+
+What this still does not do: prove that the *plugin* deployed alongside that
+runtime is the code in this checkout. This compares this checkout's declared
+budgets against the deployed ceilings. If the vendored plugin is behind, its
+budgets are not these ones — `seed_fan_in_workflow.py --check` is the tool for
+that half, and neither substitutes for the upstream contract test that would
+read both halves in CI (biffo-template#1364).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+# Resolve `marketing.*` from the checkout rather than an installed package.
+# Run with `uv run python scripts/check_runtime_ceiling.py`: importing
+# `marketing.definitions` pulls in `marketing/__init__.py` -> `plugin.py` ->
+# `aws_lambda_powertools`, which a bare `python3` will not have. Same
+# bootstrap, and same caveat, as `seed_fan_in_workflow.py`.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from marketing.definitions import (  # noqa: E402
+    AGENT_TIMEOUT_SECONDS,
+    RUNTIME_TIMEOUT_CEILING_SECONDS,
+    discover_definition_factories,
+)
+
+IN_STEP = 0
+DRIFTED = 1
+CANNOT_TELL = 2
+
+#: The two environment variables `agent_runtime` resolves its ceilings from,
+#: named here because the report has to tell an operator which lever to move
+#: and they live in another repo's Terraform
+#: (`services/_plugins/agent-runtime/terraform/main.tf` sets
+#: `AGENT_RUNTIME_MAX_SECONDS = tostring(var.run_timeout_seconds)`).
+TIMEOUT_CEILING_ENV = "AGENT_RUNTIME_MAX_SECONDS"
+TURNS_CEILING_ENV = "AGENT_RUNTIME_MAX_TURNS"
+
+
+class CannotReadError(Exception):
+    """The deployment could not be asked — never "the deployment is fine".
+
+    Its own exception type rather than a `None` return so a caller cannot
+    accidentally treat "could not ask" as "asked, and there was nothing
+    there". That collapse is what `marketing.ssm` exists to prevent on the
+    SSM path, for the same reason (issue #25).
+    """
+
+
+def read_deployed_configuration(
+    function_name: str, *, profile: str | None = None, region: str | None = None
+) -> dict[str, Any]:
+    """The deployed Lambda's configuration, or `CannotReadError`.
+
+    boto3 is imported inside the function, matching `marketing.ssm`: neither
+    boto3 nor credentials nor a region need to exist for this module to be
+    imported, so the tests below can exercise every comparison without AWS
+    being reachable at all.
+    """
+    try:
+        import boto3
+    except Exception as exc:  # pragma: no cover — boto3 is a declared dependency
+        raise CannotReadError(f"boto3 is not importable: {exc}") from exc
+
+    try:
+        session = boto3.Session(profile_name=profile, region_name=region)
+        client = session.client("lambda")
+        return dict(client.get_function_configuration(FunctionName=function_name))
+    except Exception as exc:
+        # Every failure here is "cannot tell", never "in step": a missing
+        # function, a denied `lambda:GetFunctionConfiguration`, an expired
+        # SSO session and a typo'd name are indistinguishable to this script
+        # and none of them is evidence that the ceilings agree.
+        raise CannotReadError(
+            f"could not read {function_name}: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _ceiling_from(environment: dict[str, str], name: str) -> float | None:
+    """One ceiling as the deployment sets it, or `None` for "cannot tell".
+
+    `None` covers both "the function does not set this variable" and "it sets
+    something unparseable", and both are deliberately *not* resolved to
+    `agent_runtime`'s own code default (240s / 10 turns).
+
+    Substituting that default is the tempting move and it would recreate this
+    script's own bug class: the default is a Python constant in a repo that is
+    not a dependency here, so writing it down would be a fresh hand-copy,
+    presented — by a tool whose whole purpose is to stop trusting copies — as a
+    reading of the deployment. An unset ceiling is a question this repo cannot
+    answer, and saying so is the honest output.
+    """
+    raw = environment.get(name)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def compare(configuration: dict[str, Any]) -> tuple[int, list[str]]:
+    """The whole comparison, as a pure function of a Lambda configuration.
+
+    Returns `(exit_code, report_lines)`. Kept separate from the AWS call so
+    every case below — including the ones that need a *deployment* in a
+    particular state — is a plain unit test rather than something only a live
+    environment can reach.
+
+    Verdict precedence is `DRIFTED` > `CANNOT_TELL` > `IN_STEP`: a definite
+    disagreement outranks an unanswerable half, and anything unanswerable
+    outranks a pass. Exit 2 is never a clean bill of health (AGENTS.md §7).
+    """
+    environment = dict(configuration.get("Environment", {}).get("Variables", {}))
+    findings: list[str] = []
+    unknowns: list[str] = []
+
+    deployed_timeout = _ceiling_from(environment, TIMEOUT_CEILING_ENV)
+    if deployed_timeout is None:
+        unknowns.append(
+            f"{TIMEOUT_CEILING_ENV} is not set (or is unparseable) on this function, so the "
+            f"wall-clock ceiling is `agent_runtime`'s own code default — a constant in a repo "
+            f"this plugin does not depend on. Nothing here can read it, and this script will "
+            f"not guess it. Set `var.run_timeout_seconds` in the agent-runtime module and "
+            f"re-run, or read the default in `agent_runtime/loop.py` by hand."
+        )
+    else:
+        findings += _timeout_findings(deployed_timeout)
+        findings += _lambda_timeout_findings(configuration, deployed_timeout)
+
+    deployed_turns = _ceiling_from(environment, TURNS_CEILING_ENV)
+    if deployed_turns is None:
+        unknowns.append(
+            f"{TURNS_CEILING_ENV} is not set (or is unparseable) on this function, so no turn "
+            f"budget declared here can be checked against what the deployment will grant."
+        )
+    else:
+        findings += _turn_findings(deployed_turns)
+
+    report = findings + unknowns
+    if findings:
+        return DRIFTED, report
+    if unknowns:
+        return CANNOT_TELL, report
+    return IN_STEP, [
+        f"In step — {TIMEOUT_CEILING_ENV}={deployed_timeout:g}s matches "
+        f"RUNTIME_TIMEOUT_CEILING_SECONDS, AGENT_TIMEOUT_SECONDS "
+        f"({AGENT_TIMEOUT_SECONDS:g}s) is exactly what the deployment grants, and every "
+        f"declared max_turns fits under {TURNS_CEILING_ENV}={deployed_turns:g}."
+    ]
+
+
+def _timeout_findings(deployed_timeout: float) -> list[str]:
+    """The hand-copied ceiling, and the budget built on it, against the real one.
+
+    Two separate assertions on purpose. The copy being wrong and the budget
+    being wrong are different defects with different costs, and instance 5 was
+    the first — a *correct* budget for the ceiling this repo believed in, and
+    60 unspent seconds against the ceiling that was actually deployed.
+    """
+    findings: list[str] = []
+
+    if RUNTIME_TIMEOUT_CEILING_SECONDS != deployed_timeout:
+        direction = (
+            "WIDENED — the deployment grants MORE than this repo believes"
+            if deployed_timeout > RUNTIME_TIMEOUT_CEILING_SECONDS
+            else "NARROWED — the deployment grants LESS than this repo believes"
+        )
+        findings.append(
+            f"{direction}: {TIMEOUT_CEILING_ENV} is {deployed_timeout:g}s on the deployment "
+            f"but RUNTIME_TIMEOUT_CEILING_SECONDS in definitions.py says "
+            f"{RUNTIME_TIMEOUT_CEILING_SECONDS:g}s. Update the constant AND the deployed value "
+            f"quoted in its docstring (a test pins those two to each other), then reconsider "
+            f"AGENT_TIMEOUT_SECONDS, which is deliberately equal to the ceiling."
+        )
+
+    if AGENT_TIMEOUT_SECONDS > deployed_timeout:
+        findings.append(
+            f"CLAMPED: every agent asks for {AGENT_TIMEOUT_SECONDS:g}s but the deployment "
+            f"grants at most {deployed_timeout:g}s, so `RunLimits.from_snapshot` reduces it. "
+            f"This is the direction the runtime now logs (biffo-template#1586) — search the "
+            f"agent-runtime log group for `budget_clamped` to see it happening. Either raise "
+            f"`var.run_timeout_seconds` (and `var.timeout` above it) or lower "
+            f"AGENT_TIMEOUT_SECONDS so the source stops claiming a budget no run has."
+        )
+    elif AGENT_TIMEOUT_SECONDS < deployed_timeout:
+        findings.append(
+            f"UNSPENT: the deployment grants {deployed_timeout:g}s and every agent asks for "
+            f"{AGENT_TIMEOUT_SECONDS:g}s — {deployed_timeout - AGENT_TIMEOUT_SECONDS:g}s is "
+            f"available and unused. This is exactly #132 instance 5, and it is the direction "
+            f"nothing else reports: no run is clamped, no run fails, and the runtime says "
+            f"nothing about a ceiling it did not have to enforce. Raise AGENT_TIMEOUT_SECONDS "
+            f"to the granted value, or record in its docstring why the headroom is refused."
+        )
+
+    return findings
+
+
+def _lambda_timeout_findings(configuration: dict[str, Any], deployed_timeout: float) -> list[str]:
+    """The ceiling against the Lambda's own timeout.
+
+    `AGENT_RUNTIME_MAX_SECONDS` is what the runtime will *grant*; the function
+    `Timeout` is what AWS will *allow* before killing the invocation outright.
+    A grant at or above the function timeout is a budget that cannot be spent —
+    the run dies as a Lambda timeout, which surfaces as neither a clamp nor a
+    run error, so it looks like an infrastructure fault rather than a
+    misconfiguration. Both docstrings in `definitions.py` say `var.timeout`
+    must stay above `var.run_timeout_seconds`; this is that sentence, checked.
+    """
+    lambda_timeout = configuration.get("Timeout")
+    if not isinstance(lambda_timeout, (int, float)):
+        return []
+    if lambda_timeout > deployed_timeout:
+        return []
+    return [
+        f"NO ROOM: the function's own Timeout is {lambda_timeout:g}s while it grants runs up "
+        f"to {deployed_timeout:g}s, so a run spending its full budget is killed by AWS before "
+        f"the runtime can end it. Raise `var.timeout` above `var.run_timeout_seconds`."
+    ]
+
+
+def _turn_findings(deployed_turns: float) -> list[str]:
+    """Every stage's declared turn budget against the deployed turns ceiling.
+
+    Swept from `discover_definition_factories()` rather than a list written
+    here — #132 hole 1 was a hand-maintained denominator in a test, and a
+    hand-maintained one in a script would be the same defect wearing a
+    different hat. A stage added tomorrow is checked by this without anyone
+    remembering to add it.
+
+    Unlike the wall clock, no constant in this repo claims to know the turns
+    ceiling, so there is nothing to compare it *to* — only the declared budgets
+    to compare it *against*. That asymmetry is why a clamp here would be found
+    by this script and not by any test.
+    """
+    findings: list[str] = []
+    for factory in discover_definition_factories():
+        definition = factory(model="some/model", instructions="do the thing")
+        declared = definition.get("max_turns")
+        if isinstance(declared, (int, float)) and declared > deployed_turns:
+            findings.append(
+                f"CLAMPED: {factory.__name__} declares max_turns={declared:g} but "
+                f"{TURNS_CEILING_ENV} on the deployment is {deployed_turns:g}, so the run gets "
+                f"{deployed_turns:g} turns and this repo's source says otherwise."
+            )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--function-name",
+        required=True,
+        help=(
+            "the deployed agent-runtime Lambda, e.g. "
+            "tabsii-platform-dev-plugin-agent-runtime. No default: see this "
+            "script's docstring for why one would be a fourth hand-copy."
+        ),
+    )
+    parser.add_argument("--profile", default=None, help="AWS profile to read it with")
+    parser.add_argument("--region", default=None, help="AWS region the function is in")
+    args = parser.parse_args(argv)
+
+    try:
+        configuration = read_deployed_configuration(
+            args.function_name, profile=args.profile, region=args.region
+        )
+    except CannotReadError as exc:
+        print(f"CANNOT TELL: {exc}", file=sys.stderr)
+        return CANNOT_TELL
+
+    code, report = compare(configuration)
+    stream = sys.stdout if code == IN_STEP else sys.stderr
+    for line in report:
+        print(f"  - {line}" if code != IN_STEP else line, file=stream)
+    if code == DRIFTED:
+        print(
+            "\nThe deployment and this checkout disagree about what a run may spend.",
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/marketing/definitions.py
+++ b/src/marketing/definitions.py
@@ -1749,6 +1749,18 @@ RUNTIME_DEFAULT_TIMEOUT_SECONDS = 120.0
 #: present in the deployed artefact 2026-08-16). So a clamp is now findable in
 #: a log rather than only in a dead campaign; a *widening*, as here, still is
 #: not, because nothing reports a ceiling it did not have to enforce.
+#:
+#: **Do not update this number by hand from memory — ask the deployment.**
+#: ``uv run python scripts/check_runtime_ceiling.py --function-name
+#: <project>-<env>-plugin-agent-runtime`` reads both ceilings off the running
+#: Lambda and reports either direction of disagreement (0 in step · 1 drifted ·
+#: 2 cannot tell). It is the only thing in this repo that can tell you whether
+#: the line above is still true, and it is what instance 5 needed and did not
+#: have: the widening that created it produces no clamp, no failure and no log
+#: line, so it is invisible to everything else. It is an operator command
+#: rather than a CI gate because it needs AWS credentials and answers
+#: differently per environment — the CI-side version has to live where both
+#: halves are importable (biffo-template#1364).
 RUNTIME_TIMEOUT_CEILING_SECONDS = 300.0
 
 #: The wall clock every agent in this plugin may spend, in seconds

--- a/tests/test_marketing_agent_run_limits.py
+++ b/tests/test_marketing_agent_run_limits.py
@@ -101,9 +101,27 @@ def test_researchs_wall_clock_is_not_silently_clamped_by_the_runtime() -> None:
     not move with it — nothing tells this test the number it is comparing
     against has gone stale. So this proves internal self-consistency between
     two beliefs held in this repo, never agreement with the deployed
-    Terraform variable. That gap needs an upstream contract test that can
-    read both sides (biffo-template#1364) or a loud clamp in `from_snapshot`
-    (today it clamps silently); neither is buildable from here.
+    Terraform variable.
+
+    **Two of the three things that would close that gap have since arrived,
+    and this comment used to say none of them could.** It read "neither is
+    buildable from here", which was wrong in both halves:
+
+    - The clamp is no longer silent. `RunLimits.from_snapshot` records a
+      `LimitClamp` naming requested, granted, ceiling and the env var that
+      raises it (biffo-template#1586, verified present in the deployed
+      artefact 2026-08-16). So a NARROWING is now findable in a log.
+    - A WIDENING still is not — nothing reports a ceiling it did not have to
+      enforce — and that is the direction that produced #132 instance 5. What
+      is buildable from here, and now exists, is
+      `scripts/check_runtime_ceiling.py`: it reads the ceilings off the
+      deployed Lambda and reports either direction. It cannot be a pytest
+      (AWS credentials, and a different answer per environment), so it is an
+      operator command like `seed_fan_in_workflow.py --check` rather than
+      something that can fail this suite.
+
+    What is still not buildable here is a CI gate that reads both sides —
+    that remains biffo-template#1364.
     """
     assert AGENT_TIMEOUT_SECONDS <= _RUNTIME_TIMEOUT_CEILING, (
         f"{AGENT_TIMEOUT_SECONDS}s exceeds the runtime ceiling "
@@ -236,9 +254,10 @@ def test_the_ceilings_docstring_evidence_agrees_with_the_ceiling_it_documents() 
             f'definitions.py quotes AGENT_RUNTIME_MAX_SECONDS as "{value}" '
             f"while RUNTIME_TIMEOUT_CEILING_SECONDS is "
             f"{RUNTIME_TIMEOUT_CEILING_SECONDS}. One of them was updated and "
-            "the other was not — re-read the deployed value with `aws lambda "
-            "get-function-configuration` and make both say it (issue #132 "
-            "instance 5)."
+            "the other was not — re-read the deployed value with `uv run "
+            "python scripts/check_runtime_ceiling.py --function-name "
+            "<project>-<env>-plugin-agent-runtime` and make both say it "
+            "(issue #132 instance 5)."
         )
 
 

--- a/tests/test_marketing_runtime_ceiling_check.py
+++ b/tests/test_marketing_runtime_ceiling_check.py
@@ -1,0 +1,222 @@
+"""The check that reads the deployed ceiling instead of asserting it (#132).
+
+Every other assertion about run budgets in this repo compares one of this
+repo's beliefs against another of this repo's beliefs — `AGENT_TIMEOUT_SECONDS`
+against `RUNTIME_TIMEOUT_CEILING_SECONDS`, the constant against the deployment
+value quoted in its own docstring. Those are worth having and they are what
+`test_marketing_agent_run_limits.py` does, but none of them can fail when the
+*deployment* moves, because none of them has ever seen it.
+
+`scripts/check_runtime_ceiling.py` is the one thing in this repo that reads the
+real number. It cannot run in CI (it needs AWS credentials and the answer
+differs per environment), so what CI can prove is that its comparison is right:
+every case below hands `compare()` a Lambda configuration in a known state and
+asserts the verdict, with no AWS involved.
+
+**The case that matters most is `test_an_unset_ceiling_is_cannot_tell`.** A
+drift check that reports "fine" when it could not actually find the number is a
+fail-open, and this class's history is entirely made of green checks over
+questions nobody asked (biffo-template#1363).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from _scripts import load_script
+
+from marketing.definitions import (
+    AGENT_TIMEOUT_SECONDS,
+    RUNTIME_TIMEOUT_CEILING_SECONDS,
+    discover_definition_factories,
+)
+
+_check = load_script("check_runtime_ceiling")
+
+IN_STEP = _check.IN_STEP
+DRIFTED = _check.DRIFTED
+CANNOT_TELL = _check.CANNOT_TELL
+
+#: Bigger than any turn budget this plugin declares, so a test aimed at the
+#: wall clock cannot be failed by an unrelated turns finding. Derived rather
+#: than typed: a stage added tomorrow with a larger budget must not quietly
+#: turn these into turns tests.
+_GENEROUS_TURNS = (
+    max(
+        factory(model="some/model", instructions="do the thing")["max_turns"]
+        for factory in discover_definition_factories()
+    )
+    + 1
+)
+
+
+def _configuration(
+    *,
+    seconds: str | None = str(int(RUNTIME_TIMEOUT_CEILING_SECONDS)),
+    turns: str | None = str(_GENEROUS_TURNS),
+    lambda_timeout: float | None = None,
+) -> dict[str, Any]:
+    """A `get_function_configuration` response in whatever state a test needs.
+
+    Shaped exactly as boto3 returns it — the ceilings live under
+    `Environment.Variables` as **strings**, which is the detail a test written
+    against a tidied-up dict would miss.
+    """
+    variables: dict[str, str] = {}
+    if seconds is not None:
+        variables[_check.TIMEOUT_CEILING_ENV] = seconds
+    if turns is not None:
+        variables[_check.TURNS_CEILING_ENV] = turns
+    timeout = lambda_timeout if lambda_timeout is not None else RUNTIME_TIMEOUT_CEILING_SECONDS + 60
+    return {
+        "FunctionName": "tabsii-platform-dev-plugin-agent-runtime",
+        "Timeout": timeout,
+        "Environment": {"Variables": variables},
+    }
+
+
+def test_a_deployment_matching_this_checkout_is_in_step() -> None:
+    """The pass case, stated first so the failures below mean something."""
+    code, report = _check.compare(_configuration())
+
+    assert code == IN_STEP, report
+
+
+def test_a_widened_ceiling_is_reported_as_unspent_headroom() -> None:
+    """#132 instance 5, exactly: the deployment moved 240 -> 300, this repo did
+    not notice for two days, nothing failed, and 60 seconds of granted budget
+    went unspent on two stages already measured as marginal.
+
+    This is the direction with no other detector anywhere. `RunLimits.
+    from_snapshot` reports a clamp (biffo-template#1586) and deliberately says
+    nothing when it did not have to clamp, so a deployment granting MORE than
+    the plugin asks for produces no log line, no failure and no symptom.
+    """
+    widened = RUNTIME_TIMEOUT_CEILING_SECONDS + 60
+    code, report = _check.compare(_configuration(seconds=str(int(widened))))
+
+    assert code == DRIFTED
+    blob = " ".join(report)
+    assert "WIDENED" in blob
+    assert "UNSPENT" in blob
+    # Both numbers named, because a report that says "drifted" without saying
+    # from what sends the reader back to the deployment to find out.
+    assert f"{widened:g}" in blob
+    assert f"{RUNTIME_TIMEOUT_CEILING_SECONDS:g}" in blob
+
+
+def test_a_narrowed_ceiling_is_reported_as_a_clamp() -> None:
+    """The direction that killed #126 and #130. Every agent asks for
+    `AGENT_TIMEOUT_SECONDS`; a deployment below that grants less, silently as
+    far as this repo's source is concerned, and the run dies partway through
+    with the pipeline continuing on whatever it got."""
+    narrowed = AGENT_TIMEOUT_SECONDS - 60
+    code, report = _check.compare(_configuration(seconds=str(int(narrowed))))
+
+    assert code == DRIFTED
+    blob = " ".join(report)
+    assert "NARROWED" in blob
+    assert "CLAMPED" in blob
+    assert f"{AGENT_TIMEOUT_SECONDS:g}" in blob
+
+
+def test_an_unset_ceiling_is_cannot_tell_and_never_a_pass() -> None:
+    """The fail-open this check must not be.
+
+    A function with no `AGENT_RUNTIME_MAX_SECONDS` falls back to
+    `agent_runtime`'s own code default — a constant in a repo that is not a
+    dependency here. The tempting move is to write that default down and carry
+    on comparing; that would make a tool built to stop trusting hand-copies
+    depend on a hand-copy, and it would report a confident verdict derived from
+    a number nobody read. Refusing to answer is the honest output, and exit 2
+    is never a pass (AGENTS.md §7).
+    """
+    code, report = _check.compare(_configuration(seconds=None))
+
+    assert code == CANNOT_TELL, report
+    assert _check.TIMEOUT_CEILING_ENV in " ".join(report)
+
+
+def test_an_unparseable_ceiling_is_cannot_tell() -> None:
+    """Same refusal, different cause: a variable set to something that is not a
+    number is not a deployment granting zero seconds."""
+    code, _ = _check.compare(_configuration(seconds="none"))
+
+    assert code == CANNOT_TELL
+
+
+def test_a_definite_drift_outranks_an_unanswerable_half() -> None:
+    """Precedence, asserted rather than assumed: an unreadable turns ceiling
+    must not downgrade a wall clock that provably disagrees. Reporting
+    "cannot tell" over a finding that IS tellable would lose the finding."""
+    code, report = _check.compare(
+        _configuration(seconds=str(int(RUNTIME_TIMEOUT_CEILING_SECONDS + 60)), turns=None)
+    )
+
+    assert code == DRIFTED
+    # The unanswerable half is still printed — it is a second thing to fix,
+    # not something the first finding excuses.
+    assert _check.TURNS_CEILING_ENV in " ".join(report)
+
+
+def test_a_turn_budget_above_the_deployed_ceiling_is_reported() -> None:
+    """The other half of the same seam. No constant in this repo claims to know
+    the turns ceiling, so nothing here can even hold a stale copy of it — which
+    means a turn budget the deployment will clamp is invisible to every test in
+    this repo, and visible only to something that asks the deployment."""
+    code, report = _check.compare(_configuration(turns="1"))
+
+    assert code == DRIFTED
+    assert "max_turns" in " ".join(report)
+
+
+def test_every_definition_factory_is_swept_for_turn_budgets() -> None:
+    """#132 hole 1 was a hand-maintained denominator in a test; the same list
+    written out in a script would be the same defect. With the turns ceiling at
+    1, every factory must appear by name in the report — so a stage added
+    tomorrow is checked without anyone remembering this file exists."""
+    _, report = _check.compare(_configuration(turns="1"))
+
+    blob = " ".join(report)
+    for factory in discover_definition_factories():
+        assert factory.__name__ in blob
+
+
+def test_a_lambda_timeout_below_the_granted_budget_is_reported() -> None:
+    """A grant the invocation cannot survive. The runtime would allow a run
+    `AGENT_RUNTIME_MAX_SECONDS` seconds, but AWS kills the invocation at
+    `Timeout` — so the run dies as a Lambda timeout, which is neither a clamp
+    nor a run error and reads as an infrastructure fault. Both docstrings in
+    `definitions.py` require `var.timeout` above `var.run_timeout_seconds`;
+    this is that requirement checked against the deployment."""
+    code, report = _check.compare(_configuration(lambda_timeout=RUNTIME_TIMEOUT_CEILING_SECONDS))
+
+    assert code == DRIFTED
+    assert "NO ROOM" in " ".join(report)
+
+
+def test_an_unreadable_deployment_exits_cannot_tell(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point of `CannotReadError` being an exception rather than an
+    empty dict: a denied `lambda:GetFunctionConfiguration`, an expired session
+    and a typo'd function name must not arrive at `compare()` looking like a
+    function that sets no ceilings, and must never exit 0."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise _check.CannotReadError("could not read it")
+
+    monkeypatch.setattr(_check, "read_deployed_configuration", _boom)
+
+    assert _check.main(["--function-name", "whatever"]) == CANNOT_TELL
+
+
+def test_main_exits_in_step_when_the_deployment_agrees(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The success path end to end, so the exit codes the runbook quotes are
+    the ones the script actually returns."""
+
+    def _fake(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return _configuration()
+
+    monkeypatch.setattr(_check, "read_deployed_configuration", _fake)
+
+    assert _check.main(["--function-name", "whatever"]) == IN_STEP


### PR DESCRIPTION
Refs #132. Not `Closes`: remedy 3 (a CI gate that reads both halves) still needs biffo-template#1364, which no plugin repo can write.

## What was already resolved, checked rather than assumed

| | state | evidence |
| --- | --- | --- |
| Hole 1 — hand-maintained denominator | **fixed** | `tests/test_marketing_agent_run_limits.py:54` `DEFINITION_FACTORIES = discover_definition_factories()`, swept at `:164`, self-checked at `:193`; `definitions.py:2021` raises if the derived count drifts |
| Hole 2, remedy 1 — make the clamp loud | **shipped upstream, deployed** | `agent_runtime/loop.py` `LimitClamp` / `clamp_report()`; read in the vendored source, not taken from a changelog |
| Hole 2, remedy 2 — buy headroom | **shipped and spent** | #174 moved both constants 240 -> 300 |
| Instances 1-5 | **all closed** | #126, #130, #131, #155, #174 |
| Hole 2 — the copy itself | **still a copy** | this PR |

## The gap this closes

`RunLimits.from_snapshot` reports a clamp and — deliberately — says nothing when it did not have to clamp: *"a line on every run is noise, noise gets filtered, and a filtered line reports nothing."* So the runtime tells you when the deployment grants **less** than you asked for and never when it grants **more**.

Instance 5 was the widening direction. The deployment moved 240 -> 300, this repo did not notice for two days, no run was clamped, nothing failed, and 60 seconds of granted budget sat unspent on the two stages already measured as marginal. It was found by a human reading a deployed Lambda for an unrelated reason.

The issue was parked earlier today on the grounds that nothing here can read the ceiling because `agent_runtime` cannot be **imported**. That is true of importing and not of reading: this repo already reads deployed state it cannot import, in `seed_fan_in_workflow.py --check`. `boto3` is already a dependency.

## What this adds

`scripts/check_runtime_ceiling.py` — reads both ceilings off the deployed Lambda and compares them with what this checkout declares:

- `RUNTIME_TIMEOUT_CEILING_SECONDS` vs the deployed `AGENT_RUNTIME_MAX_SECONDS`, naming the direction (`WIDENED` / `NARROWED`)
- `AGENT_TIMEOUT_SECONDS` vs what the deployment will actually grant — `CLAMPED` above it, `UNSPENT` below it (instance 5's shape)
- every stage's `max_turns` vs `AGENT_RUNTIME_MAX_TURNS`, swept from `discover_definition_factories()` so hole 1 is not recreated in a script
- the granted budget vs the function's own `Timeout` (`NO ROOM`) — a run that spends its full budget is killed by AWS first, which is neither a clamp nor a run error

`0` in step · `1` drifted · `2` cannot tell. Verified live rather than only unit-tested:

```
$ uv run python scripts/check_runtime_ceiling.py \
    --function-name biffo-platform-dev-plugin-agent-runtime
In step — AGENT_RUNTIME_MAX_SECONDS=300s matches RUNTIME_TIMEOUT_CEILING_SECONDS,
AGENT_TIMEOUT_SECONDS (300s) is exactly what the deployment grants, and every
declared max_turns fits under AGENT_RUNTIME_MAX_TURNS=10.        (exit 0)
```

confirmed independently against `aws lambda get-function-configuration` (`"AGENT_RUNTIME_MAX_SECONDS": "300"`, `Timeout: 360`, `AGENT_RUNTIME_MAX_TURNS: "10"`).

**No default function name, deliberately** — it would be a fourth copy of another repo's fact, wrong on every environment but one, in the tool built to remove such copies. **An unset ceiling exits 2, not 0**: resolving it to `agent_runtime`'s code default would make this depend on a hand-copy.

## Tests, each proven to fail without the fix

Reverted by file copy, one mutation at a time, then restored:

| mutation | test that caught it |
| --- | --- |
| unset ceiling resolved to `240.0` | `test_an_unset_ceiling_is_cannot_tell_and_never_a_pass`, `test_a_definite_drift_outranks_an_unanswerable_half` |
| `UNSPENT` branch deleted | `test_a_widened_ceiling_is_reported_as_unspent_headroom` |
| `CANNOT_TELL` given precedence over `DRIFTED` | `test_a_definite_drift_outranks_an_unanswerable_half` |
| `CLAMPED` branch deleted | `test_a_narrowed_ceiling_is_reported_as_a_clamp` |
| turn sweep truncated to one factory | `test_every_definition_factory_is_swept_for_turn_budgets` |
| `NO ROOM` check neutered | `test_a_lambda_timeout_below_the_granted_budget_is_reported` |
| `main` returning `IN_STEP` on an unreadable deployment | `test_an_unreadable_deployment_exits_cannot_tell` |

## Comments corrected because this makes them false

- `test_marketing_agent_run_limits.py` said of the two remaining remedies *"neither is buildable from here"*. One shipped upstream (#1586); the other is this script.
- `RUNTIME_TIMEOUT_CEILING_SECONDS`'s docstring pointed at a raw `aws lambda get-function-configuration`; it now points at the check that says what the answer means.

## Not verified

Only `biffo-platform-dev` was read — I have no credentials for the tabsii account, so the tabsii deployment is unchecked by me. This also does not prove the *plugin* deployed beside that runtime is this checkout; `seed_fan_in_workflow.py --check` is the tool for that half.

Gates: `uv run pytest` (871 passed, 4 skipped), `ruff check`, `ruff format --check`, `pyright` (0 errors), web-admin lint/typecheck/test all green (front end untouched).