### PR TITLE
ci(marketing): gate error branches here, not one repo downstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,61 @@ jobs:
       # switch happens outside this repo's control).
       - run: command -v ffmpeg >/dev/null || (sudo apt-get update && sudo apt-get install -y ffmpeg)
       - run: uv sync --all-groups
-      - run: uv run pytest --cov --cov-report=xml
+      # `--cov-report=json` is not a second copy of the xml for Codecov's
+      # benefit — `scripts/error_branch_coverage.py` reads `coverage.json` and
+      # nothing else, so without this line the step below has no input and
+      # exits 2 ("no coverage data"), which is the gate failing to run rather
+      # than the gate passing. Same pairing the instance's `ci.yml` uses.
+      - run: uv run pytest --cov --cov-report=xml --cov-report=json
+      # Fails only when error handling is ADDED with nothing exercising it
+      # (#183; the check itself is keiranholloway/biffo-template#956). An
+      # unexecuted `except` is unverified — nobody has ever observed what it
+      # does — and that is where every fail-open this estate has found actually
+      # lived.
+      #
+      # ## Why this repo grew it late, and what it cost
+      #
+      # This is a ratchet the INSTANCE has run for months and this repo ran not
+      # at all. Not a narrower version of it — none: `gh pr checks 180` listed
+      # twelve contexts and `Error-branch coverage` was not among them. The
+      # analyser is template-owned (`biffo-template/scripts/`) and reaches an
+      # instance through `biffo core upgrade`; it is absent from that repo's
+      # `shared-files.json` AND from the `@biffo/cli` package `scripts/biffo.sh`
+      # resolves, so there was no channel by which a satellite could ever have
+      # received it (the class biffo-template#1570 records: "merged upstream"
+      # and "present downstream" are different facts).
+      #
+      # The bill came due on PR #180, which added an `except Exception` to
+      # `scripts/check_runtime_ceiling.py` converting any AWS failure into
+      # `CannotReadError`, went green on every check here, and then reddened
+      # tabsii-platform the moment `biffo plugin install` vendored it:
+      #
+      #   1 error branch(es) added with no test exercising them:
+      #     services/marketing/scripts/check_runtime_ceiling.py:except:except Exception
+      #
+      # A gate that only exists one repo downstream of the author is a gate
+      # that reports to the wrong person.
+      #
+      # ## No `hashFiles('.github/workflows/rls-tests.yml')` guard here
+      #
+      # The instance's copy of this step carries one, because a repo with a
+      # real-Postgres lane has error branches this job structurally cannot
+      # execute, and its combined assertion happens once in
+      # `error-branch-coverage-gate.yml` instead. A plugin repo has neither
+      # file, so replicating the guard would buy nothing and cost something
+      # real: if an `rls-tests.yml` ever appeared here the condition would
+      # silently skip this step and NOTHING would take over the assertion — a
+      # fail-open dressed as a deliberate narrowing. Instead the condition is
+      # absent and `tests/test_marketing_error_branch_gate.py` asserts this
+      # repo still has no RLS lane, so the day one arrives the test goes red and
+      # names this decision rather than the gate going quiet.
+      #
+      # `scripts/error_branch_coverage.py` is byte-identical to
+      # `biffo-template/scripts/error_branch_coverage.py`. Do not edit it here;
+      # edit it upstream — the same rule `scripts/py-dependency-audit.sh`
+      # already carries.
+      - name: Error-branch coverage
+        run: uv run python scripts/error_branch_coverage.py --check --coverage coverage.json
       - uses: codecov/codecov-action@v5
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,16 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 
+# Coverage artefacts. `--cov-report=json` became a routine local step with the
+# error-branch ratchet (#183) — it is the analyser's only input, so anyone
+# re-taking the baseline writes one — and an untracked `coverage.json` sitting
+# in `git status` is how a measurement output ends up committed as if it were
+# source. `.coverage` (the sqlite datafile) and `coverage.xml` (Codecov's
+# input) are the same category and were never ignored either.
+.coverage
+coverage.json
+coverage.xml
+
 # Node
 node_modules/
 dist/

--- a/docs/practices/error-branch-baseline.json
+++ b/docs/practices/error-branch-baseline.json
@@ -1,0 +1,7 @@
+{
+  "total": 2,
+  "branches": [
+    "src/marketing/pipeline.py:except:except ValidationError",
+    "src/marketing/pipeline.py:except:except json.JSONDecodeError"
+  ]
+}

--- a/docs/practices/error-branch-baseline.md
+++ b/docs/practices/error-branch-baseline.md
@@ -1,0 +1,104 @@
+# The error-branch ratchet
+
+`error-branch-baseline.json` beside this file is **a measurement, not a
+target**. It records the error-handling branches this repo's test suite has
+never executed, as of the last time somebody re-took it. CI's
+`Error-branch coverage` step compares today's set against it and fails **only
+on an entry that is not already in the list** — a branch already there never
+blocks anybody.
+
+## What counts as an error branch
+
+`scripts/error_branch_coverage.py` parses every Python file that appears in
+`coverage.json` and looks for two shapes, both of which have produced real
+fail-opens in this estate:
+
+- an `except` handler, whose body runs only when something raised;
+- an `if` whose single statement is `return <constant>` — the "if we cannot
+  tell, say yes" fallback.
+
+A branch is listed when coverage.py reports its first body line as *missing*.
+An unexecuted error branch is not automatically a defect, but it is
+**unverified**: nobody has ever observed what it does.
+
+## Why a ratchet and not a gate
+
+Some error branches are legitimately untested — an `except ImportError` around
+an optional dependency, a defensive re-raise. A hard gate at this precision is
+red every morning, and a guard that is red every morning is one people learn to
+scroll past, taking the real findings with it. So this fails on **growth**
+only: new unverified error handling has to be a deliberate, visible choice.
+
+## How to shrink it
+
+The list is meant to get shorter. To remove an entry:
+
+1. write a test that actually drives the handler — raise the thing it catches,
+   or arrange the condition the fallback answers;
+2. re-measure and re-record:
+
+   ```sh
+   uv run pytest --cov --cov-report=json
+   uv run python scripts/error_branch_coverage.py --write
+   ```
+
+3. commit the shrunken `error-branch-baseline.json` with the test.
+
+`--write` rewrites the file from whatever it currently measures, so **it
+accepts additions as readily as removals**. Running it to make a red CI green
+is how a ratchet quietly becomes a rubber stamp; do it only when you have
+either covered something or decided, in the PR description, that a new
+uncovered branch is correct.
+
+Without `--write`, the analyser only reports:
+
+```sh
+uv run python scripts/error_branch_coverage.py                        # report
+uv run python scripts/error_branch_coverage.py --check --coverage coverage.json  # what CI runs
+```
+
+## Why this repo has one at all
+
+It did not, until #183. `scripts/error_branch_coverage.py` is template-owned
+and reaches a **core instance** through `biffo core upgrade`; it is in neither
+`biffo-template`'s `shared-files.json` nor the `@biffo/cli` package that
+`scripts/biffo.sh` resolves, so no channel existed by which a satellite like
+this one could receive it.
+
+That mattered because `biffo plugin install` vendors this repo whole into
+`tabsii-platform` as `services/marketing/`, where the instance's own
+`Error-branch coverage` gate **does** run — over `src/` *and* `scripts/*`.
+PR #180 added an `except Exception` to `scripts/check_runtime_ceiling.py`,
+passed all twelve checks here, and reddened the instance on vendoring:
+
+```
+1 error branch(es) added with no test exercising them:
+  services/marketing/scripts/check_runtime_ceiling.py:except:except Exception
+```
+
+The gate existed one repo downstream of the person who could fix it. It now
+runs here, over the same scope (`[tool.coverage.run] source = ["src",
+"scripts"]`, matching the instance's `source = ["services", "packages"]` /
+`omit = ["*/tests/*"]`).
+
+## Keep the analyser byte-identical
+
+`scripts/error_branch_coverage.py` is a verbatim copy of
+`biffo-template/scripts/error_branch_coverage.py`. **Do not edit it here** —
+edit it upstream, the same rule `scripts/py-dependency-audit.sh` already
+carries. A local edit is drift that nothing polices, and the instance would go
+on judging this plugin by the upstream version regardless.
+
+The durable fix is to add it to `biffo-template`'s `shared-files.json` so
+`shared-sync.sh` arms every satellite; until that lands, this copy and
+`biffo-plugin-idea-scout` / `biffo-plugin-ideation` having none is the actual
+state of the estate.
+
+## The wiring is tested
+
+`tests/test_marketing_error_branch_gate.py` asserts that CI really runs the
+analyser with `--check`, that the same job writes the `coverage.json` it reads,
+that `[tool.coverage.run] source` covers every top-level directory of Python
+found on disk, and that this baseline exists — because an absent baseline makes
+the analyser report and exit 0, which is the gate present and inert.
+</content>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,31 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
 
