### PR TITLE
security(gitleaks): narrow biffo-aws-account-id to the template's match-scoped rule

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,11 +1,29 @@
 title = "Biffo Plugin Gitleaks Configuration"
 
 # Mirrors biffo-template's .gitleaks.toml `biffo-aws-account-id` rule
-# verbatim (see /home/keiran/code/biffo-template/.gitleaks.toml). Without it,
-# a bare 12-digit fixture value passes this repo's own Secret Scan and only
-# fails one repo and one CI cycle downstream, once vendored into an instance
-# whose gitleaks config does have this rule (#19). A plugin repo's gates
-# should be a superset of what its vendored copy will face downstream.
+# verbatim (see /home/keiran/code/biffo-template/.gitleaks.toml, ATTEMPT 3 in
+# its long comment there — read it before touching this rule again, because
+# two earlier designs looked reasonable and were both prosecuted and broken
+# with the real binary). Without it, a bare 12-digit fixture value passes
+# this repo's own Secret Scan and only fails one repo and one CI cycle
+# downstream, once vendored into an instance whose gitleaks config does have
+# this rule (#19). A plugin repo's gates should be a superset of what its
+# vendored copy will face downstream.
+#
+# This repo previously carried the broad `\b\d{12}\b` rule plus a `commits`
+# allowlist naming three specific commits whose fixture UUIDs (all-digit
+# tails) tripped it — a finite defence against an infinite class: every new
+# fixture UUID with an all-digit tail needed a fourth entry. Narrowed here
+# instead (tabsii-com/tabsii-platform#893) to the template's current,
+# three-times-iterated regex, which consumes a UUID's two-hex-quad prefix and
+# reports only the twelve digits via `secretGroup`, with a match-scoped (not
+# line-scoped) allowlist. The `commits` allowlist is removed: verified by
+# stripping it and re-running `gitleaks detect --log-opts="--full-history
+# HEAD"` against all commits reachable from dev under the narrowed rule —
+# zero leaks, so the three entries were suppressing only the old rule's
+# false-positive on this content and are dead weight now. See PR that
+# introduced this change for the full case matrix and the real gitleaks
+# output that established the above.
 
 [extend]
 useDefault = true
@@ -13,26 +31,23 @@ useDefault = true
 [[rules]]
 id = "biffo-aws-account-id"
 description = "AWS Account ID — should only appear in .tfvars.example or biffo.config.json placeholders"
-regex = '''\b\d{12}\b'''
+regex = '''\b(?:[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-)?(\d{12})\b'''
+secretGroup = 1
 entropy = 0
-[rules.allowlist]
+
+# Suppresses a UUID's final segment, and ONLY that shape — match-scoped, not
+# line-scoped, so a genuine account id sharing a line with an unrelated UUID
+# is still caught (see biffo-template's .gitleaks.toml for why a line-scoped
+# allowlist was rejected).
+[[rules.allowlists]]
+regexTarget = "match"
+regexes = [
+  "^[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-\\d{12}$",
+]
+
+[[rules.allowlists]]
 regexes = [
   "\\{\\{AWS_ACCOUNT_ID\\}\\}",  # placeholder in template files
   "123456789012",                  # canonical example account ID used in tests
   "999999999999",                  # canonical wrong-account ID used in error-path tests
-]
-# security-secrets' history scan runs `--full-history HEAD` (see ci.yml), so
-# this rule reaches every commit reachable from dev, not only this branch's
-# diff. #14 already fixed the *current* fixture values (the all-digit UUID
-# suffixes this rule exists to catch, e.g. b3f1c0de-...-000000000001), but the
-# pre-fix values are permanently part of dev's merged history and this rule
-# would otherwise flag them retroactively on every PR from now on — dev is
-# protected and its history is not ours to rewrite. Allowlisted by commit,
-# not by value or path, so the rule stays fully live against any NEW bare
-# 12-digit number introduced anywhere in the repo going forward — only these
-# three already-merged, already-superseded commits are exempted.
-commits = [
-  "bfb5dc5e075cc740dfaed146aa53aa1fca4dab45", # feat(marketing): mint tracked links for a campaign (#13)
-  "86f57b34c7ada4b7f84276148722602b29e8e57b", # feat(marketing): research + positioning agents, citation-enforced (#18)
-  "d2ddeef824268a5ec6464f5019b71735fd6d249c", # feat(marketing): still-image generation behind a provider port (#20)
 ]


