### PR TITLE
test(marketing): cover the ceiling check's read failure, which the instance gates

### DIFF
--- a/tests/test_marketing_runtime_ceiling_check.py
+++ b/tests/test_marketing_runtime_ceiling_check.py
@@ -21,6 +21,8 @@ questions nobody asked (biffo-template#1363).
 
 from __future__ import annotations
 
+import sys
+import types
 from typing import Any
 
 import pytest
@@ -220,3 +222,44 @@ def test_main_exits_in_step_when_the_deployment_agrees(monkeypatch: pytest.Monke
     monkeypatch.setattr(_check, "read_deployed_configuration", _fake)
 
     assert _check.main(["--function-name", "whatever"]) == IN_STEP
+
+
+def test_a_refused_lambda_read_becomes_cannot_read_not_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`read_deployed_configuration` itself, with the AWS call failing.
+
+    `test_an_unreadable_deployment_exits_cannot_tell` above replaces this whole
+    function, so it proves `main` handles a `CannotReadError` — and never
+    executes the `except` that raises one. The two are different claims, and
+    only this one covers the line that turns a botocore exception into the
+    tri-state's "cannot tell".
+
+    It is not a hypothetical path: run the script against a name that does not
+    exist and this is what answers, via `ResourceNotFoundException`.
+
+    boto3 is injected through `sys.modules` rather than monkeypatched on the
+    script, because the import is inside the function precisely so that neither
+    boto3 nor credentials need to exist for the rest of the module to be
+    testable — patching an attribute that does not exist at module scope would
+    pass while testing nothing.
+    """
+
+    class _Client:
+        def get_function_configuration(self, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("AccessDeniedException: not authorized")
+
+    class _Session:
+        def __init__(self, **_kwargs: Any) -> None: ...
+
+        def client(self, _name: str) -> _Client:
+            return _Client()
+
+    monkeypatch.setitem(sys.modules, "boto3", types.SimpleNamespace(Session=_Session))
+
+    with pytest.raises(_check.CannotReadError) as excinfo:
+        _check.read_deployed_configuration("some-function")
+
+    # The cause survives into the message: "cannot tell" is only actionable if
+    # it says which of denied/expired/typo'd it was.
+    assert "AccessDeniedException" in str(excinfo.value)


### PR DESCRIPTION
#180's `read_deployed_configuration` converts any AWS failure into `CannotReadError`, so a denied call, an expired session and a typo'd function name all reach the tri-state as **"cannot tell"** rather than as a crash or a false pass. Nothing exercised that `except`.

`test_an_unreadable_deployment_exits_cannot_tell` looks like it does, and does not — it replaces the whole function, proving `main` handles the error while never running the line that raises it. This test goes through the real function with the AWS call failing.

boto3 is injected via `sys.modules` rather than monkeypatched on the script, because the import is deliberately inside the function so neither boto3 nor credentials need to exist for the rest of the module to be testable. Patching a module-scope attribute that does not exist would have passed while testing nothing.

## How it was found, which is the part worth keeping

**Not by this repo.** tabsii-platform#932 vendored #180, and the instance's `Error-branch coverage` gate reported exactly one added branch with no test exercising it:

```
1 error branch(es) added with no test exercising them:
  services/marketing/scripts/check_runtime_ceiling.py:except:except Exception
```

This repo's own error-branch gate did not flag it. So plugin code can go green here and red one repo downstream, on the same gate name — the vendoring step is where that asymmetry shows up, and only because something happened to be vendored. Worth a look separately; I have not opened an issue for it yet.

## Proof it bites

Reverting `raise CannotReadError(...)` to a bare `raise` lets the botocore exception escape, and the test fails on it:

```
E       RuntimeError: AccessDeniedException: not authorized
FAILED tests/..._ceiling_check.py::test_a_refused_lambda_read_becomes_cannot_read_not_a_crash
```

(Deleting the `except` outright was my first attempt and is not a valid revert — a `try` with no handler is a `SyntaxError`, so the suite fails at collection and proves nothing.)

899 tests pass; ruff, format and pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)