+# `scripts` is in `source` because the INSTANCE measures it, and a scope this
+# repo does not share is a scope this repo cannot gate (#183).
+#
+# When `biffo plugin install` vendors this repo it lands whole at
+# `services/marketing/` — `src/`, `scripts/`, `tests/`, all of it — and
+# tabsii-platform's own `[tool.coverage.run]` reads
+# `source = ["services", "packages"]`, `omit = ["*/tests/*", ...]`. So the set
+# the instance's `Error-branch coverage` gate judges this plugin over is
+# "everything except tests/", while this file used to say `source = ["src"]`
+# alone. Measured at 1e432ff: `uv run pytest --cov --cov-report=json` wrote 23
+# files, every one under `src/`, and the four modules in `scripts/` appeared in
+# no coverage report at all — which is why PR #180 could add an `except
+# Exception` to `scripts/check_runtime_ceiling.py`, pass all twelve checks
+# here, and red-light the instance the moment it was vendored:
+#
+#   1 error branch(es) added with no test exercising them:
+#     services/marketing/scripts/check_runtime_ceiling.py:except:except Exception
+#
+# The analyser (`scripts/error_branch_coverage.py`) only ever inspects files
+# that appear in `coverage.json`, so widening this line is what puts `scripts/`
+# in front of it. Keep the two repos' scopes in agreement: a directory added
+# here that is not in `source` is a directory this repo does not check and the
+# instance does.
 [tool.coverage.run]
-source = ["src"]
+source = ["src", "scripts"]
 omit = ["*/tests/*"]
 
 # python-semantic-release config for release.yml. This repo does not use

