### PR TITLE
security(gitleaks): narrow biffo-aws-account-id to exclude UUID tails

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,7 +13,7 @@ useDefault = true
 [[rules]]
 id = "biffo-aws-account-id"
 description = "AWS Account ID — should only appear in .tfvars.example or biffo.config.json placeholders"
-regex = '''\b\d{12}\b'''
+regex = '''(?:^|[^0-9A-Fa-f-])(\d{12})\b'''
 entropy = 0
 [rules.allowlist]
 regexes = [
@@ -21,18 +21,15 @@ regexes = [
   "123456789012",                  # canonical example account ID used in tests
   "999999999999",                  # canonical wrong-account ID used in error-path tests
 ]
-# security-secrets' history scan runs `--full-history HEAD` (see ci.yml), so
-# this rule reaches every commit reachable from dev, not only this branch's
-# diff. #14 already fixed the *current* fixture values (the all-digit UUID
-# suffixes this rule exists to catch, e.g. b3f1c0de-...-000000000001), but the
-# pre-fix values are permanently part of dev's merged history and this rule
-# would otherwise flag them retroactively on every PR from now on — dev is
-# protected and its history is not ours to rewrite. Allowlisted by commit,
-# not by value or path, so the rule stays fully live against any NEW bare
-# 12-digit number introduced anywhere in the repo going forward — only these
-# three already-merged, already-superseded commits are exempted.
-commits = [
-  "bfb5dc5e075cc740dfaed146aa53aa1fca4dab45", # feat(marketing): mint tracked links for a campaign (#13)
-  "86f57b34c7ada4b7f84276148722602b29e8e57b", # feat(marketing): research + positioning agents, citation-enforced (#18)
-  "d2ddeef824268a5ec6464f5019b71735fd6d249c", # feat(marketing): still-image generation behind a provider port (#20)
-]
+# A `commits` allowlist used to sit here, naming three commits (#13, #18, #20)
+# whose fixture UUIDs (e.g. b3f1c0de-...-000000000001) tripped the old broad
+# regex (`\b\d{12}\b`) on their all-digit tail. That was a finite defence
+# against an infinite class: every new fixture UUID with an all-digit tail
+# would need a fourth entry. The regex above is narrowed instead (tabsii-com/
+# tabsii-platform#893) — its leading `[^0-9A-Fa-f-]` excludes the hyphen a
+# UUID segment sits behind, so those UUIDs no longer match at all. Verified by
+# stripping this allowlist and re-running `gitleaks detect --log-opts
+# "--full-history HEAD"` against all 108 commits reachable from dev: zero
+# leaks, so the three entries were suppressing only this rule and are removed
+# as dead weight rather than left to describe a conflict that no longer
+# exists.


### PR DESCRIPTION
Refs tabsii-com/tabsii-platform#893

## What

Narrows the `biffo-aws-account-id` gitleaks rule from `\b\d{12}\b` to
`(?:^|[^0-9A-Fa-f-])(\d{12})\b`, matching the regex already carried by
`biffo-template`, `biffo-platform`, and `tabsii-platform`. This was the one
repo (of the four holding a `.gitleaks.toml`) where the narrowing had not
travelled.

Also removes the three-entry `commits` allowlist that was papering over the
old broad rule (see "Allowlist" below).

## Why

The old regex matched any bare run of twelve digits, so a fixture UUID whose
final segment happens to be all-digit (e.g.
`b3f1c0de-0000-4000-8000-000000000001`) tripped it exactly like a real AWS
account id. The only defence on offer was allowlisting each commit that hit
this by name — finite against an infinite class, since the next such UUID
needs a fourth entry. The narrowed regex's leading `[^0-9A-Fa-f-]` excludes
the hyphen a UUID segment sits behind, so fixture UUIDs stop tripping the rule
while a genuine bare 12-digit account id still does.

## Allowlist — per-entry finding

The `commits` allowlist named three commits, each because a fixture UUID's
all-digit tail tripped the *old* broad regex:

| Commit | PR | Content that tripped it | Still trips narrowed regex? |
|---|---|---|---|
| `bfb5dc5e` | #13 | `b3f1c0de-0000-4000-8000-000000000001` | No — preceded by `-` |
| `86f57b34` | #18 | `b3f1c0de-0000-4000-8000-000000000002` | No — preceded by `-` |
| `d2ddeef8` | #20 | `b3f1c0de-0000-4000-8000-000000000006` | No — preceded by `-` |

Each commit's diff contains exactly one 12-digit run, and in every case it is
a UUID's terminal segment immediately preceded by a hyphen — exactly the
shape the narrowed regex's leading character class excludes. Verified
directly: stripped the `commits` allowlist entirely and re-ran
`gitleaks detect --log-opts="--full-history HEAD"` (the same invocation
`ci.yml` uses, `--full-history` so all 108 commits reachable from `dev` are
walked) against the narrowed regex — zero leaks. All three entries were
suppressing only this rule, on this content, and are dead weight now that the
regex no longer matches it — removed rather than left describing a conflict
that no longer exists.

## Fail-first proof (real gitleaks output, not reasoning)

**Before** (old regex `\b\d{12}\b`), against a fixture file with the same
UUID shapes plus a genuine-looking account id:

```
Finding:     ...c0de-0000-4000-8000-000000000001
RuleID:      biffo-aws-account-id
File:        fixture.txt
Line:        1
--
Finding:     ...c0de-0000-4000-8000-000000000006
RuleID:      biffo-aws-account-id
File:        fixture.txt
Line:        2
--
Finding:     ... = "aws_account_id: 481930275610
RuleID:      biffo-aws-account-id
File:        fixture.txt
Line:        3

leaks found: 3
```

**After** (narrowed regex), same fixture file — the two UUID tails no longer
match, the genuine account id still does:

```
Finding:     ... = "aws_account_id: 481930275610
RuleID:      biffo-aws-account-id
File:        fixture.txt
Line:        3

leaks found: 1
```

This is the half that proves the rule was narrowed rather than disabled: it
still catches a real-shaped 12-digit account id with no adjacent hex/hyphen
context.

## Full repo scan (both steps `ci.yml` runs, verbatim)

```
$ gitleaks detect --redact -v --exit-code=2 --log-opts="--full-history HEAD"
108 commits scanned.
no leaks found

$ gitleaks detect --no-git --redact -v --exit-code=2
no leaks found
```

Both exit 0. The full repo — history and working tree — is clean under the
narrowed rule with the allowlist removed.

## Not verified

- CI has not been observed green on this PR yet — pushed and dispatched, not
  waited on.
- `tests/test_marketing_paid_pack_routes.py`'s docstring ("Fixture UUIDs
  deliberately do not end in twelve digits...") still describes the old
  broad-rule constraint. It isn't wrong, just stricter than necessary now —
  left alone as out of scope for a one-concern PR; flagging it here rather
  than silently leaving it unmentioned.
- The two gaps #893's second comment also names — `tabsii-crm` and
  `tabsii-marketplace` carrying no `.gitleaks.toml` at all — are explicitly
  out of scope for this PR and tracked separately (#1623 per the issue
  thread).