### PR DESCRIPTION
Refs tabsii-com/tabsii-platform#893

## Premise check (2026-08-17, after 14 sync PRs ran across the estate today)

`origin/dev`'s `.gitleaks.toml` still carried the original broad
`\b\d{12}\b` regex plus a `commits` allowlist naming three specific commits
when this PR was built — no sync round had carried the template's narrowed
rule here. This is genuinely the one repo (of the four holding a
`.gitleaks.toml`) it had not reached.

**However, an existing open PR, #185, already attempted this fix** — and it
implements the *superseded* `tabsii-com/tabsii-platform#893` first-attempt
regex (`(?:^|[^0-9A-Fa-f-])(\d{12})\b`), not the template's current
(three-times-iterated) rule. biffo-template's own `.gitleaks.toml` comment
documents exactly why that first attempt was rejected: it silently drops the
most common real-world leak shape, `<name>-<account-id>` bucket/role/log-group
names, because the leading `[^0-9A-Fa-f-]` exclusion blocks on *any*
preceding hyphen, not just a UUID's. Reproduced live against #185's exact
regex, isolated:

```
$ cat fixture.txt
resource "aws_s3_bucket" "artifacts" {
  bucket = "my-app-artifacts-123456789012"
}
$ gitleaks detect --no-git -c pr185_rule.toml --redact -v --exit-code=2
scanned ~84 bytes (84 bytes) in 991µs
no leaks found
```

A genuine account-id-suffixed bucket name passes #185's rule silently. #185
should not be merged as-is — recommend closing it in favour of this PR, which
carries the template's current verbatim rule instead. I did not touch #185's
branch or worktree (not mine to modify per AGENTS.md/`biffo-workflow`); this
is a fresh worktree and branch.

## What changed (regex, before -> after)

**Before** (this repo, `origin/dev`, until this PR):
```toml
regex = '''\b\d{12}\b'''
entropy = 0
[rules.allowlist]
regexes = [ ... "123456789012", "999999999999" ]
commits = [ "bfb5dc5e...", "86f57b34...", "d2ddeef8..." ]
```

**After** (biffo-template's current rule, taken verbatim, not re-derived):
```toml
regex = '''\b(?:[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-)?(\d{12})\b'''
secretGroup = 1
entropy = 0

[[rules.allowlists]]
regexTarget = "match"
regexes = [ "^[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-\\d{12}$" ]

[[rules.allowlists]]
regexes = [ "\\{\\{AWS_ACCOUNT_ID\\}\\}", "123456789012", "999999999999" ]
```

This is the template's ATTEMPT 3, taken verbatim per the brief — it took
three builds and ~750k tokens to land there (`biffo-template`'s own
`.gitleaks.toml` comment has the full history: attempt #893 missed
`<name>-<account-id>` bucket names; `#1628` attempt 1 missed
`backup-2024-<id>` because gitleaks' hex class includes all ten digits;
`#1628` attempt 2's line-scoped allowlist waved through a real account id
sharing a line with an unrelated UUID). Not re-reasoned here, just copied.

## Per-entry audit of the three allowlisted commits

| Commit | PR | Triggering content | Load-bearing under the new rule? |
|---|---|---|---|
| `bfb5dc5e` | #13 | `b3f1c0de-0000-4000-8000-000000000001` | No |
| `86f57b34` | #18 | `b3f1c0de-0000-4000-8000-000000000002` | No |
| `d2ddeef8` | #20 | `b3f1c0de-0000-4000-8000-000000000006` | No |

Each commit's only 12-digit-adjacent content (confirmed by grepping the raw
diff of each, individually) is a UUID whose final segment is immediately
preceded by exactly two hyphen-separated 4-hex-digit groups (`4000-8000-`,
`0000-8000-` etc, RFC 4122 fields 3 and 4) — precisely the shape the new
rule's match-scoped allowlist exempts. Proved directly, not inferred: with
the `commits` allowlist removed entirely, a full-history scan under the new
rule finds nothing in any of the 108 commits reachable from `dev`, these
three included:

