### PR TITLE
chore(security): drop biffo-aws-account-id gitleaks rule, per upstream

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,38 +1,4 @@
 title = "Biffo Plugin Gitleaks Configuration"
 
-# Mirrors biffo-template's .gitleaks.toml `biffo-aws-account-id` rule
-# verbatim (see /home/keiran/code/biffo-template/.gitleaks.toml). Without it,
-# a bare 12-digit fixture value passes this repo's own Secret Scan and only
-# fails one repo and one CI cycle downstream, once vendored into an instance
-# whose gitleaks config does have this rule (#19). A plugin repo's gates
-# should be a superset of what its vendored copy will face downstream.
-
 [extend]
 useDefault = true
-
-[[rules]]
-id = "biffo-aws-account-id"
-description = "AWS Account ID — should only appear in .tfvars.example or biffo.config.json placeholders"
-regex = '''\b\d{12}\b'''
-entropy = 0
-[rules.allowlist]
-regexes = [
-  "\\{\\{AWS_ACCOUNT_ID\\}\\}",  # placeholder in template files
-  "123456789012",                  # canonical example account ID used in tests
-  "999999999999",                  # canonical wrong-account ID used in error-path tests
-]
-# security-secrets' history scan runs `--full-history HEAD` (see ci.yml), so
-# this rule reaches every commit reachable from dev, not only this branch's
-# diff. #14 already fixed the *current* fixture values (the all-digit UUID
-# suffixes this rule exists to catch, e.g. b3f1c0de-...-000000000001), but the
-# pre-fix values are permanently part of dev's merged history and this rule
-# would otherwise flag them retroactively on every PR from now on — dev is
-# protected and its history is not ours to rewrite. Allowlisted by commit,
-# not by value or path, so the rule stays fully live against any NEW bare
-# 12-digit number introduced anywhere in the repo going forward — only these
-# three already-merged, already-superseded commits are exempted.
-commits = [
-  "bfb5dc5e075cc740dfaed146aa53aa1fca4dab45", # feat(marketing): mint tracked links for a campaign (#13)
-  "86f57b34c7ada4b7f84276148722602b29e8e57b", # feat(marketing): research + positioning agents, citation-enforced (#18)
-  "d2ddeef824268a5ec6464f5019b71735fd6d249c", # feat(marketing): still-image generation behind a provider port (#20)
-]


### PR DESCRIPTION
Refs tabsii-com/tabsii-platform#893

## What changed

Deletes the `biffo-aws-account-id` gitleaks rule from `.gitleaks.toml`
— the rule itself, its scoped `rules.allowlist`, the per-commit
`commits` allowlist entries that existed only to suppress this rule's
own false positives on three historical commits, and the header
comment justifying the mirror (it described why this rule was kept in
step with `biffo-template`'s, and that rule no longer exists).

## Why

Owner-approved decision on `tabsii-com/tabsii-platform#893`
("My recommendation: A now, C next" — this PR is A, done in parallel
across the two repos still carrying the rule). `biffo-template`
iterated this rule four times and then deleted it outright on
2026-08-17 (`eaefe02`); its `dev` today has **zero** occurrences.
Recorded reasoning: a 12-digit AWS account id has no distinguishing
shape — no regex separates it from a UUID segment, a date, or a
timestamp — and it is not a credential in any case.

This repo's copy was already a step further behind than
`tabsii-platform`'s: it still carried the original, unnarrowed
`\b\d{12}\b` regex (never received the UUID-boundary fix from
`tabsii-platform#893`'s earlier round), which is exactly the shape the
authority abandoned outright rather than continuing to patch.

## Verification

Ran gitleaks **8.30.1** locally (matches the version this repo's own
CI pins), both scans:

```
$ gitleaks detect --no-git --redact -v --exit-code=2
...no leaks found
exit: 0

$ gitleaks detect --redact -v --exit-code=2 --log-opts="--full-history HEAD"
110 commits scanned.
...no leaks found
exit: 0
```

The three previously-exempted commits (`bfb5dc5e`, `86f57b34`,
`d2ddeef8`) pass the full-history scan cleanly with the exemption
entries gone too — confirming nothing but this rule was ever catching
them.

Local `scripts/biffo.sh verify` pre-push gate also passed, including
its own `gitleaks` step.

## Scope note

Not doing Option C (making `.gitleaks.toml` a distributed, enforced
copy) — that is the owner's stated next step, not this one.
