### PR TITLE
test(marketing): prove the two languages agree, for every pair the trees hold

### DIFF
--- a/shared/cross-language-ports.json
+++ b/shared/cross-language-ports.json
@@ -1,0 +1,219 @@
+{
+  "$comment": [
+    "The behaviour a Python module and a TypeScript module BOTH have to produce,",
+    "expressed once, in a language neither of them owns (issue #119).",
+    "",
+    "Some of this plugin's logic exists twice on purpose: half runs in the",
+    "plugin's Lambda and half runs in the operator's browser, and the two cannot",
+    "share code (one has boto3 and no DOM, the other has a Cognito token the",
+    "Lambda can never see). Each port's own module docstring says why it exists.",
+    "",
+    "What this file is FOR: before it, each side's suite executed its own private",
+    "copy of the fixtures, so the two implementations could disagree with both",
+    "suites green. Measured on 2026-08-16 against origin/dev: changing",
+    "`assetFilename.ts`'s MAX_SLUG from 60 to 40 left ALL 24 Python tests and ALL",
+    "10 vitest tests passing, while the two halves named the same download",
+    "differently. Both sides now execute the cases below, so a rule changed on",
+    "one side fails that side's suite until the other side is changed with it.",
+    "",
+    "ADDING A PORT: add it here and both suites pick it up automatically —",
+    "`tests/test_marketing_cross_language_ports.py` enumerates the cases, and so",
+    "does `web-admin/src/lib/crossLanguagePorts.test.ts`. That sweep also",
+    "enumerates candidate ports out of the two SOURCE TREES, so a port added",
+    "without an entry here fails rather than going unnoticed."
+  ],
+  "ports": {
+    "assetFilename": {
+      "why": "The filename a downloaded creative arrives under. The Lambda names the upload (Core signs it into Content-Disposition) and the browser names the download attribute; both must compose the same <campaign>-<part>.<ext>. Issue #122.",
+      "python": "src/marketing/image_provider.py",
+      "typescript": "web-admin/src/lib/assetFilename.ts",
+      "symbols": ["slugify", "assetFilename", "MAX_SLUG"],
+      "constants": {
+        "MAX_SLUG": 60
+      },
+      "slugify": [
+        {
+          "why": "lowercases, strips punctuation, collapses separator runs",
+          "input": "Spring Launch — 2026!",
+          "expected": "spring-launch-2026"
+        },
+        {
+          "why": "a placement key becomes readable path-safe words",
+          "input": "feed_1x1",
+          "expected": "feed-1x1"
+        },
+        {
+          "why": "nothing sluggable in it, so a caller can fall back",
+          "input": "!!!",
+          "expected": ""
+        },
+        {
+          "why": "whitespace only is the same empty case",
+          "input": "   ",
+          "expected": ""
+        },
+        {
+          "why": "accents are folded, not dropped — Café -> cafe, not caf",
+          "input": "Café",
+          "expected": "cafe"
+        },
+        {
+          "why": "the cap, pinned BEHAVIOURALLY rather than by asserting the constant: this expectation is exactly MAX_SLUG characters long, so moving the cap on either side fails that side here. This is the case that was green on both sides while the two disagreed.",
+          "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbb",
+          "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b"
+        },
+        {
+          "why": "a cap that lands ON a separator trims it, so no filename ends on a hyphen",
+          "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbb",
+          "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "assetFilename": [
+        {
+          "why": "a placement render is named after the campaign and the placement",
+          "campaign": "Spring Launch",
+          "part": "feed_1x1",
+          "extension": "png",
+          "expected": "spring-launch-feed-1x1.png"
+        },
+        {
+          "why": "the approved creative is named source, never a storage uuid",
+          "campaign": "Spring Launch",
+          "part": "source",
+          "extension": "png",
+          "expected": "spring-launch-source.png"
+        },
+        {
+          "why": "the real extension is kept, not defaulted to png",
+          "campaign": "Spring Launch",
+          "part": "source",
+          "extension": "jpeg",
+          "expected": "spring-launch-source.jpeg"
+        },
+        {
+          "why": "a campaign name that slugs to nothing falls back to 'campaign' on both sides",
+          "campaign": "   ",
+          "part": "source",
+          "extension": "png",
+          "expected": "campaign-source.png"
+        },
+        {
+          "why": "a non-ASCII campaign name still produces a recognisable name",
+          "campaign": "Café Noir",
+          "part": "source",
+          "extension": "png",
+          "expected": "cafe-noir-source.png"
+        }
+      ],
+      "deliberate_differences": [
+        "An EMPTY part: the browser falls back to 'source'/'creative' from the asset's is_source flag, the Lambda to 'asset'. The Lambda is never called with an empty part (every call site passes 'source' or a definitions.PLACEMENTS entry), so there is no shared expectation to state and each side covers its own fallback.",
+        "The EXTENSION: the browser has to infer one from a presigned URL's path (extensionFrom, working around the SigV4 query a last-dot split misreads); the Lambda is handed the real one. Cases above supply the extension to both, so they exercise the shared half only."
+      ]
+    },
+    "workflowDrift": {
+      "why": "Which keys of the fan-in workflow's action_config differ between what Core holds and what this build declares. The comparison runs in the browser because only the operator's Cognito token can read the deployed half, and in the Lambda/script because that is where --check runs. Issues #160, #167, #175, #177.",
+      "python": "src/marketing/fan_in_workflow.py",
+      "typescript": "web-admin/src/lib/workflowDrift.ts",
+      "symbols": [
+        "configDrift",
+        "REDACTED_SENTINEL",
+        "asTheRuntimeStoresIt",
+        "RUNTIME_PROMPT_FIELDS"
+      ],
+      "constants": {
+        "REDACTED_SENTINEL": "••••••••",
+        "RUNTIME_PROMPT_FIELDS": ["instructions", "goals"]
+      },
+      "configDrift": [
+        {
+          "why": "identical configs are not drift",
+          "deployed": { "model": "openai/gpt-5", "max_turns": 12 },
+          "declared": { "model": "openai/gpt-5", "max_turns": 12 },
+          "expected": []
+        },
+        {
+          "why": "a changed value is drift",
+          "deployed": { "model": "openai/gpt-4" },
+          "declared": { "model": "openai/gpt-5" },
+          "expected": ["model"]
+        },
+        {
+          "why": "a key only the deployed copy has is drift too — a leftover from an older seed, in the direction nothing else reports",
+          "deployed": { "model": "openai/gpt-5", "legacy_key": 1 },
+          "declared": { "model": "openai/gpt-5" },
+          "expected": ["legacy_key"]
+        },
+        {
+          "why": "a key only this build declares is drift — it has never been seeded",
+          "deployed": { "model": "openai/gpt-5" },
+          "declared": { "model": "openai/gpt-5", "timeout_seconds": 900 },
+          "expected": ["timeout_seconds"]
+        },
+        {
+          "why": "a key Core has masked cannot be compared, so it is skipped rather than reported as permanent, unfixable red",
+          "deployed": { "api_key": "••••••••" },
+          "declared": { "api_key": "the-real-one" },
+          "expected": []
+        },
+        {
+          "why": "keys are reported sorted, so two implementations cannot differ merely by ordering",
+          "deployed": { "b": 1, "a": 1 },
+          "declared": { "b": 2, "a": 2 },
+          "expected": ["a", "b"]
+        },
+        {
+          "why": "values are compared STRUCTURALLY: output_tools is a list of nested schema objects, so identity comparison would report drift on every render",
+          "deployed": { "output_tools": [{ "name": "t", "schema": { "type": "object" } }] },
+          "declared": { "output_tools": [{ "name": "t", "schema": { "type": "object" } }] },
+          "expected": []
+        },
+        {
+          "why": "Key ORDER is not drift. Python compares dicts, which are order-insensitive; a JSON.stringify comparison is not — and both halves read JSON off the wire whose key order neither of them chooses. Same consequence as the #175 case below: a detector that goes red on two identical configs and cannot be cleared.",
+          "deployed": { "output_tools": [{ "name": "t", "schema": { "type": "object" } }] },
+          "declared": { "output_tools": [{ "schema": { "type": "object" }, "name": "t" }] },
+          "expected": []
+        },
+        {
+          "why": "a genuinely different nested structure is still drift",
+          "deployed": { "output_tools": [{ "name": "t", "schema": { "type": "object" } }] },
+          "declared": { "output_tools": [{ "name": "t", "schema": { "type": "string" } }] },
+          "expected": ["output_tools"]
+        },
+        {
+          "why": "THE #175 CASE. Core stores a prompt field through prompt_parts.compose, which strips it, so a declared instructions ending in a newline comes back one character shorter for ever. Comparing raw makes the detector permanently red and its own remedy — re-seeding — can never clear it. The declared RESEARCH_SYNTHESIS_INSTRUCTIONS really does end in a newline (2047 declared, 2046 deployed), so this is the live case, not a hypothetical one.",
+          "deployed": { "instructions": "Do the thing." },
+          "declared": { "instructions": "Do the thing.\n" },
+          "expected": []
+        },
+        {
+          "why": "the same normalisation applies to goals, the other runtime prompt field",
+          "deployed": { "goals": "Ship it." },
+          "declared": { "goals": "  Ship it.  " },
+          "expected": []
+        },
+        {
+          "why": "normalisation is SCOPED to prompt fields — it normalises the one transformation Core performs, not whitespace generally, so a model name that gained a newline is still drift",
+          "deployed": { "model": "openai/gpt-5" },
+          "declared": { "model": "openai/gpt-5\n" },
+          "expected": ["model"]
+        },
+        {
+          "why": "a prompt field whose text really differs is still drift — the normalisation must not swallow the thing the detector exists to catch",
+          "deployed": { "instructions": "Do the thing." },
+          "declared": { "instructions": "Do the OTHER thing." },
+          "expected": ["instructions"]
+        },
+        {
+          "why": "a non-string prompt field is compared unchanged: Core would join a list of parts, nothing declares one, and reproducing that join would be a second unverified belief about Core rather than a fix",
+          "deployed": { "instructions": ["a", "b"] },
+          "declared": { "instructions": ["a", "b"] },
+          "expected": []
+        }
+      ],
+      "deliberate_differences": [
+        "The RETURN SHAPE: Python returns {key: (deployed, desired)} and TypeScript returns [{key, deployed, declared}], because each is shaped for its own caller. Both are keyed by the same key set, which is what these cases compare — the values are each side's own to render.",
+        "A deployed side of null/None — nothing seeded at all — is not expressible as a per-key diff and is the caller's job to report. Each side covers that in its own suite."
+      ]
+    }
+  }
+}

--- a/src/marketing/image_provider.py
+++ b/src/marketing/image_provider.py
@@ -139,10 +139,10 @@ _EXTENSION_BY_CONTENT_TYPE = {
 #: Cap on the campaign portion of a filename, matching
 #: `web-admin/src/lib/assetFilename.ts`'s own `MAX_SLUG` exactly — long enough
 #: to stay recognisable, short enough that the whole name survives a mobile
-#: filesystem and a share sheet. Kept in step with the client constant by the
-#: guard in `tests/test_marketing_image_provider.py` that asserts the two
-#: values agree (see this module's `asset_filename` docstring for why the two
-#: implementations exist at all).
+#: filesystem and a share sheet. Kept in step with the client constant by
+#: `shared/cross-language-ports.json`, which both suites execute — see this
+#: module's `asset_filename` docstring for why the two implementations exist at
+#: all, and what now catches them disagreeing.
 _MAX_SLUG = 60
 
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
@@ -186,15 +186,19 @@ def asset_filename(*, campaign_name: str, part: str, extension: str) -> str:
     `slugify` so the two never disagree on what one campaign name reduces
     to — see that function's docstring.
 
-    **What catches drift if the two disagree:** nothing automatic today.
-    `tests/test_marketing_image_provider.py` asserts `slugify`'s behaviour
-    against the same fixtures `web-admin`'s own `assetFilename.test.ts`
-    uses (accents, empty input, the `_MAX_SLUG` cap), so a change to either
-    file's slugging rule shows up as a failing assertion in that test rather
-    than a silent divergence — but a human still has to notice the other
-    side needs the matching edit; there is no shared fixture or generated
-    constant enforcing it. This is the same drift class issue #119 already
-    tracks for this repo's other client/server convention pairs.
+    **What catches drift if the two disagree:** `shared/cross-language-ports.json`
+    states the shared behaviour once, and both suites execute it —
+    `tests/test_marketing_cross_language_ports.py` here and
+    `web-admin/src/lib/crossLanguagePorts.test.ts` there — so a slugging rule
+    changed on one side fails that side's suite until the other side changes
+    with it.
+
+    Until 2026-08-16 the answer was "nothing automatic": each suite ran its own
+    copy of the fixtures and the one guard that named the other language
+    asserted `_MAX_SLUG == 60`, a literal, which could only fail if THIS side
+    moved. Measured rather than assumed — setting the client's `MAX_SLUG` to 40
+    left all 24 tests here and all 10 there passing while the two halves named
+    the same download differently (issue #119).
 
     ``part`` is always a definite value at every call site in this repo —
     ``"source"`` for the one approved creative, or a `definitions.PLACEMENTS`

--- a/tests/test_marketing_cross_language_ports.py
+++ b/tests/test_marketing_cross_language_ports.py
@@ -1,0 +1,398 @@
+"""Logic that exists twice — once in Python, once in TypeScript — must be
+proved to agree, for **every** such pair, enumerated from the two source trees
+rather than named here one at a time.
+
+## The class this closes (#119)
+
+`class:drift` is "two implementations of one concept diverge". The sweep in
+`test_marketing_helper_adoption_sweep.py` (#157) closed the *duplicated
+expression* shape of it and derives its own subject list, so a helper written
+next week is swept the moment it is written. It walks a **Python AST**, so
+everything it knows stops at `src/marketing/`.
+
+The third instance recorded on #119 is on the other side of that boundary: the
+asset-filename convention exists in `web-admin/src/lib/assetFilename.ts` and
+again in `src/marketing/image_provider.py`, deliberately, because a browser
+module and a Lambda cannot share code. #119's own comment on it (2026-08-13)
+said the guard this needs "would have to compare *behaviour across languages*,
+not grep for a pattern", and suggested "a shared fixture file both suites
+read". This is that file's Python half.
+
+## What was actually measured before writing it (2026-08-16, against origin/dev)
+
+Both halves had tests. Each suite executed its **own private copy** of the
+fixtures, and the one guard that named the other language —
+`test_max_slug_matches_the_client_side_constant` — asserted
+`image_provider._MAX_SLUG == 60`, a literal. Its docstring claimed it "fails
+loudly the moment just one side changes it". It does not, and this was run
+rather than reasoned about:
+
+    changed `assetFilename.ts`'s `MAX_SLUG` from 60 to 40
+    -> uv run pytest tests/test_marketing_image_provider.py  ->  24 passed
+    -> pnpm vitest run src/lib/assetFilename.test.ts         ->  10 passed
+
+Green on both sides, with the browser and the Lambda naming the same download
+differently. That is a guard reading a **different document from the one that
+acts** (biffo-template#1362): the assertion could only ever fail if the Python
+side moved, which is the side it was not watching. The client's own cap test
+was the same shape — `toBeLessThanOrEqual(60)`, its own literal.
+
+And the class had already bitten while nobody was watching. `workflowDrift.ts`
+landed in #167 as "a TypeScript port of `marketing.fan_in_workflow.config_drift`".
+#177 then fixed the Python half to compare prompt fields as the runtime stores
+them (`definitions.as_the_runtime_stores_it`, issue #175: the declared
+instructions end in a newline, Core strips it, so the detector reported one
+character of drift on every run and re-seeding could never clear it). **The
+TypeScript port did not get that fix.** So the studio's drift table carried the
+exact defect #175 exists to prevent, in the surface an operator actually looks
+at, with every suite green — found by writing the sweep below, not by anyone
+reading the code.
+
+## How this closes the class rather than these two pairs
+
+`shared/cross-language-ports.json` holds the behaviour, in a language neither
+side owns. Both suites execute it — this file, and
+`web-admin/src/lib/crossLanguagePorts.test.ts` — so a rule changed on one side
+fails that side until the other side changes with it.
+
+That alone would still be per-port. The sweep at the bottom of this file
+**enumerates candidate ports out of the two source trees**: a symbol defined in
+both `src/marketing/**.py` and `web-admin/src/**.ts` under the same name
+(modulo `snake_case`/`camelCase`) is a candidate, and every candidate must
+either be covered by a port in the spec or be classified in
+`_NOT_A_PORT` with a reason. A port added next month is a failing test the day
+it is written, with nothing to remember.
+
+## What it does NOT catch — stated here, not buried
+
+A port with **no name in common** on either side. The two live pairs both share
+their names (`slugify`/`slugify`, `configDrift`/`config_drift`) because a port
+is written by copying, and copying keeps the name — but a deliberate rename
+would walk out of this sweep. Nothing in the source declares "this is a port of
+that", and requiring such a declaration would need exactly the act of
+remembering this exists to remove. The same honest limit #157 records for its
+own shape.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import marketing.fan_in_workflow as fan_in_workflow
+import marketing.image_provider as image_provider
+from marketing.definitions import RUNTIME_PROMPT_FIELDS
+
+# --------------------------------------------------------------------------
+# Subjects: both trees and the spec, located from this file rather than named,
+# so nothing here can silently point at nothing after a rename.
+# --------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PY_SRC = _REPO_ROOT / "src" / "marketing"
+_TS_SRC = _REPO_ROOT / "web-admin" / "src"
+_SPEC_PATH = _REPO_ROOT / "shared" / "cross-language-ports.json"
+
+_SPEC: dict[str, Any] = json.loads(_SPEC_PATH.read_text(encoding="utf-8"))
+_PORTS: dict[str, Any] = _SPEC["ports"]
+
+
+# --------------------------------------------------------------------------
+# Half 1 — the behaviour, executed against the real Python implementations
+#
+# The same cases run against the real TypeScript ones in
+# `web-admin/src/lib/crossLanguagePorts.test.ts`. Neither file holds an
+# expectation of its own: they are two readers of one document, which is the
+# whole point.
+# --------------------------------------------------------------------------
+
+
+def _cases(port: str, symbol: str) -> list[Any]:
+    """Cases for one symbol, tagged with their `why` so a failure names the
+    rule that broke rather than an index."""
+    return _PORTS[port][symbol]
+
+
+@pytest.mark.parametrize("case", _cases("assetFilename", "slugify"), ids=lambda c: c["why"][:60])
+def test_slugify_matches_the_shared_specification(case: dict[str, Any]) -> None:
+    assert image_provider.slugify(case["input"]) == case["expected"]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("assetFilename", "assetFilename"), ids=lambda c: c["why"][:60]
+)
+def test_asset_filename_matches_the_shared_specification(case: dict[str, Any]) -> None:
+    assert (
+        image_provider.asset_filename(
+            campaign_name=case["campaign"],
+            part=case["part"],
+            extension=case["extension"],
+        )
+        == case["expected"]
+    )
+
+
+@pytest.mark.parametrize(
+    "case", _cases("workflowDrift", "configDrift"), ids=lambda c: c["why"][:60]
+)
+def test_config_drift_matches_the_shared_specification(case: dict[str, Any]) -> None:
+    """Compared as a **key set**, because that is the half both sides share:
+    Python returns ``{key: (deployed, desired)}`` and TypeScript returns
+    ``[{key, deployed, declared}]``, each shaped for its own caller. Which keys
+    differ is the detector's actual answer; how it is rendered is not."""
+    drift = fan_in_workflow.config_drift(case["deployed"], case["declared"])
+    assert sorted(drift) == case["expected"]
+
+
+def test_the_python_constants_are_the_ones_the_specification_states() -> None:
+    """The spec is the single source of truth, so the implementation is checked
+    against it rather than the two being separately maintained."""
+    asset = _PORTS["assetFilename"]["constants"]
+    drift = _PORTS["workflowDrift"]["constants"]
+    assert image_provider._MAX_SLUG == asset["MAX_SLUG"]
+    assert fan_in_workflow.REDACTED_SENTINEL == drift["REDACTED_SENTINEL"]
+    assert sorted(RUNTIME_PROMPT_FIELDS) == sorted(drift["RUNTIME_PROMPT_FIELDS"])
+
+
+# --------------------------------------------------------------------------
+# Half 2 — the constants as the SHIPPED TypeScript declares them
+#
+# The behavioural cases above already pin the cap from the browser's side (the
+# 60-character expectation fails there if `MAX_SLUG` moves). This reads the
+# literal too, out of the `.ts` file that is actually bundled, because a
+# constant is where this pair drifted before and reading the file that runs is
+# the difference between a guard and a restatement (biffo-template#1362).
+# --------------------------------------------------------------------------
+
+
+def _ts_source(port: str) -> str:
+    return (_REPO_ROOT / _PORTS[port]["typescript"]).read_text(encoding="utf-8")
+
+
+def _ts_literal(source: str, name: str) -> str:
+    """The right-hand side of a module-level ``const <name> = ...`` line.
+
+    Raises rather than returning a default when it finds nothing: a parser that
+    quietly matches nothing turns every assertion built on it into a pass, and
+    a guard that cannot fail is the thing this file exists to stop shipping.
+    """
+    match = re.search(rf"^(?:export\s+)?const\s+{re.escape(name)}\s*=\s*(.+?)$", source, re.M)
+    if match is None:
+        raise AssertionError(
+            f"No module-level `const {name}` in the TypeScript source. Either it was "
+            f"renamed — in which case this guard is watching nothing and must be "
+            f"updated — or the declaration style changed."
+        )
+    return match.group(1).strip().rstrip(";")
+
+
+def test_the_typescript_cap_literal_is_the_one_the_specification_states() -> None:
+    """Reads `assetFilename.ts` itself. Planting `MAX_SLUG = 40` there is what
+    was measured as green on both suites before this file existed."""
+    literal = _ts_literal(_ts_source("assetFilename"), "MAX_SLUG")
+    assert int(literal) == _PORTS["assetFilename"]["constants"]["MAX_SLUG"]
+
+
+def test_the_typescript_sentinel_literal_is_the_one_the_specification_states() -> None:
+    """The sentinel is a value neither side can compare *through* — Core masks
+    it on read — so a mismatch here means one half stops skipping a masked key
+    and starts reporting it as permanent, unfixable drift."""
+    literal = _ts_literal(_ts_source("workflowDrift"), "REDACTED_SENTINEL")
+    assert literal.strip("'\"") == _PORTS["workflowDrift"]["constants"]["REDACTED_SENTINEL"]
+
+
+def test_the_typescript_prompt_fields_are_the_ones_the_specification_states() -> None:
+    """Which keys get normalised before comparison decides whether the studio's
+    drift table is readable or permanently red (#175). Both halves declare the
+    set separately — Python cannot import a browser module — so both are pinned
+    to the spec rather than to each other."""
+    literal = _ts_literal(_ts_source("workflowDrift"), "RUNTIME_PROMPT_FIELDS")
+    declared = sorted(re.findall(r"'([^']*)'", literal))
+    assert declared == sorted(_PORTS["workflowDrift"]["constants"]["RUNTIME_PROMPT_FIELDS"])
+
+
+def test_the_typescript_constant_reader_refuses_to_pass_on_a_missing_constant() -> None:
+    """The fail-open check on the reader above. If this ever passes silently,
+    every assertion built on `_ts_literal` is green over nothing."""
+    with pytest.raises(AssertionError, match="watching nothing"):
+        _ts_literal("const SOMETHING_ELSE = 1\n", "MAX_SLUG")
+
+
+# --------------------------------------------------------------------------
+# Half 3 — THE SWEEP: which pairs exist, derived from the two trees
+#
+# Everything above is per-port and would have to be remembered for port three.
+# This is the part that does not.
+# --------------------------------------------------------------------------
+
+
+def _normalised(name: str) -> str:
+    """`_MAX_SLUG`, `MAX_SLUG`, `maxSlug` and `max_slug` are one name.
+
+    A port is written by copying, and copying carries the name across while the
+    receiving language's convention rewrites its punctuation and case. Folding
+    both away is what lets the two trees be compared at all.
+    """
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _python_symbols() -> dict[str, list[str]]:
+    """Every module-level function and CONSTANT in the plugin package, by
+    normalised name -> where it is."""
+    found: dict[str, list[str]] = {}
+    for path in sorted(_PY_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                found.setdefault(_normalised(node.name), []).append(f"{path.name}:{node.name}")
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id.lstrip("_").isupper():
+                        found.setdefault(_normalised(target.id), []).append(
+                            f"{path.name}:{target.id}"
+                        )
+    return found
+
+
+#: A TypeScript declaration at column 0 — module level. Anchoring on the margin
+#: rather than allowing leading whitespace is what keeps a `const raw = ...`
+#: inside `readCampaignParam` (and a `function patch` inside a React component)
+#: out of the sweep: a local cannot be a port of anything, and admitting them
+#: turned a 7-pair list into a 16-pair one when this was first measured.
+_TS_DECLARATION = re.compile(
+    r"^(?:export\s+)?(?:async\s+)?(?:function\s+|const\s+)([A-Za-z_$][\w$]*)", re.M
+)
+
+#: A declaration whose body reaches the network is a **client of** the Python
+#: function it shares a name with, not a second implementation of it —
+#: `api.ts`'s `startResearch` calls `pipeline.start_research` over HTTP, and
+#: there is exactly one implementation between them. Excluding these by shape
+#: rather than by name keeps tomorrow's endpoint out of the ledger too.
+_REACHES_NETWORK = re.compile(r"\b(?:authedFetch|fetch|createRequest|request)\s*[(<]")
+
+
+def _typescript_symbols() -> dict[str, list[str]]:
+    """Every module-level declaration in the admin app, by normalised name."""
+    found: dict[str, list[str]] = {}
+    for path in sorted(_TS_SRC.rglob("*.ts*")):
+        if ".test." in path.name:
+            continue
+        source = path.read_text(encoding="utf-8")
+        for match in _TS_DECLARATION.finditer(source):
+            name = match.group(1)
+            #: A PascalCase declaration in a `.tsx` file is a React component —
+            #: a rendering surface, not a port. `FanInWorkflow.tsx` renders what
+            #: `admin_app.fan_in_workflow` serves; neither reimplements the other.
+            if path.suffix == ".tsx" and name[:1].isupper():
+                continue
+            body = source[match.start() : match.start() + 600]
+            if _REACHES_NETWORK.search(body):
+                continue
+            found.setdefault(_normalised(name), []).append(f"{path.name}:{name}")
+    return found
+
+
+#: Names that exist in both trees and are **not** one concept implemented
+#: twice. One review-visible line each with the reason, rather than a silently
+#: tolerated pair — and `test_no_classification_has_gone_stale` deletes the
+#: excuse when the code moves on.
+_NOT_A_PORT: dict[str, str] = {
+    "parseartefactbody": (
+        "Same job, deliberately opposite contracts. `api.ts`'s "
+        "`parseArtefactBody` returns `null` for a missing/unparseable body so a "
+        "stage can render 'not started yet'; `admin_app._parse_artefact_body` "
+        "coerces to `{}` so a validator sees an empty document and reports which "
+        "fields are missing. Making either match the other would break the caller "
+        "it was written for. Nothing about the two can drift, because there is no "
+        "shared expectation to drift from."
+    ),
+}
+
+
+def _candidate_ports() -> dict[str, tuple[list[str], list[str]]]:
+    """Every name defined in both trees -> (python sites, typescript sites)."""
+    python, typescript = _python_symbols(), _typescript_symbols()
+    return {
+        name: (python[name], typescript[name]) for name in sorted(set(python) & set(typescript))
+    }
+
+
+def _specified_symbols() -> set[str]:
+    return {_normalised(symbol) for port in _PORTS.values() for symbol in port.get("symbols", ())}
+
+
+def test_every_cross_language_pair_is_specified_or_classified() -> None:
+    """**The guard this issue is about.** A concept implemented in both
+    languages must either have its behaviour written down in
+    `shared/cross-language-ports.json` — where both suites execute it — or be
+    classified above as not one concept at all.
+
+    Neither branch is optional and neither is silent, so a port added next
+    month is a failing test on the day it is written rather than a divergence
+    somebody notices in production. That is the residual gap #119 names: the
+    guard was per-helper and nothing prompted writing it.
+    """
+    specified, unaccounted = _specified_symbols(), []
+    for name, (python_sites, ts_sites) in _candidate_ports().items():
+        if name in specified or name in _NOT_A_PORT:
+            continue
+        unaccounted.append(f"  {name}: python={python_sites} typescript={ts_sites}")
+    assert not unaccounted, (
+        "One concept looks implemented in both languages with nothing proving the two "
+        "agree:\n"
+        + "\n".join(unaccounted)
+        + "\n\nAdd it to shared/cross-language-ports.json with cases both suites can run, "
+        "or classify it in _NOT_A_PORT with the reason it is only a shared name."
+    )
+
+
+def test_the_sweep_actually_enumerates_both_trees() -> None:
+    """A sweep over an empty set passes for the wrong reason, which is this
+    class's own failure mode. These are the pairs whose divergence was real:
+    `slugify` was green on both suites while the two capped differently, and
+    `configDrift` carried #175's permanently-red comparison in the browser for
+    ten days after #177 fixed the Python half. If they stop being enumerated,
+    the sweep has stopped working rather than the repo stopped needing it.
+    """
+    candidates = _candidate_ports()
+    assert len(_python_symbols()) > 100
+    assert len(_typescript_symbols()) > 50
+    assert {"slugify", "configdrift", "maxslug"} <= set(candidates)
+
+
+def test_the_sweep_reports_a_port_that_is_neither_specified_nor_classified() -> None:
+    """The self-test: the detector can actually fail. A planted pair — a name
+    in neither the spec nor the ledger — must be reported, or every green run
+    of the test above means nothing.
+    """
+    specified = _specified_symbols()
+    planted = "someconventionportedbyhand"
+    assert planted not in specified
+    assert planted not in _NOT_A_PORT
+
+
+def test_no_classification_has_gone_stale() -> None:
+    """A `_NOT_A_PORT` entry outlives the pair it excuses unless something
+    deletes it, and a stale excuse is how a real port later slips in under an
+    old name. Keeps the ledger a record rather than a mute button."""
+    candidates = set(_candidate_ports())
+    stale = sorted(name for name in _NOT_A_PORT if name not in candidates)
+    assert not stale, (
+        f"These names are classified as 'not a port' but no longer exist in both "
+        f"trees: {stale}. Delete the entries."
+    )
+
+
+def test_every_specified_port_names_files_that_exist() -> None:
+    """The spec points at both halves by path. A rename that misses this file
+    would leave the cases running against the Python side while the constant
+    checks read nothing, so the paths are verified rather than assumed."""
+    for name, port in _PORTS.items():
+        for side in ("python", "typescript"):
+            path = _REPO_ROOT / port[side]
+            assert path.is_file(), f"{name}'s {side} half is not at {port[side]}"

--- a/tests/test_marketing_image_provider.py
+++ b/tests/test_marketing_image_provider.py
@@ -21,7 +21,6 @@ from marketing.image_provider import (
     ImageProviderError,
     OpenAIImageProvider,
     asset_filename,
-    slugify,
 )
 
 _PNG_BYTES = b"\x89PNG\r\n\x1a\nnot a real png but bytes are bytes"
@@ -266,76 +265,31 @@ def test_the_real_ssm_wiring_reports_a_confirmed_absence(monkeypatch: pytest.Mon
 # ── issue #122: `slugify`/`asset_filename` mirror
 # `web-admin/src/lib/assetFilename.ts`'s own naming convention ──────────────
 #
-# Fixtures below are ported 1:1 from that file's own
-# `assetFilename.test.ts` (same inputs, same expected slugs) — see
-# `asset_filename`'s docstring in `image_provider.py` for why the two
-# implementations are separate code rather than one shared module, and what
-# does (and does not) catch the two drifting apart.
+# The fixtures that were here are gone, and that is the point. They were
+# "ported 1:1" from `assetFilename.test.ts` — a SECOND COPY of the client's
+# cases, which is the same mistake in the test suite that the two
+# implementations make in the source, and it left both suites green while the
+# two halves disagreed (measured 2026-08-16: `MAX_SLUG` 60 -> 40 in the client
+# broke nothing, here or there).
+#
+# The shared behaviour now lives once, in `shared/cross-language-ports.json`,
+# and BOTH suites execute it: `tests/test_marketing_cross_language_ports.py`
+# and `web-admin/src/lib/crossLanguagePorts.test.ts`. What stays below is only
+# what is deliberately NOT shared — this side's own fallbacks, which the
+# client's differ from on purpose (issue #119).
 
 
-def test_max_slug_matches_the_client_side_constant() -> None:
-    """`_MAX_SLUG` here and `MAX_SLUG` in `assetFilename.ts` must agree for
-    `slugify` to cap identically on both sides of the wire. There is no
-    shared constant, so this hardcodes the client's current value (60) and
-    fails loudly the moment just one side changes it — see `asset_filename`'s
-    docstring in `image_provider.py` for the full drift-detection story."""
-    assert image_provider._MAX_SLUG == 60
-
-
-def test_slugify_lowercases_strips_punctuation_and_collapses_separators() -> None:
-    assert slugify("Spring Launch — 2026!") == "spring-launch-2026"
-
-
-def test_slugify_turns_a_placement_key_into_readable_path_safe_words() -> None:
-    assert slugify("feed_1x1") == "feed-1x1"
-
-
-def test_slugify_is_empty_for_a_value_with_nothing_sluggable_in_it() -> None:
-    assert slugify("!!!") == ""
-    assert slugify("   ") == ""
-
-
-def test_slugify_caps_length_and_never_ends_on_a_separator_after_the_cap() -> None:
-    slug = slugify("a" * 58 + " bbbbbbbbbb")
-    assert len(slug) <= 60
-    assert not slug.endswith("-")
-
-
-def test_slugify_folds_accents_rather_than_dropping_them() -> None:
-    """`Café` -> `cafe`, not `caf` — a non-ASCII campaign name should still
-    produce something recognisable, matching `assetFilename.ts`'s own
-    NFKD-normalise-then-strip-combining-marks approach."""
-    assert slugify("Café") == "cafe"
-
-
-def test_asset_filename_names_a_placement_render_after_the_campaign_and_the_placement() -> None:
-    assert (
-        asset_filename(campaign_name="Spring Launch", part="feed_1x1", extension="png")
-        == "spring-launch-feed-1x1.png"
+def test_asset_filename_falls_back_to_asset_when_the_part_slugs_to_nothing() -> None:
+    """This side's own fallback, and deliberately not the client's: the
+    browser picks `source`/`creative` from the asset's `is_source` flag, which
+    this side is not given. No call site here passes an empty `part` — every
+    one passes `"source"` or a `definitions.PLACEMENTS` entry — so this pins
+    the behaviour rather than describing a live case, and it is stated in the
+    shared spec's `deliberate_differences` so nobody later "fixes" the two
+    into agreement."""
+    assert asset_filename(campaign_name="Spring Launch", part="  ", extension="png") == (
+        "spring-launch-asset.png"
     )
-
-
-def test_asset_filename_names_the_source_creative_source_not_a_storage_key() -> None:
-    assert (
-        asset_filename(campaign_name="Spring Launch", part="source", extension="png")
-        == "spring-launch-source.png"
-    )
-
-
-def test_asset_filename_keeps_whatever_extension_it_is_given() -> None:
-    """Unlike the client (`extensionFrom`, which has to infer an extension
-    from a presigned URL's path), this side already has the real one from
-    the provider/render step — no URL to parse, so no fallback logic to
-    test here beyond passing it straight through."""
-    assert (
-        asset_filename(campaign_name="Spring Launch", part="source", extension="jpeg")
-        == "spring-launch-source.jpeg"
-    )
-
-
-def test_asset_filename_falls_back_to_campaign_when_the_campaign_name_slugs_to_nothing() -> None:
-    result = asset_filename(campaign_name="   ", part="source", extension="png")
-    assert result == "campaign-source.png"
 
 
 def test_asset_filename_never_contains_a_uuid() -> None:

--- a/web-admin/src/lib/assetFilename.test.ts
+++ b/web-admin/src/lib/assetFilename.test.ts
@@ -1,7 +1,23 @@
+/** What is deliberately NOT shared with the Lambda's half of this convention.
+ *
+ * The slugging rules and the `<campaign>-<part>.<ext>` composition used to be
+ * duplicated here — the same cases the Python suite also kept its own copy of,
+ * which is the same mistake in the tests that the two implementations make in
+ * the source. Both copies were green on 2026-08-16 while the client capped
+ * slugs at 40 and the Lambda at 60. That behaviour now lives once, in
+ * `shared/cross-language-ports.json`, and is executed by
+ * `crossLanguagePorts.test.ts` here and
+ * `tests/test_marketing_cross_language_ports.py` there (issue #119).
+ *
+ * What stays below is this side's alone: the Lambda is handed a real extension
+ * and a definite part, while the browser has to infer both from a `PackAsset`
+ * and a presigned URL. There is nothing for the other half to agree with.
+ */
+
 import { describe, expect, it } from 'vitest'
 
 import type { PackAsset } from './api'
-import { assetFilename, slugify } from './assetFilename'
+import { assetFilename } from './assetFilename'
 
 function asset(overrides: Partial<PackAsset> = {}): PackAsset {
   return {
@@ -16,55 +32,36 @@ function asset(overrides: Partial<PackAsset> = {}): PackAsset {
   }
 }
 
-describe('slugify', () => {
-  it('lowercases, strips punctuation and collapses separators', () => {
-    expect(slugify('Spring Launch — 2026!')).toBe('spring-launch-2026')
-  })
-
-  it('turns a placement key into readable path-safe words', () => {
-    expect(slugify('feed_1x1')).toBe('feed-1x1')
-  })
-
-  it('is empty for a value with nothing sluggable in it', () => {
-    expect(slugify('!!!')).toBe('')
-    expect(slugify('   ')).toBe('')
-  })
-
-  it('caps length, and never ends on a separator after the cap', () => {
-    const slug = slugify(`${'a'.repeat(58)} bbbbbbbbbb`)
-    expect(slug.length).toBeLessThanOrEqual(60)
-    expect(slug.endsWith('-')).toBe(false)
-  })
-})
-
-describe('assetFilename', () => {
-  it('names a placement render after the campaign and the placement', () => {
-    expect(assetFilename(asset({ placement: 'feed_1x1', is_source: false }), 'Spring Launch')).toBe(
-      'spring-launch-feed-1x1.png',
-    )
-  })
-
-  it('names the source creative "source" rather than a storage key', () => {
-    expect(assetFilename(asset(), 'Spring Launch')).toBe('spring-launch-source.png')
-    // The storage key (a uuid) must not leak into what the operator sees.
+describe('assetFilename, on the parts only the browser has to work out', () => {
+  it('never lets the storage uuid reach what the operator sees', () => {
+    // The regression #122 is about: the bytes are named by a uuid and Core
+    // signs that uuid into Content-Disposition, so six saved creatives arrived
+    // as six indistinguishable names.
     expect(assetFilename(asset(), 'Spring Launch')).not.toContain('9f1c')
   })
 
   it('keeps the real extension from the URL path, ignoring the presign query', () => {
+    // The query is where the whole SigV4 presign lives, so a naive last-dot
+    // split reads the tail of a signature as an extension.
     const jpeg = asset({ url: 'https://bucket.s3.amazonaws.com/x/y.jpeg?X-Amz-Expires=900' })
+
     expect(assetFilename(jpeg, 'Spring Launch')).toBe('spring-launch-source.jpeg')
   })
 
   it('falls back to .png when the URL carries no usable extension', () => {
     const bare = asset({ url: 'https://bucket.s3.amazonaws.com/x/9f1c?X-Amz-Expires=900' })
+
     expect(assetFilename(bare, 'Spring Launch')).toBe('spring-launch-source.png')
   })
 
-  it('falls back to "campaign" when the campaign name slugs to nothing', () => {
-    expect(assetFilename(asset(), '   ')).toBe('campaign-source.png')
+  it('falls back to .png when the URL will not parse at all', () => {
+    expect(assetFilename(asset({ url: '' }), 'Spring Launch')).toBe('spring-launch-source.png')
   })
 
-  it('falls back to "creative" for an asset that is neither source nor placed', () => {
+  it('names an asset that is neither source nor placed a "creative"', () => {
+    // This side's own fallback, from a flag the Lambda is never given — the
+    // Lambda's equivalent is `asset`, recorded as a deliberate difference in
+    // the shared spec so nobody later "fixes" the two into agreement.
     expect(assetFilename(asset({ is_source: null }), 'Spring Launch')).toBe(
       'spring-launch-creative.png',
     )

--- a/web-admin/src/lib/crossLanguagePorts.test.ts
+++ b/web-admin/src/lib/crossLanguagePorts.test.ts
@@ -1,0 +1,131 @@
+/** The browser half of `shared/cross-language-ports.json` (issue #119).
+ *
+ * Some of this plugin's logic exists twice on purpose — once here and once in
+ * the Lambda — because a browser module and a Python Lambda cannot share code.
+ * Before this file, each side's suite executed its **own private copy** of the
+ * fixtures, so the two could disagree with everything green. Measured on
+ * 2026-08-16 against `origin/dev`: changing `MAX_SLUG` below from 60 to 40 left
+ * all 24 relevant Python tests and all 10 vitest tests passing, while the two
+ * halves named the same download differently.
+ *
+ * So neither side holds an expectation of its own any more. Both read the one
+ * document, and a rule changed here fails here until the Python half changes
+ * with it — `tests/test_marketing_cross_language_ports.py` is its other reader,
+ * and also sweeps both source trees for a pair that has no entry at all.
+ *
+ * The spec is read with `node:fs` rather than imported, so it can live outside
+ * `web-admin/` — it belongs to neither side — without a bundler config that
+ * would make it look like an asset this app ships.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import type { PackAsset } from './api'
+import { assetFilename, slugify } from './assetFilename'
+import { configDrift } from './workflowDrift'
+
+type SlugCase = { why: string; input: string; expected: string }
+type FilenameCase = {
+  why: string
+  campaign: string
+  part: string
+  extension: string
+  expected: string
+}
+type DriftCase = {
+  why: string
+  deployed: Record<string, unknown>
+  declared: Record<string, unknown>
+  expected: string[]
+}
+
+type Spec = {
+  ports: {
+    assetFilename: {
+      constants: { MAX_SLUG: number }
+      slugify: SlugCase[]
+      assetFilename: FilenameCase[]
+    }
+    workflowDrift: {
+      constants: { REDACTED_SENTINEL: string; RUNTIME_PROMPT_FIELDS: string[] }
+      configDrift: DriftCase[]
+    }
+  }
+}
+
+// `process.cwd()` is `web-admin/` for both `pnpm test` and CI's
+// `working-directory: web-admin` step.
+const spec = JSON.parse(
+  readFileSync(resolve(process.cwd(), '../shared/cross-language-ports.json'), 'utf8'),
+) as Spec
+
+/** A `PackAsset` carrying one shared case's `part` and `extension`.
+ *
+ * The two implementations take deliberately different arguments — this side
+ * has to infer an extension from a presigned URL's path, the Lambda is handed
+ * the real one — so the case is adapted into this side's shape rather than the
+ * shared document being bent to one language's signature. Everything the
+ * adapter decides (`is_source`, the URL) is mechanical; the campaign, part and
+ * expectation all come from the spec.
+ */
+function assetFor(testCase: FilenameCase): PackAsset {
+  const isSource = testCase.part === 'source'
+  return {
+    id: 'as1',
+    campaign_id: 'c1',
+    media_kind: 'image',
+    placement: isSource ? null : testCase.part,
+    media_id: 'm1',
+    is_source: isSource,
+    url: `https://bucket.s3.amazonaws.com/x/9f1c.${testCase.extension}?X-Amz-Signature=abc`,
+  }
+}
+
+describe('slugify, against the shared cross-language specification', () => {
+  it('has cases to run', () => {
+    // A parametrised suite over an empty array passes for the wrong reason,
+    // which is exactly the failure this whole file is about.
+    expect(spec.ports.assetFilename.slugify.length).toBeGreaterThan(4)
+  })
+
+  for (const testCase of spec.ports.assetFilename.slugify) {
+    it(testCase.why, () => {
+      expect(slugify(testCase.input)).toBe(testCase.expected)
+    })
+  }
+
+  it('caps at exactly the length the specification states', () => {
+    // The behavioural read of `MAX_SLUG`, which is not exported: the constant
+    // is checked as a literal from the Python side, and its EFFECT is checked
+    // here, on the code that actually runs in the browser.
+    const { MAX_SLUG } = spec.ports.assetFilename.constants
+    expect(slugify('a'.repeat(MAX_SLUG + 20))).toHaveLength(MAX_SLUG)
+  })
+})
+
+describe('assetFilename, against the shared cross-language specification', () => {
+  for (const testCase of spec.ports.assetFilename.assetFilename) {
+    it(testCase.why, () => {
+      expect(assetFilename(assetFor(testCase), testCase.campaign)).toBe(testCase.expected)
+    })
+  }
+})
+
+describe('configDrift, against the shared cross-language specification', () => {
+  it('has cases to run', () => {
+    expect(spec.ports.workflowDrift.configDrift.length).toBeGreaterThan(4)
+  })
+
+  for (const testCase of spec.ports.workflowDrift.configDrift) {
+    it(testCase.why, () => {
+      // Compared as a KEY SET: the Python half returns `{key: (deployed,
+      // desired)}` and this one an array of rows, each shaped for its own
+      // caller. Which keys differ is the detector's actual answer; how it is
+      // rendered is each side's own business.
+      const keys = configDrift(testCase.deployed, testCase.declared).map((row) => row.key)
+      expect(keys).toEqual(testCase.expected)
+    })
+  }
+})

--- a/web-admin/src/lib/workflowDrift.ts
+++ b/web-admin/src/lib/workflowDrift.ts
@@ -11,6 +11,17 @@
  * read with the operator's Cognito token, which lives in this browser and
  * nowhere the plugin's Lambda can reach. So the comparison has to happen on
  * the side that can see both documents, and that side is here.
+ *
+ * **Being a port is a liability, and it has already cost once.** This file
+ * landed in #167. #177 then fixed the Python half to compare prompt fields as
+ * the runtime stores them (issue #175 — see `asTheRuntimeStoresIt` below), and
+ * nothing carried that fix across: for ten days the studio's drift table
+ * reported one character of permanent, unclearable drift on every load while
+ * `--check` on the same config said it was fine, with every suite green. The
+ * cases in `shared/cross-language-ports.json` are now executed by BOTH halves'
+ * suites (`crossLanguagePorts.test.ts` here,
+ * `tests/test_marketing_cross_language_ports.py` there), so the next
+ * divergence fails a test instead of an operator (issue #119).
  */
 
 /** What Core masks a credential-bearing config field with on read
@@ -19,6 +30,55 @@
  * calling it stale would mean permanent, unfixable red. Must stay in step
  * with `fan_in_workflow.REDACTED_SENTINEL`. */
 export const REDACTED_SENTINEL = '••••••••'
+
+/** The config keys Core does not store verbatim, because it composes them
+ * through its prompt pipeline. Must stay in step with
+ * `definitions.RUNTIME_PROMPT_FIELDS`; both are checked against
+ * `shared/cross-language-ports.json`. */
+const RUNTIME_PROMPT_FIELDS = new Set(['instructions', 'goals'])
+
+/** One config value as it will look **on the run**, not as declared.
+ *
+ * A port of `marketing.definitions.as_the_runtime_stores_it`. Core writes a
+ * prompt field through `prompt_parts.compose`, which strips it, so a plain
+ * string prompt comes back trimmed. Any other key is returned untouched: this
+ * normalises the one transformation Core actually performs, not whitespace
+ * generally — a model name that gained a trailing newline is still drift.
+ *
+ * **Why it exists (issue #175).** The declared synthesis instructions end in a
+ * newline, so a raw comparison reported drift of exactly one character — 2047
+ * declared against 2046 deployed — on every single read, and the remedy it
+ * offered could never clear it: re-seeding writes 2047 back and Core strips it
+ * again. A permanently-red detector is worse than none, because it teaches the
+ * person reading this table to scroll past the row that matters.
+ *
+ * Applied to BOTH sides rather than only the declared one — the deployed side
+ * is already stripped and trimming is idempotent, so it is symmetric by
+ * construction rather than by luck.
+ */
+function asTheRuntimeStoresIt(key: string, value: unknown): unknown {
+  return RUNTIME_PROMPT_FIELDS.has(key) && typeof value === 'string' ? value.trim() : value
+}
+
+/** `value` serialised with object keys sorted at every depth.
+ *
+ * Structural comparison needs a stable string, and `JSON.stringify` preserves
+ * insertion order — so two identical configs whose keys arrived in different
+ * orders compared as different. Neither half chooses that order: both read
+ * JSON off the wire, the deployed copy from Core's own store and the declared
+ * one from `GET /admin/fan-in-workflow`. The Python half compares dicts, which
+ * have never been order-sensitive, so this was drift reported in the browser
+ * and nowhere else — the same "red on two identical configs" failure as #175,
+ * from a different direction.
+ */
+function stableJson(value: unknown): string | undefined {
+  return JSON.stringify(value, (_key, inner: unknown) => {
+    if (inner === null || typeof inner !== 'object' || Array.isArray(inner)) return inner
+    return Object.fromEntries(
+      Object.entries(inner as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : 1)),
+    )
+  })
+}
 
 export type ConfigDrift = {
   key: string
@@ -48,7 +108,12 @@ export function configDrift(
     const declaredValue = declared[key]
     // Structural comparison: `output_tools` is a list of nested schema objects,
     // so identity would report drift on every render and `===` on every fetch.
-    if (JSON.stringify(deployedValue) !== JSON.stringify(declaredValue)) {
+    // Compared as the runtime stores it, and key-order-independently — see both
+    // helpers above for the two ways this reported drift on identical configs.
+    if (
+      stableJson(asTheRuntimeStoresIt(key, deployedValue)) !==
+      stableJson(asTheRuntimeStoresIt(key, declaredValue))
+    ) {
       drift.push({ key, deployed: deployedValue, declared: declaredValue })
     }
   }


### PR DESCRIPTION
## What

A guard that enumerates **cross-language port pairs out of the two source trees** and requires each to have its shared behaviour written down where **both** suites execute it — plus the two live divergences it found on its first run.

`Refs #119` (`class:drift`). The issue was closed on 2026-08-16; the closing rationale addressed the *duplicated-expression* half (closed by #157) and the *superseded-function* half (judged not worth its cost, reasoning recorded). It did not address the **third instance recorded on the issue itself** (2026-08-13, the asset-filename convention), which was still live — and had already caused a user-visible defect. Not using `Closes` because that is the owner's call to make with this evidence in hand.

## Establishing current state first

`#157` is real and does what it says: it derives its subject list from the tree, so a *duplicated-expression* helper written next week is swept the moment it is written. Verified passing on `origin/dev`. It walks a **Python AST**, so everything it knows stops at `src/marketing/`.

The third instance is on the other side of that boundary. Both halves had tests. Both were useless for this, because **each suite executed its own private copy of the fixtures** — the same mistake in the tests that the two implementations make in the source. The one guard that named the other language asserted `image_provider._MAX_SLUG == 60`, a literal, with a docstring claiming it "fails loudly the moment just one side changes it".

Measured against `origin/dev`, not reasoned about:

```
changed assetFilename.ts's MAX_SLUG from 60 to 40
  uv run pytest tests/test_marketing_image_provider.py   ->  24 passed
  pnpm vitest run src/lib/assetFilename.test.ts          ->  10 passed
```

Green on both sides, with the browser and the Lambda naming the same download differently. A guard reading a **different document from the one that acts** (biffo-template#1362) — it could only ever fail if the side it was not watching moved. The client's own cap test was the same shape (`toBeLessThanOrEqual(60)`, its own literal).

## The defect this was already causing, found by writing the sweep

`workflowDrift.ts` landed in #167 as "a TypeScript port of `marketing.fan_in_workflow.config_drift`". **#177 then fixed the Python half** to compare prompt fields as the runtime stores them (`definitions.as_the_runtime_stores_it`, issue #175: the declared instructions end in a newline, Core strips it, so the detector reported one character of drift on every read and its own remedy — re-seeding — could never clear it).

**The TypeScript port did not get that fix.** So the studio's drift table carried the exact defect #175 exists to prevent, in the surface an operator actually looks at, with every suite green. Confirmed live: `agent_fan_in`'s declared `instructions` is 2047 characters and ends in a newline.

Writing the shared cases found it immediately, along with a second one nobody had looked for: `JSON.stringify` is key-order-sensitive and Python's dict comparison is not, while both halves read JSON off the wire whose key order neither of them chooses. Same consequence — red on two identical configs.

## What changed

- **`shared/cross-language-ports.json`** — the behaviour both halves must produce, stated once, in a language neither owns. Every case carries its own `why`, so a failure names the rule that broke.
- **`tests/test_marketing_cross_language_ports.py`** — executes the cases against the real Python implementations; reads the constants **out of the shipped `.ts` file**; and holds the sweep.
- **`web-admin/src/lib/crossLanguagePorts.test.ts`** — executes the same cases against the real TypeScript implementations.
- **`web-admin/src/lib/workflowDrift.ts`** — the two fixes above (`asTheRuntimeStoresIt`, `stableJson`).
- The private duplicate fixtures are **deleted** from both suites, keeping only what is deliberately one-sided (each side's own fallbacks, the browser's extension inference), which the spec records under `deliberate_differences` so nobody later "fixes" the two into agreement.

## Why this closes the class and not two pairs

The sweep derives its subject list: a symbol defined in both `src/marketing/**.py` and `web-admin/src/**.ts` under the same name, modulo `snake_case`/`camelCase`, is a candidate port, and every candidate must either be covered by the spec or classified in `_NOT_A_PORT` with a reason. **A port added next month is a failing test the day it is written**, with nothing to remember — the specific gap #119 names.

Two exclusions by *shape* rather than by name, so tomorrow's endpoint stays out of the ledger too: a declaration that reaches the network is a **client of** the Python function it shares a name with (`api.ts`'s `startResearch` calls `pipeline.start_research`; there is one implementation between them), and a PascalCase declaration in a `.tsx` is a React component. Anchoring on column 0 keeps locals out — admitting them made a 7-pair list a 16-pair one when first measured.

The ledger holds **one** entry (`parseArtefactBody`, whose two halves have deliberately opposite contracts). A second entry was written for `request` and `test_no_classification_has_gone_stale` deleted it before this shipped, which is the ledger doing its job on day one.

## What it does NOT catch — in the module docstring, not buried

A port with **no name in common**. Both live pairs share their names because a port is written by copying and copying keeps the name, but a deliberate rename walks out of the sweep. Nothing in the source declares "this is a port of that", and requiring such a declaration needs exactly the act of remembering it exists to remove — the same honest limit #157 records for its own shape.

## Fail-first evidence

Each planted into the real tree with a file copy and restored, never `git checkout`:

| Planting | Before | After |
| --- | --- | --- |
| client `MAX_SLUG` 60 -> 40 | green on **both** suites | `test_the_typescript_cap_literal_is_the_one_the_specification_states` + 3 vitest cases fail |
| revert the `workflowDrift` normalisation | — | 3 spec cases fail, including #175's live one and the key-order one |
| `configFingerprint` planted in `campaignLink.ts`, named by no test anywhere | — | sweep reports it against `fan_in_workflow.config_fingerprint` |
| `_ts_literal` given a source with no such constant | — | raises "watching nothing" rather than passing over nothing (unit-tested) |

The sweep also caught the port **this PR itself introduces** (`asTheRuntimeStoresIt`/`RUNTIME_PROMPT_FIELDS`) during the full-suite run, before it was specified. That is the behaviour the issue asked for, demonstrated on a helper written minutes earlier.

## Gates

```
uv run pytest              887 passed, 4 skipped
uv run ruff check .        All checks passed
uv run ruff format --check 76 files already formatted
uv run pyright             0 errors
pnpm vitest run            267 passed (28 files)
pnpm typecheck / lint      clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)