### PR TITLE
docs(marketing): make spend_routes' brand_id argument stand on its own

### DIFF
--- a/src/marketing/spend_routes.py
+++ b/src/marketing/spend_routes.py
@@ -24,11 +24,14 @@ work, for four independent reasons — any one of which is sufficient:
 2. **``brand_id`` is ``NOT NULL`` and this plugin has no brand.** The generic
    CRUD create handler injects ``tenant_id`` only; ``brand_id`` is an
    ordinary caller-supplied payload field, and there is no brand header and
-   no default brand anywhere in Core. The reading side does not answer this
-   question either — tabsii's ``campaign_results.py`` documents that it
-   deliberately **ignores** ``brand_id`` and sums across every brand, calling
-   the requirement "a genuine, structural mismatch this endpoint works
-   around, not past". There is no value to reuse, only an acknowledged gap.
+   no default brand anywhere in Core. Writing ``lead_source_costs`` would
+   therefore need a brand value this plugin has no way to produce — that is
+   the mismatch on its own terms, independent of anything the reading side
+   does with the column once it exists. (As of 2026-08-22, the reading side
+   has stopped reading that table at all — ``tabsii-platform#892`` removed
+   the ``lead_source_costs`` read from ``campaign_results.py`` entirely, so
+   ``marketing_spend`` is now the sole cost ledger. That is a second,
+   independent reason to prefer it, not the basis for this one.)
 3. **The plugin's transport cannot reach that route.** Everything this
    plugin sends to Core goes through ``principal_client`` — SigV4 plus the
    admin's forwarded token — onto ``/api/v1/internal/plugins/marketing/*``.


### PR DESCRIPTION
Refs #189.

## What changed

Rewrote reason #2 of `spend_routes.py`'s four-reason argument for writing
`marketing_spend` instead of `tabsii.lead_source_costs`, so it no longer rests
on a claim about another repo's current behaviour.

## Why

The comment cited `campaign_results.py` in tabsii-platform as deliberately
ignoring `brand_id` and summing across every brand, quoting it as "a genuine,
structural mismatch this endpoint works around, not past". That was true when
written and is false as of today: `tabsii-platform#892` (PR `tabsii-platform#1116`,
merged 2026-08-22T18:29:06Z) removes the `lead_source_costs` read from
`campaign_results.py` entirely, so `marketing_spend` is now the sole cost
ledger on the reading side too. Nothing in this repo could detect the citation
going stale, because the fact it rested on belongs to a different repo.

## The fix

The argument now stands on facts this repo owns: `brand_id` is `NOT NULL` on
`lead_source_costs`, and this plugin has no brand value to supply — the
generic CRUD create handler injects `tenant_id` only, and there is no brand
header or default brand anywhere in Core. That holds regardless of what the
reading side does, so it needs no upkeep against another repo.

The now-true observation that the reading side has also stopped reading the
table is kept, but demoted to a secondary, dated note ("As of 2026-08-22...")
rather than the load-bearing claim — it strengthens the case for
`marketing_spend`, it does not make it.

## Level reached

Level 2 (automatic) in spirit: the comment is now self-supporting rather than
hand-maintained against tabsii-platform's behaviour, so there is nothing left
to go stale when that repo changes again. A detector that cross-checks this
citation against tabsii-platform (level 4) was considered and rejected — the
right fix here was removing the cross-repo dependency from the argument, not
adding a guard to watch it.

## What I checked

- Grepped `tests/` and `src/marketing/` for any assertion on the old comment
  text (the "genuine, structural mismatch" phrase) — none exists. No test or
  guard depended on this comment's wording.
- `uv run pytest tests/test_marketing_spend_routes.py` — 12 passed.
- `uv run ruff check src/marketing/spend_routes.py` — clean.
- Local `verify` gate (pre-push) — all applicable checks passed.

## What I did not change

Line 68 of the same file also references `campaign_results._cost_metric`, but
for an unrelated claim (the null-vs-zero convention, not `brand_id`/cross-brand
summing). That is out of this issue's scope and untouched here.

## Where else this appears

The issue notes this comment is also vendored into `tabsii-platform` at
`services/marketing/src/marketing/spend_routes.py:27-31`. Per the issue, that
copy is fixed by distribution, not edited directly — not done in this PR.