--- a/scripts/error_branch_coverage.py
+++ b/scripts/error_branch_coverage.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Which error-handling branches has the test suite never executed? (#956)
+
+A fail-open is a check that passes without checking. Four surfaced on
+2026-07-30 alone, none caught by a gate, and every one lived in a branch that
+runs only when something has already gone wrong — an `except` that swallows, a
+fallback that returns a permissive default. Ordinary line coverage hides them:
+the happy path through a function is well covered, so the file looks fine.
+
+This asks the narrower question. For every `except` handler and every
+`return`-a-default fallback, did the suite ever run it? An unexecuted error
+branch is not automatically a defect, but it is *unverified* — nobody has ever
+observed what it does — and today's evidence is that this is precisely where
+fail-opens live.
+
+## Why a ratchet rather than a gate
+
+Plenty of error branches are legitimately untested: an `except ImportError`
+around an optional dependency, a defensive re-raise. A hard gate at this
+precision gets switched off, taking the real findings with it — the same reason
+the substring-assertion lint in #957 was scoped down after measurement. So this
+records a **baseline** and fails only when the count *grows*: new unverified
+error handling has to be a deliberate, visible choice.
+
+## Scope, stated plainly
+
+**Python only.** The three fail-opens found on 2026-07-30 were in three
+different languages — shell (`scripts/verify.sh`'s `ci_has`), TypeScript
+(branch-protection's 403 skip) and Python (the plugin-host lifespan
+misclassification). This catches the Python one. Shell has no practical coverage
+story and is not in scope; TypeScript is a possible follow-on via vitest
+coverage. Claiming otherwise would be the same shape of error this tool exists
+to find.
+
+## The blind spot this alone cannot see, and the fix for it (#637)
+
+`--coverage` used to take exactly one `coverage.json`. In an instance, the
+Python job's coverage is all this ever saw — and that job runs with no
+Postgres, so every `*_pg.py` test skips there. An error branch reachable only
+from a real-Postgres lane (an RLS policy refusing a write, a trigger firing)
+therefore read as unexercised no matter how honestly it was tested, and the
+workaround was a second, weaker test with a stub session driving the same
+clause — duplication carried only because this gate could not see the real one.
+
+`--coverage` is now repeatable and *combines* what it is given: a
+line executed in ANY of them counts as executed. This is deliberately the same
+mechanism as `coverage combine` (coverage.py's own tool for exactly this), done
+here instead so the combine and the analysis are one step and one dependency.
+A repo with a second, Postgres-dependent test lane (e.g. an instance's `RLS
+Tests` workflow) can pass both artefacts:
+
+    python scripts/error_branch_coverage.py --check \\
+        --coverage coverage.json --coverage rls-coverage.json
+
+Passing one path (or none, using the default) behaves exactly as before — this
+is additive, not a breaking change to the single-file case.
+
+## Local and CI used to disagree here, and the cause was not what it looked like (#1588)
+
+`--check`'s verdict is entirely a function of the coverage.json(s) you hand it,
+so any gap between what a local pytest run executed and what CI's did shows up
+here as a disagreement. In *this* repo the actual cause, found and fixed by
+#1588, was neither test selection nor environment: `services/api` is async
+throughout and reaches the database through SQLAlchemy's async layer, which
+runs user code — including exception handlers — inside a **greenlet**
+(`greenlet_spawn`), itself running on a **background thread** spun up by
+FastAPI's/Starlette's `TestClient` (an `anyio` blocking portal). Coverage does
+not trace either a greenlet context or a non-main thread unless told to, and
+`[tool.coverage.run]` named neither — so a local run silently under-recorded
+24 files of async DB code (60 unexecuted branches locally against CI's
+correctly-measured 47, reproduced exactly at commit `0820ca7f`), for no
+reason a careful contributor could see by reading test output. `concurrency =
+["greenlet", "thread"]` on `[tool.coverage.run]` closes that gap; **both**
+values are required — `greenlet` alone still under-counts (verified: 80
+unexecuted, worse than no setting at all), because it never extends tracing
+into the TestClient's background thread in the first place.
+
+If `--check` still disagrees with CI on a repo carrying that setting, do not
+reach for a narrower local pytest invocation, a Postgres service, or the
+two-lane combine below as the explanation by default — confirm what actually
+differs. This repo in particular has no `rls-tests.yml` and no Postgres
+service on its Python job, so neither applies to it; the paragraph below is
+real for a repo that has grown a genuine second test lane, not a first port of
+call everywhere this script runs.
+
+## The two-lane combine, for a repo that has a real Postgres lane (#637)
+
+Since #637, CI's own verdict for one commit is not even stable across its own
+runs on a repo whose CI *does* run a second, Postgres-backed lane (e.g. an
+instance's `RLS Tests` workflow) alongside the plain Python job — that is a
+different, additive concern from the greenlet/thread gap above, and applies
+only where such a lane exists. A local `--check` reports against whatever
+coverage.json(s) YOU hand it — for most contributors, one file, from one
+pytest invocation, compared against the recorded baseline. A repo's `ci.yml`
+does exactly the same comparison against the same baseline, but best-effort
+combines the Postgres-only lane's artefact when it can reach one (see that
+file's own comments on the timing this depends on) — and combining coverage
+can only mark MORE lines executed, never fewer, so the second artefact can
+only turn a branch from "new and unexecuted" into "already covered", never
+the reverse. That means: a run of CI that catches the artefact in time can go
+green on a branch an earlier, artefact-less run of the very same commit
+reported as newly unexecuted. **On a repo with such a lane, a clean local
+`--check` is therefore not evidence CI will pass, and neither is a red CI run
+evidence the next run of the identical commit will also be red** —
+re-running once the Postgres-only lane has finished is the remedy for that
+shape of red, not a sign the gate is flaky. Pass every coverage.json you have
+(see the `--coverage` usage above) and trust the one that has seen the most.
+
+Usage:
+    uv run pytest --cov --cov-report=json      # writes coverage.json
+    python scripts/error_branch_coverage.py            # report
+    python scripts/error_branch_coverage.py --write    # update the baseline
+    python scripts/error_branch_coverage.py --check    # fail if it grew
+    python scripts/error_branch_coverage.py --check --coverage a.json --coverage b.json
+                                                 # combine two lanes' coverage first (#637)
+    python scripts/error_branch_coverage.py --check --source-root <tree> --coverage a.json
+                                                 # judge a tree other than this
+                                                 # script's own repo (#1595)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_REL = Path("docs/practices/error-branch-baseline.json")
+BASELINE = REPO_ROOT / BASELINE_REL
+COVERAGE_JSON = REPO_ROOT / "coverage.json"
+
+
+def baseline_for(source_root: Path) -> Path:
+    """The baseline belonging to the tree being judged.
+
+    Ordinarily that is this script's own repo and the answer is `BASELINE`,
+    unchanged. It differs only for a caller that passed `--source-root` — see
+    `unexecuted`'s note for why the source and the baseline must travel
+    together rather than being taken from wherever the script happens to sit.
+    """
+    if source_root == REPO_ROOT:
+        return BASELINE
+    return source_root / BASELINE_REL
+
+
+# The two commands that take the first measurement, in the order they must run.
+# Named in every message about a missing baseline, because the missing piece is
+# never obvious from the failure: the analyser reads `coverage.json`, which only
+# exists after a --cov run, and neither the FileNotFoundError nor "N error
+# branches added" says so (#983).
+BOOTSTRAP_COMMANDS = (
+    "uv run pytest --cov --cov-report=json",
+    "uv run python scripts/error_branch_coverage.py --write",
+)
+
+
+# Why an absent baseline is a normal state, not a broken repo.
+#
+# This script is template-owned and reaches every instance through `biffo core
+# upgrade`. Its baseline is NOT, and must not be: the file is a measurement of
+# the repo it lives in, so shipping the template's copy would assert the
+# template's unexecuted branches against an instance's tree — wrong data, naming
+# files that do not exist there.
+#
+# So the test travels and its data cannot, and every instance arrives at this
+# gate having never taken the measurement. A ratchet with no prior position
+# should start, not block.
+def no_baseline_message(baseline: Path) -> str:
+    """Written against the baseline actually looked for, not a fixed path.
+
+    A caller that passed `--source-root` is judging a different tree, and
+    naming this repo's baseline in the failure would send the reader to a file
+    that was never consulted.
+    """
+    try:
+        where: Path | str = baseline.relative_to(REPO_ROOT)
+    except ValueError:
+        where = baseline
+
+    return (
+        f"No error-branch baseline at {where}.\n"
+        "\n"
+        "That file is a measurement of THIS repo, so it is not distributed by a core\n"
+        "upgrade — a fresh instance has simply never taken it (#983). Take it with:\n"
+        "\n"
+        f"  {BOOTSTRAP_COMMANDS[0]}\n"
+        f"  {BOOTSTRAP_COMMANDS[1]}\n"
+        "\n"
+        "Until then the ratchet has no prior position to compare against, so it\n"
+        "reports what it finds and does not fail."
+    )
+
+
+@dataclass(frozen=True)
+class Branch:
+    """One error-handling branch, identified by where its body starts."""
+
+    path: str
+    line: int
+    kind: str
+    label: str
+
+    def key(self) -> str:
+        return f"{self.path}:{self.kind}:{self.label}"
+
+
+def _handler_label(node: ast.ExceptHandler) -> str:
+    if node.type is None:
+        return "except:"
+    try:
+        return f"except {ast.unparse(node.type)}"
+    except Exception:  # pragma: no cover - unparse is total on real trees
+        return "except <?>"
+
+
+def error_branches(tree: ast.AST, path: str) -> list[Branch]:
+    """Every error-handling branch in one module.
+
+    Two shapes, both of which have produced fail-opens in this estate:
+
+    - an `except` handler, whose body runs only when something raised;
+    - a bare `return`/`return <literal>` that is the *only* statement of an
+      `if`, which is the fallback shape — "if we cannot tell, say yes".
+    """
+    found: list[Branch] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler):
+            body = node.body[0]
+            found.append(Branch(path, body.lineno, "except", _handler_label(node)))
+            continue
+
+        if isinstance(node, ast.If) and len(node.body) == 1:
+            stmt = node.body[0]
+            if not isinstance(stmt, ast.Return) or stmt.value is None:
+                continue
+            # Only constant defaults. A computed return is ordinary control
+            # flow; `return True` / `return frozenset()` under a guard is the
+            # shape that decides a question by assumption.
+            if isinstance(stmt.value, ast.Constant) or (
+                isinstance(stmt.value, ast.Call)
+                and isinstance(stmt.value.func, ast.Name)
+                and stmt.value.func.id in {"set", "frozenset", "list", "dict", "tuple"}
+                and not stmt.value.args
+            ):
+                try:
+                    label = f"if {ast.unparse(node.test)[:50]} -> {ast.unparse(stmt.value)}"
+                except Exception:  # pragma: no cover
+                    label = "if <?> -> <?>"
+                found.append(Branch(path, stmt.lineno, "fallback", label))
+
+    return found
+
+
+def unexecuted(coverage: dict, root: Path) -> list[Branch]:
+    """Error branches whose first executed line never ran under the suite.
+
+    `root` MUST be the tree the coverage was measured against. This function
+    parses `root / rel` to find branches and then asks whether their line
+    numbers appear in that report's `executed_lines` / `missing_lines` — so a
+    `root` from a different revision looks the report's line numbers up in the
+    wrong file, and a change of even one line above a branch shifts every
+    verdict below it.
+
+    That was live in the `workflow_run` gate (#1595), which runs this script
+    from the default branch — correctly, so a fork's PR cannot execute its own
+    modified analyser — and until `--source-root` existed took the *source*
+    from that same checkout too. On tabsii-platform#922 the default branch's
+    `admin_app.py` was 35 lines shorter than the commit under test's, and the
+    gate reported two covered branches as newly unexecuted at lines that held
+    unrelated code. It diverges only on files a commit changes, which is
+    exactly the set a gate exists to judge.
+    """
+    files = coverage.get("files", {})
+    out: list[Branch] = []
+
+    for rel, data in sorted(files.items()):
+        source = root / rel
+        if not source.is_file():
+            continue
+        try:
+            tree = ast.parse(source.read_text())
+        except SyntaxError:
+            continue
+
+        executed = set(data.get("executed_lines", []))
+        # A line coverage.py never considered (a comment, say) is not evidence
+        # of anything; only count a branch whose body line is one coverage.py
+        # tracked and reported as missing.
+        missing = set(data.get("missing_lines", []))
+
+        for branch in error_branches(tree, rel):
+            if branch.line in executed:
+                continue
+            if branch.line in missing:
+                out.append(branch)
+
+    return out
+
+
+def merge_coverage(reports: list[dict]) -> dict:
+    """Combine coverage.json reports so a line executed in ANY of them counts.
+
+    Built for #637: a line is "unverified" only if nothing that ran ever
+    reached it, so the merge is a per-file UNION of executed_lines — the same
+    outcome `coverage combine` gives, computed here instead so pulling in a
+    second lane (e.g. a real-Postgres test run) needs no extra tool, just a
+    second coverage.json.
+
+    `missing_lines` follows from the merged `executed_lines`, not from a
+    separate union: a line coverage.py called "missing" in one report but
+    "executed" in another was, in fact, executed — carrying the stale
+    "missing" verdict forward would silently re-introduce the exact blind
+    spot this function exists to close. A single input is the identity case:
+    merging one report must read exactly as if merge_coverage were never
+    called, so the single-`--coverage` path (unchanged since #956) still
+    behaves the same after this.
+    """
+    merged_files: dict[str, dict] = {}
+    for report in reports:
+        for rel, data in report.get("files", {}).items():
+            entry = merged_files.setdefault(rel, {"executed": set(), "missing": set()})
+            entry["executed"] |= set(data.get("executed_lines", []))
+            entry["missing"] |= set(data.get("missing_lines", []))
+
+    return {
+        "files": {
+            rel: {
+                "executed_lines": sorted(entry["executed"]),
+                "missing_lines": sorted(entry["missing"] - entry["executed"]),
+            }
+            for rel, entry in merged_files.items()
+        }
+    }
+
+
+def load_baseline(baseline: Path) -> dict | None:
+    """The committed baseline, or None when this repo has never taken one.
+
+    None rather than an empty baseline. They are different states and used to be
+    conflated: an empty baseline means "measured, and found nothing", which for a
+    tree this size means the analyser is broken; a missing one means "never
+    measured". Reading the second as the first made every branch look NEW and
+    red-lit the gate on every instance that upgraded (#983).
+    """
+    if not baseline.is_file():
+        return None
+    return json.loads(baseline.read_text())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="record the current set as baseline")
+    parser.add_argument("--check", action="store_true", help="fail if the count grew")
+    parser.add_argument(
+        "--coverage",
+        type=Path,
+        action="append",
+        default=None,
+        help=(
+            "coverage.json to analyse. Repeatable (#637): pass it more than once "
+            "to combine several lanes' coverage (e.g. the Python job's and a "
+            "real-Postgres RLS lane's) — a line executed in ANY of them counts "
+            "as executed. Defaults to a single coverage.json at the repo root."
+        ),
+    )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=None,
+        help=(
+            "tree whose source and baseline to judge the coverage against. "
+            "Defaults to this script's own repo, which is correct whenever the "
+            "coverage was produced from the same checkout. A caller running "
+            "this script from one revision against coverage measured on "
+            "ANOTHER — the workflow_run gate, which deliberately executes the "
+            "default branch's copy of this script — must point it at the "
+            "commit under test, or line numbers are looked up in the wrong "
+            "revision's AST."
+        ),
+    )
+    args = parser.parse_args()
+    coverage_paths: list[Path] = args.coverage if args.coverage else [COVERAGE_JSON]
+    source_root: Path = args.source_root.resolve() if args.source_root else REPO_ROOT
+    baseline_path = baseline_for(source_root)
+
+    present = [p for p in coverage_paths if p.is_file()]
+    if not present:
+        paths_str = ", ".join(str(p) for p in coverage_paths)
+        print(
+            f"No coverage data at {paths_str}.\nRun:  uv run pytest --cov --cov-report=json",
+            file=sys.stderr,
+        )
+        return 2
+
+    absent = [p for p in coverage_paths if p not in present]
+    for p in absent:
+        # Not fatal: a repo that has only just adopted a second lane, or is
+        # invoked before that lane has produced its artefact yet, still gets an
+        # answer from what IS present rather than refusing outright — but the
+        # gap must be LOUD, not a line to scroll past. #637 was filed on exactly
+        # this shape: "a check that skips an input it cannot evaluate is not
+        # neutral — it shrinks its own scope and reports the remainder as the
+        # whole" (AGENTS.md §2). A clean result over fewer lanes than requested
+        # has to be falsifiable, so this is a `::warning::` GitHub Actions
+        # annotation — the estate's own convention for exactly this
+        # (scripts/py-dependency-audit.sh, scripts/js-dependency-audit.sh) —
+        # not a "note:" that only shows up if someone scrolls the raw log.
+        # Printed unconditionally, not gated on running-in-CI: it is equally
+        # true, and equally worth seeing, from a terminal.
+        print(
+            f"::warning::error-branch coverage: requested artefact not found: {p} — "
+            f"proceeding with {len(present)}/{len(coverage_paths)} coverage "
+            "file(s). This result does NOT reflect that lane's coverage.",
+            file=sys.stderr,
+        )
+
+    # Restated in every summary line below (not just the warning above) so the
+    # denominator survives even if the warning scrolls past unread: a reader
+    # who sees only the final line still learns how much of the requested
+    # picture this result is actually over.
+    coverage_note = f"{len(present)}/{len(coverage_paths)} coverage artefact(s)"
+    if absent:
+        coverage_note += f" — MISSING: {', '.join(str(p) for p in absent)}"
+
+    reports = [json.loads(p.read_text()) for p in present]
+    coverage = merge_coverage(reports)
+    found = unexecuted(coverage, source_root)
+    keys = sorted({b.key() for b in found})
+
+    if args.write:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        baseline_path.write_text(
+            json.dumps({"total": len(keys), "branches": keys}, indent=2) + "\n",
+        )
+        print(f"baseline written: {len(keys)} unexecuted error branches")
+        return 0
+
+    baseline = load_baseline(baseline_path)
+    if baseline is None:
+        # Report, then stop. Loudly, on stderr, naming both commands — a gate
+        # that goes quiet without saying so is the fail-open this whole script
+        # exists to hunt.
+        print(no_baseline_message(baseline_path), file=sys.stderr)
+        for branch in sorted(found, key=lambda b: (b.path, b.line)):
+            print(f"      {branch.path}:{branch.line}  [{branch.kind}] {branch.label}")
+        print(f"unexecuted error branches: {len(keys)}  (no baseline yet; {coverage_note})")
+        return 0
+
+    known = set(baseline.get("branches", []))
+    new = [k for k in keys if k not in known]
+
+    print(
+        f"unexecuted error branches: {len(keys)}  "
+        f"(baseline {baseline.get('total', 0)}; {coverage_note})"
+    )
+    for branch in sorted(found, key=lambda b: (b.path, b.line)):
+        marker = "NEW " if branch.key() not in known else "    "
+        print(f"  {marker}{branch.path}:{branch.line}  [{branch.kind}] {branch.label}")
+
+    if args.check and new:
+        print(
+            f"\n{len(new)} error branch(es) added with no test exercising them:",
+            file=sys.stderr,
+        )
+        for k in new:
+            print(f"  {k}", file=sys.stderr)
+        print(
+            "\nAn unexecuted error branch is unverified — nobody has observed what it does.\n"
+            "Either cover it, or run --write to accept it deliberately.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_marketing_error_branch_gate.py
+++ b/tests/test_marketing_error_branch_gate.py
@@ -1,0 +1,393 @@
+"""The error-branch ratchet is wired, scans what the instance scans, and does
+not itself smuggle unverified error handling downstream (#183).
+
+## What went wrong, and why no gate here noticed
+
+PR #180 added `scripts/check_runtime_ceiling.py`, whose `except Exception`
+turns any AWS failure into `CannotReadError`. Twelve checks went green on it.
+`biffo plugin install` then vendored this repo into `tabsii-platform` as
+`services/marketing/`, and that repo's `Error-branch coverage` gate said:
+
+    1 error branch(es) added with no test exercising them:
+      services/marketing/scripts/check_runtime_ceiling.py:except:except Exception
+
+Two independent causes, both closed by the change this module guards:
+
+1. **This repo ran no error-branch gate at all** — not a narrower one, none.
+   `scripts/error_branch_coverage.py` is template-owned and reaches an
+   *instance* through `biffo core upgrade`. It is in neither
+   `biffo-template`'s `shared-files.json` nor the `@biffo/cli` package that
+   `scripts/biffo.sh` resolves, so no channel existed by which a satellite
+   could have received it. That is biffo-template#1570's class exactly:
+   "merged upstream" and "present downstream" are different facts, and nothing
+   was keeping an inventory.
+2. **The scanned scope was narrower here even in principle.** The analyser
+   only inspects files that appear in `coverage.json`. This repo measured
+   `source = ["src"]`; the instance measures `source = ["services",
+   "packages"]` with `omit = ["*/tests/*", ...]`, i.e. all of
+   `services/marketing/` bar its tests. Measured at `1e432ff`:
+   `uv run pytest --cov --cov-report=json` wrote 23 files, every one under
+   `src/`, and the four modules in `scripts/` were in no report at all.
+
+## Parse, don't grep
+
+`ci.yml` explains all of the above in prose comments that name
+`error_branch_coverage.py` several times over. A `grep` for it is satisfied by
+those comments whether or not a step runs anything — proving nothing. Same
+doctrine, and the same `yaml.safe_load`, as
+`tests/test_marketing_ci_coverage_sweep.py` (#115): YAML comments are
+discarded during parsing, so only a token in a real field counts.
+
+## Why this module also exercises the analyser's own error branches
+
+`scripts/` is vendored wholesale, so the moment this repo's copy of
+`error_branch_coverage.py` lands in the instance it becomes
+`services/marketing/scripts/error_branch_coverage.py` and its OWN unexecuted
+`except`es are new branches by the instance's reckoning. Vendoring the gate
+uncovered would therefore reproduce, in the gate itself, the precise failure
+the gate is being adopted to prevent. Measured before these tests existed: 4
+such branches (`except ValueError`, `except SyntaxError`, and two
+`-> <default>` fallbacks). They are covered here rather than baselined, so the
+file travels clean.
+
+The analyser is byte-identical to `biffo-template/scripts/error_branch_coverage.py`
+and must stay so — edit it upstream, never here. These tests are written
+against its public behaviour (a label, a verdict, a return value), not its line
+numbers, so an upstream edit that keeps the behaviour keeps them passing.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+from _scripts import load_script
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_ANALYSER_REL = "scripts/error_branch_coverage.py"
+
+#: Where `scripts/error_branch_coverage.py` looks for the ratchet's recorded
+#: position. Hardcoded in that (template-owned, byte-identical) file as
+#: `BASELINE_REL`, so it is restated rather than imported: if an upstream edit
+#: moves it, this constant is what makes the move visible here instead of the
+#: gate quietly starting from "no baseline yet" and asserting nothing.
+_BASELINE_REL = "docs/practices/error-branch-baseline.json"
+
+#: Directory names pruned when working out which top-level directories hold
+#: Python this repo must measure. Every one is already declared content-free by
+#: this repo's `.gitignore` (or, for `.git`, is never content). Listed
+#: explicitly rather than matched by a pattern, for the reason
+#: `test_marketing_ci_coverage_sweep.py` gives at length: a broad pattern is
+#: where a real directory later hides.
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        "node_modules",
+        "dist",
+        ".venv",
+        ".pytest_cache",
+        "__pycache__",
+        ".ruff_cache",
+        ".worktrees",
+        ".git",
+    }
+)
+
+#: Top-level directories deliberately outside `[tool.coverage.run] source`,
+#: with why. `tests` is the only one, and it is excluded by the INSTANCE too
+#: (`omit = ["*/tests/*", ...]`) — so this is the two repos agreeing, not this
+#: repo carving itself an exemption.
+_NOT_MEASURED = frozenset({"tests"})
+
+
+def _load_ci() -> dict[str, Any]:
+    return yaml.safe_load(_CI_WORKFLOW.read_text())
+
+
+def _steps_of_every_job(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    for job in (workflow.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if isinstance(step, dict):
+                steps.append(step)
+    return steps
+
+
+def find_error_branch_step(workflow: dict[str, Any]) -> dict[str, Any] | None:
+    """The step that actually runs the analyser, or None.
+
+    Matched on the `run:` script rather than on the step's `name:`, because a
+    name is a label anyone can attach to a step that does something else — and
+    the failure this whole module is about is a check whose name and behaviour
+    had drifted apart.
+    """
+    for step in _steps_of_every_job(workflow):
+        run = step.get("run")
+        if isinstance(run, str) and _ANALYSER_REL in run:
+            return step
+    return None
+
+
+def top_level_python_dirs(root: Path = _REPO_ROOT) -> set[str]:
+    """Top-level directories under `root` containing at least one `.py` file.
+
+    Walked from the filesystem, never a hand-maintained list. The failure mode
+    this module exists to stop is a gate green over a set nobody enumerated, so
+    the set has to be discovered — a fifth directory of Python added later
+    cannot join this repo unmeasured the way `scripts/` did.
+    """
+    found: set[str] = set()
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir() or entry.name in _EXCLUDED_DIR_NAMES:
+            continue
+        for _dirpath, dirnames, filenames in os.walk(entry):
+            dirnames[:] = sorted(d for d in dirnames if d not in _EXCLUDED_DIR_NAMES)
+            if any(f.endswith(".py") for f in filenames):
+                found.add(entry.name)
+                break
+    return found
+
+
+# --------------------------------------------------------------------------
+# The wiring: CI runs it, over the scope the instance scans.
+# --------------------------------------------------------------------------
+
+
+def test_ci_runs_the_error_branch_analyser_in_check_mode() -> None:
+    workflow = _load_ci()
+    step = find_error_branch_step(workflow)
+
+    assert step is not None, (
+        f"No step in {_CI_WORKFLOW.name} runs {_ANALYSER_REL}. Before #183 that was "
+        "this repo's entire error-branch story: PR #180's `except Exception` passed "
+        "twelve green checks here and reddened tabsii-platform the moment it was "
+        "vendored."
+    )
+    run = step["run"]
+    assert "--check" in run, (
+        f"{_ANALYSER_REL} is run without `--check`, so it reports and returns 0. "
+        "A ratchet that never fails is a log line, not a gate."
+    )
+
+
+def test_ci_writes_the_json_coverage_report_the_analyser_reads() -> None:
+    """`--cov-report=xml` is Codecov's; the analyser reads `coverage.json` only.
+
+    Without the json report the analyser exits 2 with "No coverage data" — the
+    gate failing to run, which is a different thing from the gate passing, and
+    reads identically in a green job's log if nobody checks the exit code.
+    """
+    workflow = _load_ci()
+    pytest_steps = [
+        s
+        for s in _steps_of_every_job(workflow)
+        if isinstance(s.get("run"), str) and "pytest" in s["run"]
+    ]
+    assert pytest_steps, "no step in ci.yml runs pytest at all"
+    assert any("--cov-report=json" in s["run"] for s in pytest_steps), (
+        f"no pytest step writes coverage.json, which is the only input {_ANALYSER_REL} reads."
+    )
+
+
+def test_the_analyser_step_and_the_json_report_are_in_the_same_job() -> None:
+    """Artefacts do not travel between jobs on their own.
+
+    Two GitHub Actions jobs get two runners and two empty workspaces, so a
+    `coverage.json` written in one is simply absent in the other unless it is
+    uploaded and downloaded. Splitting these across jobs would leave the gate
+    exiting 2 on every run — the "cannot tell" the estate treats as never a
+    pass — so the arrangement is asserted rather than assumed.
+    """
+    workflow = _load_ci()
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        runs = [s.get("run", "") for s in job.get("steps") or [] if isinstance(s, dict)]
+        if any(_ANALYSER_REL in r for r in runs):
+            assert any("--cov-report=json" in r for r in runs), (
+                f"job `{job_name}` runs {_ANALYSER_REL} but never writes coverage.json "
+                "in that same job."
+            )
+            return
+    raise AssertionError(f"no job runs {_ANALYSER_REL}")
+
+
+def test_coverage_source_covers_every_directory_of_python_the_instance_measures() -> None:
+    """The scope, discovered rather than declared.
+
+    The instance measures all of `services/marketing/` bar its tests. This
+    repo has to measure the same set or it cannot gate it — which is exactly
+    how `scripts/` (four modules, including the one PR #180 added) stayed
+    invisible here while being judged there.
+    """
+    config = tomllib.loads(_PYPROJECT.read_text())
+    source = set(config["tool"]["coverage"]["run"]["source"])
+    expected = top_level_python_dirs() - _NOT_MEASURED
+
+    # Printed, not just asserted: the denominator is the point.
+    missing = expected - source
+    assert not missing, (
+        f"directories holding Python that `[tool.coverage.run] source` does not "
+        f"measure: {sorted(missing)}. The instance measures them as "
+        f"services/marketing/<dir>/ and will gate error branches there that this "
+        f"repo cannot see. Discovered set: {sorted(expected)}; configured: "
+        f"{sorted(source)}."
+    )
+
+
+def test_this_repo_still_has_no_rls_lane() -> None:
+    """Guards the deliberate absence of the instance's `hashFiles` condition.
+
+    The instance's copy of the `Error-branch coverage` step skips itself when
+    `.github/workflows/rls-tests.yml` exists, because a repo with a real
+    Postgres lane has branches this job structurally cannot execute and its
+    combined assertion happens once in `error-branch-coverage-gate.yml`
+    instead. This repo replicates neither file. Had it copied the condition
+    anyway, adding an RLS lane here would silently switch the gate off with
+    nothing taking over — so instead the condition is absent and this test is
+    what goes red on the day the assumption stops holding.
+    """
+    assert not (_REPO_ROOT / ".github" / "workflows" / "rls-tests.yml").exists(), (
+        "an RLS lane appeared. ci.yml's `Error-branch coverage` step has no "
+        "`hashFiles` guard and will now assert over Python-only coverage, flagging "
+        "Postgres-only error branches as unexecuted. Port the instance's "
+        "error-branch-coverage-gate.yml before adding this lane — see that file."
+    )
+
+
+def test_the_ratchet_has_a_recorded_baseline() -> None:
+    """A baseline the analyser cannot find is a gate that reports and returns 0.
+
+    `load_baseline` distinguishes "never measured" (None) from "measured, found
+    nothing" ({}), and on None the analyser deliberately prints and exits 0 so a
+    fresh repo is not born red. That is right for a repo that has not adopted
+    the ratchet, and wrong for this one — here an absent baseline would mean the
+    step runs, prints, and gates nothing.
+    """
+    baseline = _REPO_ROOT / _BASELINE_REL
+    assert baseline.is_file(), (
+        f"no baseline at {_BASELINE_REL} — the analyser would report and exit 0, "
+        "which is the gate present and inert. Re-take it with:\n"
+        "  uv run pytest --cov --cov-report=json\n"
+        "  uv run python scripts/error_branch_coverage.py --write"
+    )
+
+
+# --------------------------------------------------------------------------
+# Negative controls. A check that can only pass proves nothing.
+# --------------------------------------------------------------------------
+
+
+def test_finder_returns_none_for_a_workflow_that_does_not_run_the_analyser() -> None:
+    synthetic = {
+        "jobs": {
+            "test": {
+                "steps": [
+                    {"uses": "actions/checkout@v5"},
+                    # Names it, in a field, without running it — the exact
+                    # shape a grep-based check would wave through.
+                    {"name": f"Error-branch coverage ({_ANALYSER_REL})", "run": "true"},
+                ]
+            }
+        }
+    }
+    assert find_error_branch_step(synthetic) is None
+
+
+def test_discovery_finds_a_synthetic_directory_of_python(tmp_path: Path) -> None:
+    (tmp_path / "widgets").mkdir()
+    (tmp_path / "widgets" / "thing.py").write_text("x = 1\n")
+    (tmp_path / "node_modules" / "pkg").mkdir(parents=True)
+    (tmp_path / "node_modules" / "pkg" / "setup.py").write_text("x = 1\n")
+    (tmp_path / "prose").mkdir()
+    (tmp_path / "prose" / "notes.md").write_text("hello\n")
+
+    assert top_level_python_dirs(tmp_path) == {"widgets"}
+
+
+# --------------------------------------------------------------------------
+# The analyser's own error branches, so the vendored copy travels clean.
+# --------------------------------------------------------------------------
+
+
+def test_no_baseline_message_names_a_path_outside_this_repo_verbatim() -> None:
+    """Covers `no_baseline_message`'s `except ValueError`.
+
+    `Path.relative_to` raises rather than returning a `../..` path, and a
+    `--source-root` pointing anywhere outside this repo (which is how the
+    instance's `workflow_run` gate invokes it) reaches that raise on every run.
+    The handler falls back to the absolute path; naming this repo's baseline
+    instead would send the reader to a file that was never consulted.
+    """
+    analyser = load_script("error_branch_coverage")
+
+    outside = Path("/nowhere/else/entirely") / _BASELINE_REL
+    message = analyser.no_baseline_message(outside)
+    assert str(outside) in message
+
+    inside = analyser.BASELINE
+    assert _BASELINE_REL in analyser.no_baseline_message(inside)
+
+
+def test_a_bare_except_is_labelled_without_a_type() -> None:
+    """Covers `_handler_label`'s `if node.type is None -> 'except:'` fallback.
+
+    `except:` with no type is the broadest possible swallow, so it is the one
+    label that must never be missing from a report.
+    """
+    analyser = load_script("error_branch_coverage")
+
+    tree = ast.parse("try:\n    f()\nexcept:\n    pass\n")
+    handler = next(n for n in ast.walk(tree) if isinstance(n, ast.ExceptHandler))
+    assert analyser._handler_label(handler) == "except:"
+
+    typed = ast.parse("try:\n    f()\nexcept ValueError:\n    pass\n")
+    typed_handler = next(n for n in ast.walk(typed) if isinstance(n, ast.ExceptHandler))
+    assert analyser._handler_label(typed_handler) == "except ValueError"
+
+
+def test_an_unparseable_source_file_is_skipped_rather_than_crashing(tmp_path: Path) -> None:
+    """Covers `unexecuted`'s `except SyntaxError`.
+
+    Coverage data can name a file this interpreter cannot parse — a module
+    written for a newer syntax, a partially-written file in a local tree. The
+    gate must skip it, not die: a crashed analyser is a step that exits
+    non-zero for a reason unrelated to any error branch, which is how a real
+    finding gets dismissed as flakiness.
+    """
+    analyser = load_script("error_branch_coverage")
+
+    (tmp_path / "broken.py").write_text("def (:\n")
+    (tmp_path / "fine.py").write_text("try:\n    f()\nexcept ValueError:\n    pass\n")
+
+    coverage = {
+        "files": {
+            "broken.py": {"executed_lines": [], "missing_lines": [1]},
+            "fine.py": {"executed_lines": [1, 2, 3], "missing_lines": [4]},
+            # A file the report names but the tree does not hold, which the
+            # `is_file()` guard above the parse must drop silently.
+            "gone.py": {"executed_lines": [], "missing_lines": [1]},
+        }
+    }
+
+    found = analyser.unexecuted(coverage, tmp_path)
+    assert [b.path for b in found] == ["fine.py"]
+
+
+def test_a_missing_baseline_reads_as_never_measured_not_as_empty(tmp_path: Path) -> None:
+    """Covers `load_baseline`'s `if not baseline.is_file() -> None`.
+
+    None and `{}` are different states and were conflated once already
+    (biffo-template#983): reading "never measured" as "measured, found nothing"
+    makes every branch look new and red-lights every repo that adopts the gate.
+    """
+    analyser = load_script("error_branch_coverage")
+
+    assert analyser.load_baseline(tmp_path / "absent.json") is None
+
+    present = tmp_path / "present.json"
+    present.write_text('{"total": 0, "branches": []}\n')
+    assert analyser.load_baseline(present) == {"total": 0, "branches": []}


### PR DESCRIPTION
Refs #183.

## What was actually wrong

The premise this started from was "the two `Error-branch coverage` gates
disagree". They do not disagree — **this repo has no such gate.**
`gh pr checks 180` lists twelve contexts and `Error-branch coverage` is not
among them; `grep -ri error.branch .github/ scripts/` at `1e432ff` returned
nothing.

`scripts/error_branch_coverage.py` is template-owned. It reaches a **core
instance** via `biffo core upgrade`, and it is in neither `biffo-template`'s
`shared-files.json` nor the `@biffo/cli` package that `scripts/biffo.sh`
resolves — so no channel existed by which a satellite could ever have received
it. Same class as biffo-template#1570: "merged upstream" and "present
downstream" are different facts and nothing kept an inventory.

Second, independent cause — the scanned scope differed even in principle:

| | this repo (before) | tabsii-platform |
|---|---|---|
| `[tool.coverage.run] source` | `["src"]` | `["services", "packages"]` |
| `omit` | `["*/tests/*"]` | `["*/tests/*", "*/migrations/*", "services/_template/*"]` |

`biffo plugin install` vendors this repo whole to `services/marketing/`, so the
instance measures `src/` **and** `scripts/`. The analyser only inspects files
present in `coverage.json`, so `scripts/` was invisible here by construction.
Measured at `1e432ff`: `uv run pytest --cov --cov-report=json` wrote 23 files,
every one under `src/`; the four modules in `scripts/` appeared in no report.

That is how PR #180's `except Exception` in `scripts/check_runtime_ceiling.py`
passed all twelve checks here and reddened the instance on vendoring.

## How wide the hole was

Not one branch. Under the corrected scope, running `--check` for the first time
finds **6 unexecuted error branches** (5 unique keys) that nothing in this repo
had ever asserted over — 4 of them in `scripts/`. Every one of them would have
been NEW by the instance's reckoning the moment it was vendored.

## What changed

- **`scripts/error_branch_coverage.py`** — vendored **byte-identical** from
  `biffo-template/scripts/` (verified with `diff` against both the template's
  and the instance's copies). Edit it upstream, never here — the same rule
  `scripts/py-dependency-audit.sh` already carries.
- **`pyproject.toml`** — `[tool.coverage.run] source = ["src", "scripts"]`, so
  this repo measures the set the instance measures.
- **`.github/workflows/ci.yml`** — `--cov-report=json` on the pytest step (the
  analyser's only input; without it the gate exits 2, which is failing to run,
  not passing), plus an `Error-branch coverage` step running
  `--check --coverage coverage.json`. This mirrors the instance's own inline
  step for a repo with no `RLS Tests` lane. The instance's
  `hashFiles('rls-tests.yml')` condition is deliberately **not** copied — with
  no `error-branch-coverage-gate.yml` here to take over, that condition would
  be a fail-open the day an RLS lane appeared. A test asserts the lane's
  absence instead, so the assumption goes red rather than the gate going quiet.
- **`docs/practices/error-branch-baseline.json`** — the ratchet. **2 entries**,
  both pre-existing in `src/marketing/pipeline.py`. Not a paper-over: it is the
  same mechanism and the same path the instance uses, it never blocks, and it
  is meant to shrink.
- **`docs/practices/error-branch-baseline.md`** — what the baseline is, why a
  ratchet rather than a hard gate, and the exact commands to shrink it
  (including the warning that `--write` accepts additions as readily as
  removals).
- **`tests/test_marketing_error_branch_gate.py`** — 12 tests.
- **`.gitignore`** — `coverage.json` / `.coverage` / `coverage.xml`, none of
  which were ignored, and `--cov-report=json` is now a routine local step.

## The 4 branches I covered rather than baselined

`scripts/` is vendored wholesale, so this repo's copy of the analyser becomes
`services/marketing/scripts/error_branch_coverage.py` downstream, and its own
unexecuted `except`es would be new branches by the instance's reckoning.
**Vendoring the gate uncovered would reproduce, in the gate itself, the exact
failure it is being adopted to prevent.** So its `except ValueError`,
`except SyntaxError` and two `-> <default>` fallbacks are covered by tests
written against behaviour, not line numbers, so an upstream edit that preserves
behaviour keeps them passing. Baseline falls from 6 branches to 2.

## Verification

Workflow changes are hard to unit-test, so the analyser was run locally against
a scratch file reproducing PR #180's exact shape (`except Exception` -> a
default, no test).

**With the new scope — red, with the instance's own message:**

```
$ uv run python scripts/error_branch_coverage.py --check --coverage coverage.json

1 error branch(es) added with no test exercising them:
  scripts/_scratch_failopen.py:except:except Exception

An unexecuted error branch is unverified — nobody has observed what it does.
Either cover it, or run --write to accept it deliberately.
unexecuted error branches: 3  (baseline 2; 1/1 coverage artefact(s))
  NEW scripts/_scratch_failopen.py:10  [except] except Exception
      src/marketing/pipeline.py:383  [except] except json.JSONDecodeError
      src/marketing/pipeline.py:566  [except] except ValidationError
      src/marketing/pipeline.py:733  [except] except ValidationError
exit=1
```

**Same file, same command, old `source = ["src"]` — green, branch invisible:**

```
unexecuted error branches: 2  (baseline 2; 1/1 coverage artefact(s))
      src/marketing/pipeline.py:383  [except] except json.JSONDecodeError
      src/marketing/pipeline.py:566  [except] except ValidationError
      src/marketing/pipeline.py:733  [except] except ValidationError
exit=0
```

That pair is the whole finding, reproduced in one repo: the scope line is what
decides whether PR #180 is caught here or one repo downstream. The scratch file
was then deleted and the gate re-run — exit 0, baseline 2.

The wiring tests were also fail-first verified: narrowing `source` back to
`["src"]` reddened
`test_coverage_source_covers_every_directory_of_python_the_instance_measures`,
and the baseline test was observed failing before
`docs/practices/error-branch-baseline.json` existed.

Local gates: `uv run pytest` **911 passed, 4 skipped**; `ruff check`,
`ruff format --check`, `pyright` (0 errors) all clean; `web-admin` lint,
typecheck and **267 vitest tests** pass.

## What I could NOT verify

- **That the instance now agrees.** I did not re-vendor this branch into
  `tabsii-platform` and run its gate. The claim is that both repos run the same
  byte-identical analyser over the same file set; it is not an observation of
  the instance going green on this commit.
- **The three `src/marketing/pipeline.py` branches in the baseline.** They are
  recorded as pre-existing and unverified, exactly as the ratchet intends — not
  reviewed for whether any is an actual fail-open. Worth a follow-up.
- **The upstream half.** The durable fix is adding
  `scripts/error_branch_coverage.py` to `biffo-template`'s `shared-files.json`
  so `shared-sync.sh` arms every satellite. I did not file that upstream, and
  `biffo-plugin-idea-scout` and `biffo-plugin-ideation` are still unarmed —
  each will hit this the first time it adds an uncovered `except`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**`Refs`, not `Closes`.** Release Guards is right to refuse: this repo's own
discipline is that an issue closes on evidence from a running environment, not
on a merge. The evidence for this one is the gate appearing in this repo's own
CI checks and staying green on a clean tree — so #183 closes by hand once that
has been observed on a PR, which is what this PR is.