```
$ gitleaks detect --redact -v --exit-code=2 --log-opts="--full-history HEAD"
108 commits scanned.
scanned ~2719252 bytes (2.72 MB) in 389ms
no leaks found
```

All three entries are dead weight and removed.

## Fail-first proof (real gitleaks 8.30.1, this repo's CI pin, real output)

Cases derived from this repo's own corpus (the three commits above) plus the
two shapes that killed the template's earlier designs. Each run in isolation
with the rule alone (`--no-git` against a one-line fixture), both regexes
tested against the identical input.

**1. Fixture UUID with an all-digit tail** (`b3f1c0de-0000-4000-8000-000000000001`,
the real shape from commit `bfb5dc5e`) — must NOT be caught after:
```
# before (old rule)
Finding:     ...c0de-0000-4000-8000-REDACTED
RuleID:      biffo-aws-account-id
leaks found: 1

# after (new rule)
no leaks found
```

**2. Genuine 12-digit account id** (`aws_account_id = "481930275610"`) — must
STILL be caught after (proves narrowed, not disabled):
```
# before
Finding:     aws_account_id = "REDACTED
leaks found: 1

# after
Finding:     aws_account_id = "REDACTED
leaks found: 1
```

**3. `backup-2024-338764933165`** — the shape that killed `#1628` attempt 1
(hex class includes all ten digits) — must be caught after:
```
# before
Finding:     ...cket = "backup-2024-REDACTED
leaks found: 1

# after
Finding:     ...cket = "backup-2024-REDACTED
leaks found: 1
```

**4. Account id sharing a line with an unrelated UUID**
(`"account 338764933165 request 11111111-1111-1111-1111-111111111111"`) —
the shape that killed `#1628` attempt 2's line-scoped allowlist — the account
id must still be caught, the UUID tail must not:
```
# before (old rule matches BOTH — the account id and the UUID tail)
Finding:     log: "account REDACTED request 11111111-11...
Finding:     ...1111-1111-1111-1111-REDACTED
leaks found: 2

# after (only the account id)
Finding:     log: "account REDACTED request 11111111-11...
leaks found: 1
```

## Full repo scan (both `ci.yml` steps, verbatim, this branch)

```
$ gitleaks detect --redact -v --exit-code=2 --log-opts="--full-history HEAD"
108 commits scanned.
scanned ~2719252 bytes (2.72 MB) in 389ms
no leaks found

$ gitleaks detect --no-git --redact -v --exit-code=2
scanned ~2469047 bytes (2.47 MB) in 319ms
no leaks found
```

Both exit 0. Run from inside this worktree (not the repo root, which has
sibling `.worktrees/` checkouts) so `--no-git`'s raw-filesystem walk only
covers this branch's own tree.

## Also run

- `uv run pytest`: 917 passed, 4 skipped — full suite, not just gitleaks-adjacent.
- Local `verify` gate (pre-push hook): all applicable checks OK.

## Not verified

- CI has not been observed green on this PR — pushed and dispatched, not
  waited on beyond one status snapshot.
- Did not touch `tests/test_marketing_paid_pack_routes.py`'s docstring
  ("Fixture UUIDs deliberately do not end in twelve digits...") — it's
  stricter than necessary now but not wrong, and out of scope for a
  one-concern PR (same call PR #185 made).
- Did not action PR #185 itself (did not close it, did not push to its
  branch) — flagging it here for whoever reconciles the two rather than
  taking that call unilaterally, since it's a live open PR I don't own.
- Did not verify this against `tabsii-crm` / `tabsii-marketplace`, which
  carry no `.gitleaks.toml` at all per issue #893's second comment — out of
  scope, tracked separately per that thread (referenced there as #1623).
